### PR TITLE
Fix EOD email: 0% daily returns for all positions

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -402,7 +402,8 @@ def run(run_date: str | None = None) -> None:
     # ── Per-position daily return & alpha contribution ──────────────────────
     # Look up prior day's positions_snapshot to get yesterday's price per ticker
     prior_snapshot_row = conn.execute(
-        "SELECT positions_snapshot FROM eod_pnl WHERE positions_snapshot IS NOT NULL ORDER BY date DESC LIMIT 1"
+        "SELECT positions_snapshot FROM eod_pnl WHERE positions_snapshot IS NOT NULL AND date < ? ORDER BY date DESC LIMIT 1",
+        (run_date,),
     ).fetchone()
     prior_positions = {}
     if prior_snapshot_row and prior_snapshot_row[0]:

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -326,7 +326,8 @@ def run(run_date: str | None = None) -> None:
 
     # Prior day's NAV (to compute daily return)
     prior_row = conn.execute(
-        "SELECT portfolio_nav FROM eod_pnl ORDER BY date DESC LIMIT 1"
+        "SELECT portfolio_nav FROM eod_pnl WHERE date < ? ORDER BY date DESC LIMIT 1",
+        (run_date,),
     ).fetchone()
     prior_nav = prior_row[0] if prior_row else None
 
@@ -342,7 +343,8 @@ def run(run_date: str | None = None) -> None:
     if spy_price:
         # Try cached prior SPY close from eod_pnl first
         spy_prior_row = conn.execute(
-            "SELECT spy_close FROM eod_pnl WHERE spy_close IS NOT NULL ORDER BY date DESC LIMIT 1"
+            "SELECT spy_close FROM eod_pnl WHERE spy_close IS NOT NULL AND date < ? ORDER BY date DESC LIMIT 1",
+            (run_date,),
         ).fetchone()
         if spy_prior_row and spy_prior_row[0]:
             spy_return = (spy_price / spy_prior_row[0] - 1) * 100
@@ -350,7 +352,8 @@ def run(run_date: str | None = None) -> None:
             # Fallback: fetch SPY close for the actual prior eod_pnl date
             # (avoids period="2d" which only gets 1 day regardless of gaps)
             prior_date_row = conn.execute(
-                "SELECT date FROM eod_pnl ORDER BY date DESC LIMIT 1"
+                "SELECT date FROM eod_pnl WHERE date < ? ORDER BY date DESC LIMIT 1",
+                (run_date,),
             ).fetchone()
             if prior_date_row:
                 prior_spy = _spy_close(prior_date_row[0])

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -45,7 +45,10 @@ class TestEntryTriggerEngine:
         assert ok is True
         assert "pullback" in reason
 
-    def test_pullback_no_fire(self):
+    @patch("executor.entry_triggers.datetime")
+    def test_pullback_no_fire(self, mock_dt):
+        mock_dt.now.return_value = _ET.localize(datetime(2026, 4, 8, 10, 0))
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
         eng = self._engine()
         ok, reason = eng.should_enter(
             {"triggers": {"pullback_pct": 0.02}},
@@ -71,7 +74,10 @@ class TestEntryTriggerEngine:
         assert ok is True
         assert "support" in reason
 
-    def test_support_broken_no_fire(self):
+    @patch("executor.entry_triggers.datetime")
+    def test_support_broken_no_fire(self, mock_dt):
+        mock_dt.now.return_value = _ET.localize(datetime(2026, 4, 8, 10, 0))
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
         eng = self._engine(disabled_triggers=["pullback"])
         ok, reason = eng.should_enter(
             {"triggers": {"support_level": 145.0}},
@@ -103,7 +109,10 @@ class TestEntryTriggerEngine:
         assert ok is True
         assert "graduated" in reason
 
-    def test_disabled_trigger(self):
+    @patch("executor.entry_triggers.datetime")
+    def test_disabled_trigger(self, mock_dt):
+        mock_dt.now.return_value = _ET.localize(datetime(2026, 4, 8, 10, 0))
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
         eng = self._engine(disabled_triggers=["pullback"])
         ok, _ = eng.should_enter(
             {"triggers": {"pullback_pct": 0.02}},


### PR DESCRIPTION
## Summary
EOD email showed +0.00% daily return for every position despite portfolio being up +2.15%.

**Root cause:** Prior snapshot query `SELECT ... ORDER BY date DESC LIMIT 1` returned today's row (just inserted earlier in the same function), so `prior_price == current_price` → 0% return for all positions.

**Fix:** Add `WHERE date < ?` filter to exclude today's date.

**Impact:** All downstream calculations were wrong:
- Position daily returns: 0% (should have been ~2% each)
- Alpha $: showed `-weight × SPY` instead of `(position_return - SPY) × weight`
- Cash showed +9.33% / +$22,162 (trade proceeds misattributed as cash return)

## Test plan
- [ ] Verify tomorrow's EOD email shows non-zero per-position returns
- [ ] Verify alpha $ signs are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)