### PR TITLE
Fix flow-doctor import — module-level, not try/except

### DIFF
--- a/executor/log_config.py
+++ b/executor/log_config.py
@@ -16,6 +16,8 @@ import logging
 import os
 from datetime import datetime, timezone
 
+import flow_doctor
+
 
 class JSONFormatter(logging.Formatter):
     """Emit log records as single-line JSON objects."""
@@ -38,27 +40,21 @@ class JSONFormatter(logging.Formatter):
 
 def _attach_flow_doctor(name: str) -> None:
     """Attach flow-doctor handler to root logger (ERROR+ only)."""
-    try:
-        import flow_doctor
-
-        fd = flow_doctor.init(
-            flow_name=f"alpha-engine-executor-{name}",
-            repo="cipher813/alpha-engine",
-            owner="@cipher813",
-            store={"type": "sqlite", "path": "flow_doctor.db"},
-            diagnosis={"enabled": True, "model": "claude-haiku-4-5-20251001"},
-            notify=[{"type": "github", "repo": "cipher813/alpha-engine"}],
-            rate_limits={
-                "max_diagnosed_per_day": 5,
-                "max_issues_per_day": 3,
-                "dedup_cooldown_minutes": 120,
-            },
-        )
-        handler = flow_doctor.FlowDoctorHandler(fd, level=logging.ERROR)
-        logging.getLogger().addHandler(handler)
-    except Exception:
-        # flow-doctor is non-critical — never block executor startup
-        logging.getLogger(__name__).debug("flow-doctor not available, skipping")
+    fd = flow_doctor.init(
+        flow_name=f"alpha-engine-executor-{name}",
+        repo="cipher813/alpha-engine",
+        owner="@cipher813",
+        store={"type": "sqlite", "path": "flow_doctor.db"},
+        diagnosis={"enabled": True, "model": "claude-haiku-4-5-20251001"},
+        notify=[{"type": "github", "repo": "cipher813/alpha-engine"}],
+        rate_limits={
+            "max_diagnosed_per_day": 5,
+            "max_issues_per_day": 3,
+            "dedup_cooldown_minutes": 120,
+        },
+    )
+    handler = flow_doctor.FlowDoctorHandler(fd, level=logging.ERROR)
+    logging.getLogger().addHandler(handler)
 
 
 def setup_logging(name: str = "executor") -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyarrow~=14.0
 anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32
+flow-doctor[diagnosis]~=0.1.0

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -57,9 +57,7 @@ class TestFlowDoctorIntegration:
         mock_handler = MagicMock(spec=logging.Handler)
         mock_handler.level = logging.ERROR
         with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
-            with patch.dict("sys.modules", {"flow_doctor": MagicMock()}) as _:
-                import sys
-                mock_module = sys.modules["flow_doctor"]
+            with patch("executor.log_config.flow_doctor") as mock_module:
                 mock_module.init.return_value = mock_fd
                 mock_module.FlowDoctorHandler.return_value = mock_handler
                 setup_logging("main")
@@ -68,23 +66,13 @@ class TestFlowDoctorIntegration:
                 assert call_kwargs["flow_name"] == "alpha-engine-executor-main"
                 assert call_kwargs["repo"] == "cipher813/alpha-engine"
 
-    def test_graceful_when_import_fails(self):
+    def test_init_failure_raises(self):
+        """flow-doctor is a hard dep — init failures should propagate."""
         with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
-            with patch("builtins.__import__", side_effect=ImportError("no flow_doctor")):
-                # Should not raise — flow-doctor is non-critical
-                setup_logging("test")
-                root = logging.getLogger()
-                assert len(root.handlers) == 1
-
-    def test_graceful_when_init_fails(self):
-        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
-            with patch.dict("sys.modules", {"flow_doctor": MagicMock()}) as _:
-                import sys
-                mock_module = sys.modules["flow_doctor"]
+            with patch("executor.log_config.flow_doctor") as mock_module:
                 mock_module.init.side_effect = RuntimeError("config error")
-                setup_logging("test")
-                root = logging.getLogger()
-                assert len(root.handlers) == 1  # only StreamHandler, no flow-doctor
+                with pytest.raises(RuntimeError, match="config error"):
+                    setup_logging("test")
 
 
 class TestJSONFormatter:


### PR DESCRIPTION
## Summary
- Move `import flow_doctor` to module level instead of inside try/except
- flow-doctor is a hard dependency in requirements.txt — import failures mean a broken deployment, not something to silently skip
- Init failures now propagate instead of being swallowed

## Test plan
- [x] 224 tests pass
- [x] Dry-run gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)