### PR TITLE
Add flow-doctor error monitoring to executor logging

### DIFF
--- a/executor/log_config.py
+++ b/executor/log_config.py
@@ -3,6 +3,10 @@ Structured logging configuration for the executor.
 
 JSON mode activates when ALPHA_ENGINE_JSON_LOGS=1 (set on EC2 via systemd env).
 Text mode (default) preserves the current human-readable format for local dev.
+
+Flow Doctor integration: attaches an error-monitoring handler that captures
+ERROR+ log records, deduplicates, diagnoses via LLM, and creates GitHub issues.
+Enabled when FLOW_DOCTOR_ENABLED=1 (default on EC2).
 """
 
 from __future__ import annotations
@@ -32,12 +36,38 @@ class JSONFormatter(logging.Formatter):
         return json.dumps(log_entry, default=str)
 
 
+def _attach_flow_doctor(name: str) -> None:
+    """Attach flow-doctor handler to root logger (ERROR+ only)."""
+    try:
+        import flow_doctor
+
+        fd = flow_doctor.init(
+            flow_name=f"alpha-engine-executor-{name}",
+            repo="cipher813/alpha-engine",
+            owner="@cipher813",
+            store={"type": "sqlite", "path": "flow_doctor.db"},
+            diagnosis={"enabled": True, "model": "claude-haiku-4-5-20251001"},
+            notify=[{"type": "github", "repo": "cipher813/alpha-engine"}],
+            rate_limits={
+                "max_diagnosed_per_day": 5,
+                "max_issues_per_day": 3,
+                "dedup_cooldown_minutes": 120,
+            },
+        )
+        handler = flow_doctor.FlowDoctorHandler(fd, level=logging.ERROR)
+        logging.getLogger().addHandler(handler)
+    except Exception:
+        # flow-doctor is non-critical — never block executor startup
+        logging.getLogger(__name__).debug("flow-doctor not available, skipping")
+
+
 def setup_logging(name: str = "executor") -> None:
     """
     Configure root logger.
 
     JSON mode: ALPHA_ENGINE_JSON_LOGS=1 (for EC2 / production)
     Text mode: default (for local dev / dry-run)
+    Flow Doctor: FLOW_DOCTOR_ENABLED=1 (for EC2 / production)
     """
     json_mode = os.environ.get("ALPHA_ENGINE_JSON_LOGS", "0") == "1"
 
@@ -53,3 +83,6 @@ def setup_logging(name: str = "executor") -> None:
     root.handlers.clear()
     root.addHandler(handler)
     root.setLevel(logging.INFO)
+
+    if os.environ.get("FLOW_DOCTOR_ENABLED", "0") == "1":
+        _attach_flow_doctor(name)

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,126 @@
+"""Tests for log_config — structured logging + flow-doctor integration."""
+
+import logging
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from executor.log_config import setup_logging, _attach_flow_doctor, JSONFormatter
+
+
+class TestSetupLogging:
+    def test_text_mode_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ALPHA_ENGINE_JSON_LOGS", None)
+            os.environ.pop("FLOW_DOCTOR_ENABLED", None)
+            setup_logging("test")
+            root = logging.getLogger()
+            assert len(root.handlers) == 1
+            assert root.level == logging.INFO
+
+    def test_json_mode(self):
+        with patch.dict(os.environ, {"ALPHA_ENGINE_JSON_LOGS": "1"}):
+            os.environ.pop("FLOW_DOCTOR_ENABLED", None)
+            setup_logging("test")
+            root = logging.getLogger()
+            assert isinstance(root.handlers[0].formatter, JSONFormatter)
+
+    def test_text_format_includes_name(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ALPHA_ENGINE_JSON_LOGS", None)
+            os.environ.pop("FLOW_DOCTOR_ENABLED", None)
+            setup_logging("daemon")
+            fmt = root = logging.getLogger().handlers[0].formatter._fmt
+            assert "[daemon]" in fmt
+
+    def test_clears_existing_handlers(self):
+        root = logging.getLogger()
+        root.addHandler(logging.StreamHandler())
+        root.addHandler(logging.StreamHandler())
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FLOW_DOCTOR_ENABLED", None)
+            setup_logging("test")
+        assert len(root.handlers) == 1
+
+
+class TestFlowDoctorIntegration:
+    def test_not_attached_when_disabled(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("FLOW_DOCTOR_ENABLED", None)
+            setup_logging("test")
+            root = logging.getLogger()
+            assert len(root.handlers) == 1  # only StreamHandler
+
+    def test_attached_when_enabled(self):
+        mock_fd = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.ERROR
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch.dict("sys.modules", {"flow_doctor": MagicMock()}) as _:
+                import sys
+                mock_module = sys.modules["flow_doctor"]
+                mock_module.init.return_value = mock_fd
+                mock_module.FlowDoctorHandler.return_value = mock_handler
+                setup_logging("main")
+                mock_module.init.assert_called_once()
+                call_kwargs = mock_module.init.call_args[1]
+                assert call_kwargs["flow_name"] == "alpha-engine-executor-main"
+                assert call_kwargs["repo"] == "cipher813/alpha-engine"
+
+    def test_graceful_when_import_fails(self):
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch("builtins.__import__", side_effect=ImportError("no flow_doctor")):
+                # Should not raise — flow-doctor is non-critical
+                setup_logging("test")
+                root = logging.getLogger()
+                assert len(root.handlers) == 1
+
+    def test_graceful_when_init_fails(self):
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch.dict("sys.modules", {"flow_doctor": MagicMock()}) as _:
+                import sys
+                mock_module = sys.modules["flow_doctor"]
+                mock_module.init.side_effect = RuntimeError("config error")
+                setup_logging("test")
+                root = logging.getLogger()
+                assert len(root.handlers) == 1  # only StreamHandler, no flow-doctor
+
+
+class TestJSONFormatter:
+    def test_formats_basic_record(self):
+        import json
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.ERROR, pathname="test.py",
+            lineno=1, msg="something failed", args=(), exc_info=None,
+        )
+        result = json.loads(formatter.format(record))
+        assert result["level"] == "ERROR"
+        assert result["msg"] == "something failed"
+        assert "ts" in result
+
+    def test_includes_exception(self):
+        import json
+        formatter = JSONFormatter()
+        try:
+            raise ValueError("test error")
+        except ValueError:
+            import sys
+            record = logging.LogRecord(
+                name="test", level=logging.ERROR, pathname="test.py",
+                lineno=1, msg="failed", args=(), exc_info=sys.exc_info(),
+            )
+        result = json.loads(formatter.format(record))
+        assert "ValueError" in result["exc"]
+
+    def test_includes_ctx(self):
+        import json
+        formatter = JSONFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="test.py",
+            lineno=1, msg="with context", args=(), exc_info=None,
+        )
+        record.ctx = {"ticker": "AAPL", "action": "ENTER"}
+        result = json.loads(formatter.format(record))
+        assert result["ctx"]["ticker"] == "AAPL"


### PR DESCRIPTION
## Summary
- Wire flow-doctor handler into `setup_logging()` in `log_config.py`
- All 3 automated entry points (main, daemon, eod_reconcile) get ERROR+ log capture
- Gated behind `FLOW_DOCTOR_ENABLED=1` env var (set on EC2 via systemd)
- Non-critical — gracefully degrades if flow-doctor is unavailable

## How it works
- `setup_logging()` is called by all automated entry points
- When `FLOW_DOCTOR_ENABLED=1`, attaches a `FlowDoctorHandler` to the root logger
- ERROR+ logs are captured, deduplicated (2hr cooldown), diagnosed via Haiku, and filed as GitHub issues
- Rate limited: 5 diagnoses/day, 3 issues/day

## Config
- Uses Haiku for cheap diagnosis (~$0.01/diagnosis)
- GitHub issues filed to cipher813/alpha-engine
- SQLite store at `flow_doctor.db` (on EC2, lives alongside trades.db)

## EC2 activation
Add to systemd env files:
```
Environment=FLOW_DOCTOR_ENABLED=1
```

## Test plan
- [x] 225 tests pass (214 existing + 11 new)
- [x] Flow-doctor handler attached when enabled
- [x] Graceful degradation when import fails
- [x] Graceful degradation when init fails
- [x] JSON formatter tests (basic, exception, ctx)
- [x] Dry-run gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)