### PR TITLE
feat: pre-commit hook to block secret commits

### DIFF
--- a/infrastructure/pre-commit-secrets
+++ b/infrastructure/pre-commit-secrets
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# pre-commit hook: block commits containing likely secrets.
+# Install: cp infrastructure/pre-commit-secrets .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or symlink from any alpha-engine repo:
+#   ln -sf ~/Development/alpha-engine/infrastructure/pre-commit-secrets .git/hooks/pre-commit
+
+set -euo pipefail
+
+# Patterns that should never appear in committed code.
+# Each is a grep -iE regex tested against staged file content.
+PATTERNS=(
+    'ANTHROPIC_API_KEY\s*=\s*"[^"]{10,}"'
+    'OPENAI_API_KEY\s*=\s*"[^"]{10,}"'
+    'AWS_SECRET_ACCESS_KEY\s*=\s*"[^"]{10,}"'
+    'GMAIL_APP_PASSWORD\s*=\s*"[^"]{4,}"'
+    'POLYGON_API_KEY\s*=\s*"[^"]{10,}"'
+    'FMP_API_KEY\s*=\s*"[^"]{10,}"'
+    'FRED_API_KEY\s*=\s*"[^"]{10,}"'
+    'DATABASE_PASSWORD\s*=\s*"[^"]{4,}"'
+    '-----BEGIN .*PRIVATE KEY-----'
+    'sk-ant-api[0-9]{2}-[A-Za-z0-9]'
+    'sk-proj-[A-Za-z0-9]'
+    'ghp_[A-Za-z0-9]{36}'
+    'gho_[A-Za-z0-9]{36}'
+    'AKIA[0-9A-Z]{16}'
+)
+
+# Files to skip (binary, lock files, baselines, this script itself)
+EXCLUDE='\.pyc$|\.parquet$|\.db$|\.png$|\.jpg$|\.whl$|\.tar\.gz$|package-lock\.json$|pre-commit-secrets$'
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep -vE "$EXCLUDE" || true)
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
+
+FOUND=0
+for pattern in "${PATTERNS[@]}"; do
+    # Check staged content (not working tree) via git show :path
+    for file in $STAGED; do
+        if git show ":$file" 2>/dev/null | grep -qiE -e "$pattern"; then
+            if [ $FOUND -eq 0 ]; then
+                echo "SECRET DETECTED — commit blocked."
+                echo ""
+            fi
+            echo "  $file: matches pattern '$pattern'"
+            FOUND=$((FOUND + 1))
+        fi
+    done
+done
+
+if [ $FOUND -gt 0 ]; then
+    echo ""
+    echo "Remove the secret(s) above before committing."
+    echo "If this is a false positive, use: git commit --no-verify"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `infrastructure/pre-commit-secrets`, a portable shell script that scans staged diffs for 14 secret patterns (Anthropic, OpenAI, AWS, Gmail, Polygon, FMP, FRED API keys, private keys, GitHub tokens, AWS access key IDs)
- Blocks the commit and prints the offending file/pattern if a match is found
- Designed to be symlinked into `.git/hooks/pre-commit` across all 6 alpha-engine repos

## Test plan
- [ ] Symlink into a repo: `ln -sf ~/Development/alpha-engine/infrastructure/pre-commit-secrets .git/hooks/pre-commit`
- [ ] Verify commit with a dummy secret string is blocked
- [ ] Verify normal commits proceed without interference

🤖 Generated with [Claude Code](https://claude.com/claude-code)