### PR TITLE
fix: prevent profit-take from firing repeatedly after REDUCE

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -786,6 +786,16 @@ def _execute_exit(
     # Update order book
     if action == "EXIT":
         order_book.remove_stop(ticker)
+    elif action == "REDUCE":
+        # Update stop record shares to reflect remaining position
+        remaining = int(positions.get(ticker, {}).get("shares", 0))
+        if remaining > 0:
+            order_book.update_stop_shares(ticker, remaining)
+            # Mark profit-take as executed so it doesn't fire again
+            if exit_signal.get("reason") == "intraday_profit_take":
+                order_book.mark_profit_take_executed(ticker)
+        else:
+            order_book.remove_stop(ticker)
     order_book.save()
 
     send_trade_alert(

--- a/executor/intraday_exit_manager.py
+++ b/executor/intraday_exit_manager.py
@@ -123,7 +123,9 @@ class IntradayExitManager:
         return None
 
     def _check_profit_take(self, stop: dict, current_price: float) -> dict | None:
-        """Reduce 50% when profit exceeds threshold."""
+        """Reduce 50% when profit exceeds threshold. Fires at most once per position."""
+        if stop.get("profit_take_executed"):
+            return None
         threshold = self._config.get("intraday_profit_take_pct", 0.08)
         entry_price = stop.get("entry_price")
         if not entry_price or entry_price <= 0:

--- a/executor/order_book.py
+++ b/executor/order_book.py
@@ -220,6 +220,20 @@ class OrderBook:
                 stop["current_stop"] = new_stop
                 break
 
+    def update_stop_shares(self, ticker: str, new_shares: int) -> None:
+        """Update the share count on a stop record after a partial REDUCE."""
+        for stop in self._data.get("active_stops", []):
+            if stop["ticker"] == ticker:
+                stop["shares"] = new_shares
+                break
+
+    def mark_profit_take_executed(self, ticker: str) -> None:
+        """Mark a stop record so profit-take doesn't fire again."""
+        for stop in self._data.get("active_stops", []):
+            if stop["ticker"] == ticker:
+                stop["profit_take_executed"] = True
+                break
+
     def set_date(self, run_date: str) -> None:
         """Set the book date (used by morning batch)."""
         self._data["date"] = run_date


### PR DESCRIPTION
## Summary
- After a profit-take REDUCE, the daemon didn't update the stop record's `shares` field, causing profit-take to fire again on the next poll with the same share count
- Combined with `_validate_sell_shares` capping to held shares, this liquidated the entire UNH position (313 shares) instead of reducing 50% (156 shares)
- Two fixes: update stop shares after REDUCE, and add `profit_take_executed` flag so profit-take fires at most once per position

## Incident
- UNH entered 4/6 at $281.21 (313 shares)
- 4/7 13:42: profit-take fired (8.4% gain), REDUCE 156 shares — correct
- 4/7 13:43: profit-take fired again (9.1% gain), REDUCE 1 share (capped from 156) — **bug**
- Net: full exit instead of 50% reduction

## Test plan
- [x] 152 unit tests pass
- [x] Pre-push dry-run gate passed
- [x] Gitleaks pre-commit passed
- [ ] Deploy to EC2 and verify profit-take fires only once

🤖 Generated with [Claude Code](https://claude.com/claude-code)