### PR TITLE
Restructure README + comms update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+Alpha Engine is a personal project by [@cipher813](https://github.com/cipher813). Contributions are welcome.
+
+## How to contribute
+
+- **Bug reports**: Open an issue with steps to reproduce, expected vs actual behavior, and relevant logs.
+- **Bug fixes**: PRs welcome. Include a test that fails before the fix and passes after.
+- **Features**: Open an issue first to discuss the approach before writing code.
+
+## Development workflow
+
+1. Fork the repo and create a feature branch from `main`
+2. Make changes, add tests
+3. Run the test suite: `pytest tests/ -v`
+4. Open a PR against `main` with a clear description of what changed and why
+
+## Code standards
+
+- All tests must pass before merging
+- No secrets, API keys, or proprietary config in commits (gitleaks pre-commit hook enforced)
+- Follow existing patterns — if unsure, check how similar code is structured elsewhere in the repo
+
+## Related repos
+
+This module is part of the [Nous Ergon](https://nousergon.ai) trading system. See the [system overview](https://github.com/cipher813/alpha-engine#readme) for architecture and the [documentation index](https://github.com/cipher813/alpha-engine-docs#readme) for all repos.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,53 @@
 # Nous Ergon: Alpha Engine
 
-**See the Nous Ergon public dashboard at [nousergon.ai](https://nousergon.ai) and blog series on [Hashnode](https://nousergon.ai/blog)**
+[![Python](https://img.shields.io/badge/python-3.11+-blue.svg)]()
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Tests](https://img.shields.io/badge/tests-152_passing-brightgreen.svg)]()
 
-**Nous Ergon** (νοῦς ἔργον — "intelligence at work") is a fully autonomous trading system that combines AI-driven research, quantitative prediction, and rule-based execution to generate market alpha.
+**[Nous Ergon](https://nousergon.ai)** (νοῦς ἔργον — "intelligence at work") is a fully autonomous trading system that combines AI-driven research, quantitative prediction, and rule-based execution to generate market alpha.
 
 ```
 Alpha = Portfolio Return − SPY Return
 ```
 
-The system targets sustained outperformance against the S&P 500 by splitting the problem into three layers, each matched to the right tool:
+**[Website](https://nousergon.ai)** | **[Blog](https://nousergon.ai/blog)** | **[Full Documentation Index](https://github.com/cipher813/alpha-engine-docs#readme)**
 
-| Layer | Tool | Role |
-|-------|------|------|
-| **Research** | LLM agents (Claude) | Judgment over unstructured data — news, analyst reports, macro context |
-| **Prediction** | Machine learning (LightGBM) | Pattern recognition over structured numerical features |
-| **Execution** | Deterministic rules | Hard risk constraints that never get creative |
+## Table of Contents
 
----
+- [System Architecture](#system-architecture)
+- [Modules](#modules)
+- [S3 Layout](#s3-layout)
+- [Key Metrics](#key-metrics)
+- [Stack](#stack)
+- [Executor Module](#executor)
 
 ## System Architecture
 
-Five modules run on AWS, connected through a shared S3 bucket. Each module reads its inputs from S3 and writes its outputs back — no shared state beyond the bucket.
+Six modules run on AWS, connected through a shared S3 bucket. Each module reads its inputs from S3 and writes its outputs back — no shared state beyond the bucket.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                    WEEKLY CADENCE (Monday)                          │
+│                    WEEKLY CADENCE (Saturday)                         │
 │                                                                     │
+│  Data Phase 1 ──── prices (ArcticDB), macro, constituents          │
+│  RAG Ingestion ──── SEC filings, 8-Ks, earnings → research KB     │
 │  Research ──── scan 900 tickers, rotate population, write signals  │
-│  Predictor Training ──── retrain on multi-year history, promote    │
-│  Backtester ──── signal quality + weight optimization + param sweep │
+│  Data Phase 2 ──── alternative data for promoted tickers           │
+│  Predictor Training ──── meta-model retrain, walk-forward validate │
+│  Backtester ──── signal quality + evaluation + param optimization  │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
 │                    DAILY CADENCE (Mon–Fri)                           │
 │                                                                     │
-│  Predictor (6:15 AM PT) ──── reads latest signals.json from S3     │
-│       │                                                             │
-│       ▼  predictions.json                                           │
-│  Executor (6:20 AM PT) ──── order book ───► entries + exits        │
-│       │                                                             │
-│       ▼  order book (approved entries + urgent exits + stops)       │
-│  Intraday Daemon (6:25 AM – 1:00 PM PT) ──── sole order executor  │
-│       │                                                             │
-│       ▼  (market close)                                             │
-│  EOD Reconcile (1:05 PM PT) ──── NAV, return, alpha ───► email     │
+│  Daily Data (6:05 AM PT) ──── daily closes + macro refresh         │
+│  Predictor (6:07 AM PT) ──── reads signals, predicts 5d alpha     │
+│       │  predictions.json                                           │
+│  Executor (6:15 AM PT) ──── order book ───► entries + exits        │
+│       │  order book (approved entries + urgent exits + stops)       │
+│  Intraday Daemon (6:20 AM – 1:15 PM PT) ──── sole order executor  │
+│       │  (market close)                                             │
+│  EOD Reconcile (1:20 PM PT) ──── NAV, alpha ───► email + EC2 stop │
 └─────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -53,75 +57,85 @@ Five modules run on AWS, connected through a shared S3 bucket. Each module reads
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-S3 as the communication bus means any module can be replaced, rewritten, or tested independently. They agree on a JSON schema, and S3 handles the rest.
-
----
+Orchestrated by three AWS Step Functions (Saturday, weekday, EOD). S3 as the communication bus means any module can be replaced, rewritten, or tested independently.
 
 ## Modules
 
-### 1. Research — [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research)
+| # | Module | Repo | Role |
+|---|--------|------|------|
+| 1 | **Research** | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) | 6 LLM sector teams + CIO scan ~900 stocks weekly, produce composite scores (0-100) as `signals.json` |
+| 2 | **Predictor** | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) | Meta-model (4 GBMs + ridge) predicts 5-day sector-relative alpha; veto gate blocks high-confidence DOWN |
+| 3 | **Executor** | [`alpha-engine`](https://github.com/cipher813/alpha-engine) *(this repo)* | Morning planner + intraday daemon: risk rules, position sizing, technical entry triggers, trailing stops |
+| 4 | **Backtester** | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) | Weekly evaluation (component grades, P/R/F1) + 6 autonomous optimizers → S3 config feedback loop |
+| 5 | **Dashboard** | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) | Streamlit monitoring: portfolio performance, signal quality, system report card, execution evaluation |
+| 6 | **Data** | [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) | Centralized data collection: ArcticDB price store (909 tickers), macro, alternative data |
 
-Autonomous investment research pipeline. Five LLM agents orchestrated by LangGraph maintain rolling investment theses on a configurable universe of tracked stocks and scan ~900 S&P 500/400 tickers weekly for top buy candidates.
+Each module has its own README with Quick Start, Architecture, and S3 Contract sections.
 
-- Quantitative filter reduces ~900 tickers to a shortlist (no LLM calls)
-- Ranking agent (Sonnet) selects top candidates from the filtered set
-- Per-ticker agents (news + research) run independently on every candidate (Haiku)
-- Macro agent (Sonnet) assesses market environment and sector conditions
-- Consolidator (Sonnet) synthesizes into a morning research brief via email
-- Outputs composite attractiveness scores (0–100) per ticker as `signals.json`
+## S3 Layout
 
-### 2. Predictor — [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor)
+All inter-module communication flows through a single S3 bucket:
 
-LightGBM model that predicts 5-day market-relative returns for each ticker. Produces directional predictions (UP/FLAT/DOWN) with confidence scores.
+```
+s3://alpha-engine-research/
+├── signals/{date}/signals.json          ← Research → Predictor + Executor
+├── arcticdb/
+│   ├── universe/                        ← 10y OHLCV, 909 tickers (ArcticDB)
+│   └── universe_slim/                   ← 2y slices for inference (ArcticDB)
+├── predictor/
+│   ├── daily_closes/{date}.parquet      ← Daily OHLCV archive
+│   ├── feature_store/{date}/            ← Pre-computed features (54 x 903 tickers)
+│   ├── weights/                         ← GBM + meta-model weights
+│   ├── predictions/{date}.json          ← Daily predictions
+│   └── metrics/latest.json              ← Model performance
+├── trades/
+│   ├── trades_full.csv                  ← Complete trade audit log
+│   └── eod_pnl.csv                      ← Daily NAV, return, alpha
+├── backtest/{date}/                     ← Weekly: report, grades, trigger/shadow/exit/veto analysis
+├── backtest/grade_history.json          ← 52-week rolling component grades
+├── config/                              ← Auto-optimized by backtester
+│   ├── scoring_weights.json             ← → Research
+│   ├── executor_params.json             ← → Executor
+│   ├── predictor_params.json            ← → Predictor
+│   └── research_params.json             ← → Research (deferred)
+├── health/{module}.json                 ← Module completion markers
+└── research.db                          ← SQLite (signal history, theses, macro)
+```
 
-- Engineered features across technical indicators, macro context, volume, and cross-sectional measures
-- Trains on sector-neutral labels (stock returns minus sector ETF returns)
-- Weekly retraining with walk-forward validation; weights promote only if IC gate passes
-- Veto gate: high-confidence DOWN predictions override BUY signals from Research
+## Key Metrics
 
-### 3. Executor — [`alpha-engine`](https://github.com/cipher813/alpha-engine) *(this repo)*
+| Metric | What It Measures |
+|--------|-----------------|
+| Total alpha | Portfolio cumulative return − SPY cumulative return |
+| Sharpe ratio | Risk-adjusted return (annualized) |
+| Signal accuracy | % of BUY signals beating SPY over configurable windows |
+| GBM IC | Rank correlation of predicted vs actual forward returns |
+| Max drawdown | Peak-to-trough portfolio decline |
+| System grade | Weekly A-F scorecard across all components (backtester) |
 
-Reads signals and predictions from S3, applies hard risk rules, sizes positions, and writes the intraday order book. The daemon is the sole order executor — no orders are placed at market open. Entry timing is optimized via technical triggers; exits execute immediately.
+## Stack
 
-- Morning planner: signal ingestion, risk evaluation, position sizing → writes order book (no orders placed)
-- Intraday daemon: sole order executor using 15-min delayed streaming via IB Gateway
-- Graduated drawdown response with configurable halt threshold
-- ATR-based trailing stops (volatility-adaptive) with time-decay exit rules
-- Broker-side trailing stops via bracket orders for crash protection
-- Telegram push notifications for all intraday trades
-- Auto-tuned by backtester via S3-delivered `config/executor_params.json`
-
-### 4. Backtester — [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester)
-
-The system's learning mechanism. Validates signal quality, runs attribution analysis, and autonomously recommends parameter updates that flow back to upstream modules.
-
-- Signal quality: measures BUY signal accuracy at configurable horizons
-- Attribution: correlates sub-scores with outperformance outcomes
-- Weight optimization: adjusts Research scoring weights with conservative guardrails
-- Parameter sweep: randomized search across executor parameters, ranked by Sharpe ratio
-- Veto threshold calibration: sweeps predictor confidence thresholds
-
-### 5. Dashboard — [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard)
-
-Read-only Streamlit application for monitoring the full system: portfolio performance vs SPY, signal quality trends, per-ticker research timelines, backtester results, and predictor metrics.
+| Component | Technology |
+|-----------|------------|
+| LLM provider | Anthropic Claude (Haiku-4.5 per-ticker, Sonnet-4.6 synthesis) |
+| ML framework | LightGBM (meta-model: 4 specialized GBMs + ridge) |
+| Agent orchestration | LangGraph |
+| Price data | ArcticDB (S3-backed) + Polygon.io + yfinance fallback |
+| Broker | Interactive Brokers (paper account via IB Gateway) |
+| Cloud | AWS (Lambda, S3, SES, EC2, Step Functions, SSM, EventBridge) |
+| Dashboard | Streamlit + Plotly |
+| Secrets | AWS SSM Parameter Store (24 params under /alpha-engine/*) |
+| Config | Private config repo (alpha-engine-config) with per-module search |
 
 ---
 
-## Getting Started
+# Executor
 
-Each module has its own README with a Quick Start section. The table below shows what you need to configure for each:
+> Reads signals and predictions from S3, applies hard risk rules, sizes positions, and executes orders via IB Gateway. The morning planner writes the order book; the daemon is the sole order executor.
 
-| Module | Config Files to Create | First Command |
-|--------|----------------------|---------------|
-| [Research](https://github.com/cipher813/alpha-engine-research) | `.env`, `config/universe.yaml`, `config/scoring.yaml`, `config/prompts/` + 13 proprietary source files | `python3 main.py --dry-run --skip-scanner` |
-| [Predictor](https://github.com/cipher813/alpha-engine-predictor) | `config/predictor.yaml` | `python train_gbm.py --data-dir data/cache` |
-| [Executor](https://github.com/cipher813/alpha-engine) | `config/risk.yaml` | `python executor/main.py --dry-run` |
-| [Backtester](https://github.com/cipher813/alpha-engine-backtester) | `config.yaml` | `python backtest.py --mode signal-quality` |
-| [Dashboard](https://github.com/cipher813/alpha-engine-dashboard) | None (works with defaults) | `streamlit run app.py` |
+**Part of the [Nous Ergon](https://nousergon.ai) autonomous trading system.**
 
----
-
-## Executor Quick Start (This Repo)
+## Quick Start
 
 ### Prerequisites
 
@@ -150,174 +164,88 @@ python executor/main.py --dry-run    # full loop, no orders placed
 ```
 executor/main.py              # Morning order-book planner (no orders placed)
 executor/daemon.py            # Sole order executor — urgent exits + technical entry triggers
-executor/order_book.py        # JSON-based intraday order book (entries, urgent exits, stops)
+executor/order_book.py        # JSON-based intraday order book
 executor/signal_reader.py     # Reads signals.json from S3
-executor/risk_guard.py        # 8-rule enforcement + graduated drawdown
+executor/risk_guard.py        # 9-rule enforcement + graduated drawdown
 executor/position_sizer.py    # Equal-weight base with 9 sizing adjustments
 executor/ibkr.py              # IB Gateway wrapper (ib_insync)
-executor/bracket_orders.py    # BUY + trailing stop as parent/child IB orders
-executor/strategies/          # ATR trailing stops, time-decay, profit-take, momentum exits
-executor/price_monitor.py     # 15-min delayed streaming subscriptions
-executor/intraday_exit_manager.py  # Intraday exit rules (trail, profit-take, collapse)
-executor/entry_triggers.py    # Intraday entry triggers (pullback, VWAP, support, expiry)
-executor/notifier.py          # Telegram push notifications for trades
-executor/eod_reconcile.py     # EOD P&L vs SPY + email
-executor/price_cache.py       # OHLCV from predictor S3 slim cache for ATR
+executor/entry_triggers.py    # Pullback, VWAP, support, graduated expiry
+executor/intraday_exit_manager.py  # Trail, profit-take, collapse exits
+executor/eod_reconcile.py     # EOD P&L vs SPY + email (Step Function orchestrated)
+executor/strategies/          # ATR stops, time-decay, profit-take, momentum
 config/risk.yaml.example      # Safe template — copy to config/risk.yaml
 ```
 
----
-
-## Executor Architecture
+## Architecture
 
 ### Daily Execution Flow
 
-The executor operates in three phases: a morning planner that writes the order book, an intraday daemon that executes all trades, and EOD reconciliation.
-
 | Step | Time (PT) | What happens |
 |------|-----------|--------------|
-| **Morning Planner** | ~6:20 AM | Read signals, evaluate exits, apply risk rules, size positions → write order book (no orders) |
-| **Intraday Daemon** | ~6:25 AM – 1:00 PM | Wait for market open (6:30 AM PT). Execute urgent exits immediately. Monitor entries for technical triggers. Monitor stops for exit rules. |
-| **EOD Reconcile** | 1:05 PM | Capture final NAV, compute daily return vs SPY, log alpha, send email report |
-
-The morning planner is the **decision-maker** (what to buy/sell and how much). The daemon is the **sole executor** (when to buy/sell during the day, with a hard safety check that the connected account is paper). Both write to the same SQLite trade log and S3 backup.
+| **Morning Planner** | ~6:15 AM | Read signals, evaluate exits, apply risk rules, size positions → write order book (no orders) |
+| **Intraday Daemon** | ~6:20 AM – 1:15 PM | Execute urgent exits at open. Monitor entries for technical triggers. Monitor stops for exit rules. |
+| **EOD Reconcile** | 1:20 PM | Capture NAV, compute daily return vs SPY, log alpha, send email. Step Function stops EC2 after. |
 
 ### Decision Pipeline
 
-Every ENTER signal flows through this deterministic pipeline:
+Every ENTER signal flows through this pipeline:
 
 ```
 signals.json (S3)
        │
-       ▼
 Signal Reader ──── read today's signals; fall back up to 5 prior trading days
        │
-       ▼
-Exit Manager ──── evaluate held positions against 5 exit strategies:
-  1. ATR trailing stop (volatility-adaptive)
-  2. Fallback stop (fixed % when ATR unavailable)
-  3. Time-based decay (reduce/exit stale HOLD positions)
-  4. Profit-taking (trim at configurable gain threshold)
-  5. Momentum exit (20d momentum flip + RSI below threshold)
-  + Sector-relative veto (skip exit if stock outperforms sector)
+Exit Manager ──── evaluate held positions against 5 exit strategies
        │
-       ▼
-Risk Guard ──── 8 rule layers (all must pass):
-  1. Score minimum (score >= min_score_to_enter)
-  2. Conviction gate (blocks "declining" conviction)
-  3. Momentum gate (20d return must exceed threshold)
-  4. Graduated drawdown (tiered sizing reduction → halt at circuit breaker)
-  5. Max single position (% of NAV, adjustable by regime)
-  6. Bear regime block (blocks new entries in underweight sectors)
-  7. Sector exposure limit (default 25% NAV)
-  8. Cross-ticker correlation (alerts on concentrated correlated holdings)
+Risk Guard ──── 9 rule layers (all must pass for entry)
        │
-       ▼
-Position Sizer ──── compute shares:
-  base_weight = 1 / n_enter_signals
-  × sector_adj (overweight/market/underweight)
-  × conviction_adj (declining → reduced)
-  × upside_adj (low price target → reduced)
-  × confidence_adj (from GBM p_up, continuous scaling)
-  × atr_adj (inverse volatility sizing)
-  × drawdown_multiplier (from graduated drawdown tier)
-  × staleness_adj (decay for aged signals)
-  × earnings_adj (reduced sizing near earnings)
-  → capped at max_position_pct
+Position Sizer ──── compute shares (base × 9 adjustments, capped)
        │
-       ▼
-Order Book ──── write approved entry to order_book.json with:
-  - shares, sizing factors, ATR value
-  - entry triggers (pullback %, VWAP discount, support level)
-  - full metadata for daemon's trade logging
+Order Book ──── write approved entry with trigger levels + metadata
        │
-       ▼
-Daemon ──── waits for technical trigger, then places bracket order + logs trade
+Daemon ──── waits for technical trigger, places bracket order, logs trade
 ```
 
-### Intraday Daemon
+### Entry Triggers (Intraday, OR Logic)
 
-The daemon is the **sole order executor**. It starts after the morning planner completes, waits for market open (9:30 AM ET / 6:30 AM PT), then runs until market close. It connects to IB Gateway on a separate `clientId` (2) to avoid conflicts with the planner (clientId 1). A runtime safety check verifies the connected account starts with "D" (paper prefix) before placing any orders.
+| Trigger | Default | Fires When |
+|---------|---------|------------|
+| Pullback | 2% | (day_high - current) / day_high >= 2% |
+| VWAP Discount | 0.5% | (vwap - current) / vwap >= 0.5% (previous day's VWAP from daily_closes) |
+| Support Bounce | 1% | 0 <= (current - support) / support <= 1% |
+| Graduated Expiry | 3-tier | Technical-only before 2 PM → graduated (price <= open+1%) 2-3:30 PM → unconditional 3:55 PM |
 
-**Execution phases:**
+### Risk Guard Rules
 
-1. **Phase 0 — Urgent exits** (immediately at market open): EXIT and REDUCE signals from Research and strategy rules execute as market orders with no trigger delay. Risk reduction is never deferred.
-2. **Phase 1+2 — Entry triggers + stop monitoring** (polling loop until market close): Pending entries wait for technical triggers. Active stops are monitored for exit rules.
+1. Score minimum (score >= min_score_to_enter)
+2. Conviction gate (blocks "declining" conviction)
+3. Momentum gate (20d return must exceed threshold)
+4. Graduated drawdown (tiered sizing reduction → halt at circuit breaker)
+5. Max single position (% of NAV, adjustable by regime)
+6. Bear regime block (blocks entries in underweight sectors)
+7. Sector exposure limit (default 25% NAV)
+8. Cross-ticker correlation (alerts on concentrated correlated holdings)
+9. Predictor veto (high-confidence DOWN prediction overrides BUY)
 
-**Price monitoring:** Subscribes to IB Gateway's free 15-minute delayed streaming data (`reqMarketDataType(3)`) for all tracked tickers. Prices update via `pendingTickersEvent` callbacks.
+### S3 Contract
 
-**Exit rules** (evaluated on each price update):
+**Reads:**
+| Path | Source | Content |
+|------|--------|---------|
+| `signals/{date}/signals.json` | Research | Per-ticker signal, score, conviction, sector |
+| `predictor/predictions/{date}.json` | Predictor | Direction, confidence, predicted alpha |
+| `config/executor_params.json` | Backtester | Auto-tuned risk parameters |
+| ArcticDB `universe_slim` | Data | 2y OHLCV for ATR computation |
 
-| Rule | Trigger | Action |
-|------|---------|--------|
-| ATR trailing stop | Price drops below `high_water - ATR × multiple` | SELL full position |
-| Profit-taking | Price up > 8% from entry | SELL 50% position |
-| Intraday collapse | Price drops > 5% from intraday high | SELL full position |
-| Time-based tightening | After 3+ days held, tighten trail to 1.5× ATR | Update stop |
+**Writes:**
+| Path | Content |
+|------|---------|
+| `trades/trades_full.csv` | Complete trade audit log |
+| `trades/eod_pnl.csv` | Daily NAV, return, alpha |
+| `trades/shadow_book.csv` | Risk guard blocked entries |
+| `health/executor.json` | Module health marker |
 
-**Entry triggers** (any one fires — OR logic):
-
-| Trigger | Logic | Default |
-|---------|-------|---------|
-| Pullback entry | Price drops ≥ 2% from intraday high | `pullback_pct: 0.02` |
-| VWAP discount | Price < VWAP by ≥ 0.5% | `vwap_discount_pct: 0.005` |
-| Support bounce | Price within 1% of 20-day support level | `support_pct: 0.01` |
-| Time expiry | No trigger by 3:30 PM ET → execute at market | `expiry_time: "15:30"` |
-
-**Notifications:** Every intraday trade sends a Telegram push notification via bot API (fire-and-forget, never blocks execution).
-
-### Data Sources
-
-The executor consumes six data streams — all read-only, no feedback during execution:
-
-| Source | What | Updated |
-|--------|------|---------|
-| `signals/{date}/signals.json` | Per-ticker signal (ENTER/EXIT/REDUCE/HOLD), score, conviction, price target, sector rating | Weekly (Monday, by Research) |
-| `predictor/predictions/{date}.json` | Per-ticker predicted direction, confidence, predicted alpha | Daily (by Predictor) |
-| IBKR account state | Live NAV, positions, current prices | Real-time via IB Gateway |
-| `predictor/price_cache_slim/*.parquet` | 2-year OHLCV per ticker (for ATR computation) | Weekly |
-| `trades.db` (SQLite) | Peak NAV, entry dates, trade history | After each execution |
-| `config/executor_params.json` (S3) | Backtester-tuned parameters | Weekly (Monday, by Backtester) |
-
-EXIT and REDUCE signals from Research always bypass all risk rules — reducing exposure is never blocked.
-
-### EC2 Infrastructure (Two Instances)
-
-The system runs on two EC2 instances to separate always-on hosting from market-hours trading:
-
-**Micro instance (t3.micro, 24/7) — dashboard host:**
-
-| Process | Type | Port |
-|---------|------|------|
-| Nginx (reverse proxy + SSL) | Always-on | 80, 443 |
-| nousergon.ai (Streamlit) | Always-on | 8502 |
-| dashboard.nousergon.ai (Streamlit) | Always-on | 8501 |
-
-**Trading instance (t3.small, market hours only) — started/stopped by EventBridge:**
-
-| Process | Type | Trigger |
-|---------|------|---------|
-| Xvfb (virtual display) | systemd | On boot |
-| IB Gateway (paper account, IBC) | systemd | After Xvfb |
-| Morning planner (`main.py`) | systemd oneshot | After IB Gateway ready (port 4002 poll) |
-| Intraday daemon (`daemon.py`) | systemd | After morning planner |
-| EOD reconcile (`eod_reconcile.py`) | systemd timer | 1:05 PM PT |
-
-**EventBridge Scheduler (serverless, no cron):**
-
-| Schedule | Time | Target |
-|----------|------|--------|
-| Start trading instance | Weekdays 6:15 AM PT | EC2 StartInstances |
-| Stop trading instance | Weekdays 1:30 PM PT | EC2 StopInstances |
-| Backtester spot launch | Mondays 08:00 UTC | SSM RunCommand → micro |
-
-**IB Gateway:** Uses IBC (IB Controller) with paper account credentials stored in `~/ibc/config.ini`. The paper account has its own dedicated username/password, separate from the live brokerage account. Paper accounts do not require 2FA. The daemon includes a runtime safety check that hard-exits if connected to a non-paper account.
-
----
-
-## Local Testing
-
-Test executor changes locally before deploying to EC2. No IB Gateway connection required.
+## Testing
 
 ```bash
 # Simulate mode: real signals from S3, synthetic IB positions, no orders placed
@@ -326,142 +254,26 @@ python executor/main.py --simulate
 # Dry run on EC2: real IB prices + positions, no order book written
 python executor/main.py --dry-run
 
-# Validate signals.json for executor compatibility (local file or S3)
-python tests/validate_signals.py --s3 2026-03-24
-python tests/validate_signals.py path/to/signals.json
+# Full test suite (152 tests)
+pytest tests/ -v
 ```
 
-**Preprod workflow:**
-1. Make code changes
-2. `python executor/main.py --simulate` — verify no crashes, review planned orders
-3. `--dry-run` on EC2 (after market close) — verify with real IB data
-4. Deploy live on next trading day
+## Deployment
 
-### Portfolio Reset
-
-Reset the portfolio to a clean $1M state (e.g., after tuning is complete and you want a fresh track record).
-
-```bash
-# Preview what will happen (no changes made)
-bash infrastructure/reset-portfolio.sh --dry-run
-
-# Execute the full reset (DESTRUCTIVE — archives all trade history first)
-bash infrastructure/reset-portfolio.sh --live
-```
-
-**Reset process:**
-1. Reset IB paper account balance at [IB Account Management](https://www.interactivebrokers.com) (manual — no API)
-2. Stop the trading instance
-3. Run `reset-portfolio.sh --live` — archives trade history to S3, writes clean db/csv
-4. Start the trading instance — first EOD reconcile creates the new inception row
-5. Dashboard automatically picks up the new inception date
-
-All historical data is preserved in `s3://alpha-engine-executor/trades/archive/{timestamp}/`.
-
----
-
-## Auto-Optimization
-
-The backtester writes three S3 config files that upstream modules read on cold-start, closing the feedback loop automatically:
-
-| S3 Key | Written By | Read By | Controls |
-|--------|-----------|---------|----------|
-| `config/scoring_weights.json` | Backtester | Research | Sub-score composite weights |
-| `config/executor_params.json` | Backtester | Executor | Risk parameters and sizing |
-| `config/predictor_params.json` | Backtester | Predictor | Veto confidence threshold |
-| `config/research_params.json` | Backtester | Research | Signal boost parameters (deferred until 200+ samples) |
-
-**Propagation timing:** Backtester runs Saturday 08:00 UTC and writes configs to S3. Lambda-based modules (Research, Predictor) pick up new configs on next cold-start (typically their next scheduled invocation). EC2-based modules (Executor) pick up configs when `main.py` runs on next trading day. There is no mid-day hot-reload — config changes take effect on the next run cycle.
-
----
-
-## Key Metrics
-
-| Metric | What It Measures |
-|--------|-----------------|
-| Total alpha | Portfolio cumulative return − SPY cumulative return |
-| Sharpe ratio | Risk-adjusted return (annualized) |
-| Daily alpha | Portfolio daily return − SPY daily return |
-| Signal accuracy | % of BUY signals beating SPY over configurable windows |
-| GBM IC | Rank correlation of predicted vs actual forward returns |
-| Max drawdown | Peak-to-trough portfolio decline |
-
----
-
-## S3 Layout
-
-All inter-module communication flows through a single S3 bucket:
-
-```
-s3://alpha-engine-research/
-├── signals/{date}/signals.json          ← Research → Predictor + Executor
-├── archive/universe/{TICKER}/           ← Research theses
-├── archive/candidates/{TICKER}/         ← Buy candidate theses
-├── archive/macro/                       ← Macro environment reports
-├── predictor/
-│   ├── price_cache/*.parquet            ← 10y OHLCV (weekly refresh)
-│   ├── price_cache_slim/*.parquet       ← 2y slice for inference
-│   ├── daily_closes/{date}.parquet      ← Daily OHLCV archive
-│   ├── weights/gbm_latest.txt           ← Active GBM model
-│   ├── predictions/{date}.json          ← Daily predictions
-│   └── metrics/latest.json              ← Model performance
-├── trades/
-│   ├── trades_full.csv                  ← Complete trade audit log
-│   └── eod_pnl.csv                      ← Daily NAV, return, alpha
-├── backtest/{date}/                     ← Weekly backtester outputs
-├── config/scoring_weights.json          ← Auto-updated by Backtester → Research
-├── config/executor_params.json          ← Auto-updated by Backtester → Executor
-├── config/predictor_params.json         ← Auto-updated by Backtester → Predictor
-└── research.db                          ← SQLite (signal history, theses)
-```
-
----
-
-## Stack
-
-| Component | Technology |
-|-----------|------------|
-| LLM provider | Anthropic Claude (Haiku for per-ticker, Sonnet for synthesis) |
-| ML framework | LightGBM |
-| Agent orchestration | LangGraph |
-| Broker | Interactive Brokers (paper account via IB Gateway) |
-| Cloud | AWS (Lambda, S3, SES, EC2) |
-| Dashboard | Streamlit + Plotly |
-| Databases | SQLite per-module (backed up to S3) |
-| Notifications | Telegram Bot API |
-
----
-
-## Cross-Module Opportunities
-
-### Stale Predictions Propagation
-
-If `daily_closes/{date}.parquet` is not written before inference runs, predictions use the slim cache only (potentially 1-2 days stale). The predictor tracks this via `price_freshness.max_age_days` in `predictor/metrics/latest.json`. The Dashboard Predictor page surfaces this metric. If `max_age_days > 2`, investigate whether `save_daily_closes()` is failing or the inference Lambda is running before market close.
-
-### S3 Retry Standardization
-
-S3 retry logic varies across modules. Current state (2026-03-30):
-
-| Module | Retry | Pattern |
-|--------|-------|---------|
-| Research | Yes | Custom `retry.py` decorator (3 attempts, exponential backoff) |
-| Predictor | No | One-shot S3 calls |
-| Executor | No | One-shot S3 calls (signals read, trades backup) |
-| Backtester | No | One-shot S3 calls (config writes, report upload) |
-| Dashboard | Yes | `_s3_get_object()` retry loop (3 attempts, backoff, transient-only) |
-
-Future: extract research's `retry.py` into a shared package or copy the pattern into predictor/backtester. Dashboard's retry is inline (appropriate for its single-file S3 loader). Priority is low — S3 throttling is rare at current request volumes.
-
----
+- **EC2 trading instance** (t3.small, market hours only): Started by weekday Step Function, stopped by EOD Step Function
+- **Boot sequence** (systemd): boot-pull → IB Gateway → morning planner → daemon
+- **Deploy gate**: boot-pull runs `--dry-run` after code update, auto-rollback on failure
+- **Config**: Reads from alpha-engine-config (private repo) first, falls back to local risk.yaml
+- **Secrets**: SSM Parameter Store (`/alpha-engine/*`), loaded at runtime
 
 ## Related Modules
 
 - [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) — Autonomous LLM research pipeline
-- [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) — GBM predictor (5-day alpha predictions)
-- [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) — Signal quality analysis and parameter optimization
+- [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) — Meta-model predictor (5-day alpha predictions)
+- [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) — Signal quality analysis, evaluation framework, and parameter optimization
 - [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) — Streamlit monitoring dashboard
-
----
+- [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) — Centralized data collection and ArcticDB price store
+- [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) — Documentation index and system audits
 
 ## License
 


### PR DESCRIPTION
## Summary
- README split: concise system overview (~100 lines) + executor-specific docs below separator
- Updated for: ArcticDB, meta-model, SSM secrets, config repo, VWAP trigger, graduated expiry, EOD Step Function
- Added: badges, TOC, S3 contract section, 6-module table (was 5)
- Removed: 200+ lines of module descriptions (each repo owns its own), stale opportunities
- CONTRIBUTING.md added

## Test plan
- [x] 152 executor tests still passing (README-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)