### PR TITLE
EOD pipeline: daemon triggers Step Function, SPY from daily_closes

### DIFF
--- a/executor/config_loader.py
+++ b/executor/config_loader.py
@@ -16,6 +16,7 @@ _SEARCH_PATHS = [
     os.path.expanduser("~/alpha-engine-config/executor/risk.yaml"),
     os.path.join(_REPO_ROOT, "..", "alpha-engine-config", "executor", "risk.yaml"),
     os.path.join(_REPO_ROOT, "config", "risk.yaml"),
+    os.path.join(_REPO_ROOT, "config", "risk.yaml.example"),
 ]
 
 

--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -682,6 +682,36 @@ def run_daemon(dry_run: bool = False) -> None:
         )
         logger.info("Daemon shutdown complete | trades=%d", trades_executed)
 
+        # Trigger EOD pipeline Step Function
+        if not dry_run:
+            _trigger_eod_pipeline(config, run_date)
+
+
+def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
+    """Start the EOD Step Function pipeline after daemon shutdown."""
+    try:
+        import boto3 as _b3_sf
+        sfn = _b3_sf.client("stepfunctions", region_name="us-east-1")
+        state_machine_arn = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        micro_instance_id = "i-09b539c844515d549"
+        trading_instance_id = "i-018eb3307a21329bf"
+        sns_topic_arn = config.get("sns_topic_arn", "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts")
+        import json as _json_sf
+        sfn.start_execution(
+            stateMachineArn=state_machine_arn,
+            name=f"eod-{run_date}-{int(__import__('time').time())}",
+            input=_json_sf.dumps({
+                "ec2_instance_id": [micro_instance_id],
+                "trading_instance_id": [trading_instance_id],
+                "sns_topic_arn": sns_topic_arn,
+                "run_date": run_date,
+                "triggered_by": "daemon_shutdown",
+            }),
+        )
+        logger.info("EOD pipeline triggered: %s", state_machine_arn)
+    except Exception as exc:
+        logger.warning("Failed to trigger EOD pipeline (non-fatal): %s", exc)
+
 
 def _execute_exit(
     ibkr: IBKRClient,

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -36,8 +36,27 @@ logger = logging.getLogger(__name__)
 from executor.config_loader import CONFIG_PATH
 
 
-def _spy_close(run_date: str) -> float | None:
-    """Fetch SPY closing price for run_date via polygon (yfinance fallback)."""
+def _spy_close(run_date: str, config: dict | None = None) -> float | None:
+    """Fetch SPY closing price for run_date.
+
+    Priority: S3 daily_closes (written by post-market data step) → polygon → yfinance.
+    """
+    # Try S3 daily_closes first (most reliable — written by PostMarketData step)
+    try:
+        import io
+        bucket = (config or {}).get("trades_bucket", "alpha-engine-research")
+        s3 = boto3.client("s3")
+        key = f"predictor/daily_closes/{run_date}.parquet"
+        obj = s3.get_object(Bucket=bucket, Key=key)
+        df = pd.read_parquet(io.BytesIO(obj["Body"].read()))
+        if "SPY" in df.index and "Close" in df.columns:
+            close = float(df.loc["SPY", "Close"])
+            logger.info("SPY close from daily_closes/%s: $%.2f", run_date, close)
+            return close
+    except Exception as e:
+        logger.debug("daily_closes SPY lookup failed: %s", e)
+
+    # Fallback: polygon
     try:
         from polygon_client import polygon_client
         close = polygon_client().get_single_close("SPY", run_date)
@@ -45,7 +64,7 @@ def _spy_close(run_date: str) -> float | None:
             return close
     except Exception as e:
         logger.warning("Polygon SPY fetch failed, trying yfinance: %s", e)
-    # Fallback to yfinance
+    # Fallback: yfinance
     try:
         import yfinance as yf
         end_date = (date.fromisoformat(run_date) + timedelta(days=1)).isoformat()
@@ -318,7 +337,7 @@ def run(run_date: str | None = None) -> None:
         daily_return = ((nav - prior_nav) / prior_nav * 100)
 
     # SPY return for the day
-    spy_price = _spy_close(run_date)
+    spy_price = _spy_close(run_date, config)
     spy_return = None
     if spy_price:
         # Try cached prior SPY close from eod_pnl first


### PR DESCRIPTION
## Summary
- Daemon triggers alpha-engine-eod-pipeline Step Function on shutdown (event-driven, no cron)
- EOD reads SPY close from daily_closes parquet (written by PostMarketData step) before falling back to polygon/yfinance
- Eliminates 0% SPY return bug caused by polygon 403 / yfinance failures after hours

## Replaces
- alpha-engine-eod.timer (systemd, 1:20 PM PT)
- alpha-engine-stop-trading (EventBridge Scheduler, 1:30 PM PT)

## Test plan
- [ ] Verify daemon log shows 'EOD pipeline triggered' on shutdown
- [ ] Verify EOD reads SPY from daily_closes (log: 'SPY close from daily_closes')
- [ ] Verify instance stops after EOD completes