### PR TITLE
fix: add missing requests dep for Telegram notifications

### DIFF
--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -97,6 +97,7 @@ def send_daemon_status(message: str) -> bool:
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if not token or not chat_id:
+        logger.warning("Telegram not configured — TELEGRAM_BOT_TOKEN=%s TELEGRAM_CHAT_ID=%s", "set" if token else "MISSING", "set" if chat_id else "MISSING")
         return False
 
     return _send_telegram(token, chat_id, message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas~=2.2
 pyarrow~=14.0
 anthropic~=0.40
 exchange-calendars~=4.5
+requests~=2.32


### PR DESCRIPTION
## Summary
- Add `requests~=2.32` to `requirements.txt` — was imported in `notifier.py` but never declared as a dependency, causing silent failures for Telegram health checks
- Add `logger.warning()` to `send_daemon_status()` when env vars are missing (was returning `False` silently with no log output)

## Deploy steps
After merge, on EC2:
```bash
cd ~/alpha-engine && git pull
source .venv/bin/activate && pip install requests
sudo systemctl restart alpha-engine-daemon
sudo journalctl -u alpha-engine-daemon -n 20 --no-pager
```
IB Gateway is NOT affected — `systemctl restart alpha-engine-daemon` only restarts the daemon process.

## Test plan
- [x] 152 tests pass locally
- [ ] Verify requests installs on EC2 venv
- [ ] Verify daemon restarts cleanly and IB Gateway stays connected
- [ ] Verify Telegram health check arrives within 1 hour (heartbeat interval)

Generated with Claude Code