### PR TITLE
fix: heartbeat logging + Telegram error visibility

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -542,16 +542,19 @@ def run_daemon(dry_run: bool = False) -> None:
             order_book.merge_executed(executed_tickers)
 
             # ── Heartbeat ─────────────────────────────────────────────
-            if _time.time() - _last_heartbeat >= _HEARTBEAT_INTERVAL:
+            _elapsed = _time.time() - _last_heartbeat
+            if _elapsed >= _HEARTBEAT_INTERVAL:
                 n_pending = len(order_book.pending_entries())
                 n_stops = len(order_book.active_stops())
                 n_positions = len(ibkr.get_positions())
-                send_daemon_status(
+                msg = (
                     f"\U0001f49a *Daemon heartbeat*\n"
                     f"Positions: {n_positions} | Stops: {n_stops} | "
                     f"Pending entries: {n_pending}\n"
                     f"Trades today: {trades_executed}"
                 )
+                ok = send_daemon_status(msg)
+                logger.info("Heartbeat sent (ok=%s) after %.0fs | pos=%d stops=%d pending=%d trades=%d", ok, _elapsed, n_positions, n_stops, n_pending, trades_executed)
                 _last_heartbeat = _time.time()
 
             # ── Mid-day backup (noon ET) ─────────────────────────────

--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -53,7 +53,7 @@ def _send_telegram(token: str, chat_id: str, text: str) -> bool:
         logger.warning("Telegram API returned %d: %s", resp.status_code, resp.text[:200])
         return False
     except Exception:
-        logger.debug("Telegram send failed", exc_info=True)
+        logger.warning("Telegram send failed", exc_info=True)
         return False
 
 

--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -97,6 +97,7 @@ def send_daemon_status(message: str) -> bool:
     token = os.getenv("TELEGRAM_BOT_TOKEN")
     chat_id = os.getenv("TELEGRAM_CHAT_ID")
     if not token or not chat_id:
+        logger.warning("Telegram not configured — TELEGRAM_BOT_TOKEN=%s TELEGRAM_CHAT_ID=%s", "set" if token else "MISSING", "set" if chat_id else "MISSING")
         return False
 
     return _send_telegram(token, chat_id, message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas~=2.2
 pyarrow~=14.0
 anthropic~=0.40
 exchange-calendars~=4.5
+requests~=2.32


### PR DESCRIPTION
## Summary
- Add `logger.info` to heartbeat: logs every fire with ok/fail, elapsed time, and position counts
- Upgrade `_send_telegram` exception logging from DEBUG to WARNING so failures are visible in daemon logs
- Previous heartbeat had ZERO log output — impossible to tell if it fired, succeeded, or failed silently

## Test plan
- [x] 152 tests pass
- [ ] Deploy, restart daemon, confirm heartbeat log line appears after 1 hour
- [ ] If heartbeat Telegram fails, WARNING now visible in /var/log/daemon.log

Generated with Claude Code