### PR TITLE
Upgrade flow-doctor to 0.2.0 and fix signal staleness window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 config/risk.yaml
 config/.executor_params_cache.json
 infrastructure/ec2.env
-flow-doctor.yaml
+# flow-doctor.yaml was previously gitignored because it held inline credentials.
+# As of flow-doctor 0.2.0 + FLOW_DOCTOR_* env var contract, all secrets come from
+# the environment and the YAML contains only ${VAR} references — safe to commit.
 
 # Python
 __pycache__/

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -33,12 +33,22 @@ def read_signals(s3_bucket: str, run_date: str | None = None) -> dict:
     return data
 
 
-def read_signals_with_fallback(s3_bucket: str, run_date: str | None = None, max_lookback: int = 5) -> dict:
+def read_signals_with_fallback(s3_bucket: str, run_date: str | None = None, max_lookback: int = 14) -> dict:
     """
     Read the latest signals from S3.
 
     Tries signals/latest.json first (written by Research alongside the dated file).
     Falls back to date-scanning if the pointer doesn't exist.
+
+    The default max_lookback of 14 days covers the Research pipeline's weekly
+    cadence (Saturday 00:00 UTC) plus a one-week buffer for a missed Saturday
+    run. Shorter windows are fragile: by Friday of any given week, the most
+    recent Saturday signals file is already 6 days old, and a 5-day window
+    would fail even on a normal week.
+
+    A staleness WARNING is logged when the signals being returned are more
+    than 7 calendar days old, so a quietly-missed Saturday run becomes visible
+    in the executor's log stream even if the signals still load successfully.
 
     Returns the signals dict. Raises RuntimeError if nothing found.
     """
@@ -52,6 +62,7 @@ def read_signals_with_fallback(s3_bucket: str, run_date: str | None = None, max_
             f"Signals loaded from signals/latest.json | date={data.get('date')} "
             f"| universe={len(data.get('universe', []))}"
         )
+        _warn_if_stale(data.get("date"), run_date)
         return data
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
@@ -68,8 +79,13 @@ def read_signals_with_fallback(s3_bucket: str, run_date: str | None = None, max_
         try:
             signals = read_signals(s3_bucket, str(candidate))
             if days_back > 0:
-                logger.warning(
+                log_fn = logger.warning if days_back > 7 else logger.info
+                log_fn(
                     f"No signals for {start} — using {candidate} "
+                    f"({days_back} calendar day(s) old). Dates tried: {tried}. "
+                    f"Research pipeline may have missed a weekly run."
+                    if days_back > 7
+                    else f"No signals for {start} — using {candidate} "
                     f"({days_back} calendar day(s) old). Dates tried: {tried}"
                 )
             return signals
@@ -84,6 +100,27 @@ def read_signals_with_fallback(s3_bucket: str, run_date: str | None = None, max_
         f"No signals found within {max_lookback} calendar days of {start}. "
         f"Dates tried: {tried}. Check that the research pipeline ran recently."
     )
+
+
+def _warn_if_stale(signals_date: str | None, run_date: str | None) -> None:
+    """Log a WARNING if the loaded signals are more than 7 days old relative to run_date.
+
+    Staleness >7 days means the Research pipeline likely missed its Saturday
+    run — the signals will still work, but something upstream needs investigation.
+    """
+    if not signals_date:
+        return
+    try:
+        sig = date.fromisoformat(signals_date)
+    except (ValueError, TypeError):
+        return
+    ref = date.fromisoformat(run_date) if run_date else date.today()
+    age = (ref - sig).days
+    if age > 7:
+        logger.warning(
+            f"Loaded signals are {age} calendar days old (signals_date={sig}, "
+            f"run_date={ref}). Research pipeline may have missed a weekly run."
+        )
 
 
 def get_actionable_signals(signals: dict) -> dict:

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -1,0 +1,24 @@
+flow_name: executor
+repo: cipher813/alpha-engine
+owner: "@brianmcmahon"
+notify:
+  - type: email
+    sender: ${EMAIL_SENDER}
+    recipients: ${EMAIL_RECIPIENTS}
+    smtp_host: smtp.gmail.com
+    smtp_port: 587
+    smtp_password: ${GMAIL_APP_PASSWORD}
+  - type: github
+    repo: cipher813/alpha-engine
+    token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+store:
+  type: sqlite
+  path: /tmp/flow_doctor.db
+dedup_cooldown_minutes: 60
+dependencies:
+  - predictor-inference
+  - data-phase1
+rate_limits:
+  max_alerts_per_day: 10
+  max_issues_per_day: 3
+  max_diagnosed_per_day: 3

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyarrow~=14.0
 anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32
-flow-doctor[diagnosis]~=0.1.0
+flow-doctor[diagnosis]>=0.2.0,<0.3.0


### PR DESCRIPTION
## Summary

Consumes the fail-loud contract shipped in flow-doctor 0.2.0 and fixes the max_lookback issue that caused today's (2026-04-10) executor crash when the Saturday 04-04 research signals fell outside the 5-day window.

## Changes

- **`requirements.txt`**: pin `flow-doctor[diagnosis]>=0.2.0,<0.3.0`. Pulls in the fail-loud refactor, `FLOW_DOCTOR_*` env var contract, `ConfigError`, and notifier send-failure logging.

- **`flow-doctor.yaml`**: add `token: \${FLOW_DOCTOR_GITHUB_TOKEN}` on the github notifier. Previously missing, which (1) would have silently dropped the notifier in 0.1.0 (this is the root cause of why no GitHub issue was filed for today's incident), (2) now raises `ConfigError` at startup in 0.2.0 if the env var is not set. The token is supplied at runtime via the alpha-engine-data `.env` file pushed by `push-secrets.sh` to ae-trading.

- **`.gitignore`**: unignore `flow-doctor.yaml`. It was previously ignored because earlier revisions embedded secrets directly. With the `FLOW_DOCTOR_*` env var contract, all credentials come from the environment and the YAML contains only \`\${VAR}\` references — safe to commit to a public repo.

- **`executor/signal_reader.py`**: bump \`max_lookback\` from 5 to 14 calendar days + add staleness WARNING log at >7 days.

## Why the max_lookback bump matters

Research runs weekly on Saturday 00:00 UTC (Friday 5 PM PT) and writes \`signals/{YYYY-MM-DD}/signals.json\`. By the following Friday, the newest signals file is already **6 days old** — outside the previous 5-day window. This was a latent bug that would have failed on any normal Friday after a Saturday run, and did fail today.

- **New floor: 14 days.** Covers one full normal week (6 days) plus a missed Saturday run (7–13 days) with buffer.
- **New staleness warning at >7 days.** If signals older than a week are being used, the log stream now surfaces a WARNING saying "Research pipeline may have missed a weekly run." This turns a quietly-missed Saturday run into a visible alert instead of a silent success.

## Why the flow-doctor.yaml change matters

The root cause of today's incident: flow-doctor's GitHub notifier was configured without a token, and flow-doctor 0.1.0 silently dropped misconfigured notifiers. Flow-doctor 0.2.0 fixes this by raising \`ConfigError\` — but the YAML still needs to reference the env var. With this PR:

1. Token in yaml as \`\${FLOW_DOCTOR_GITHUB_TOKEN}\`
2. Env var supplied by \`.env\` on EC2 via systemd \`EnvironmentFile=\`
3. flow-doctor resolves \`\${VAR}\` at load time; if the env var is missing, raises \`ConfigError\` loudly at startup

So the next executor boot will either:
- **Work** (if \`FLOW_DOCTOR_GITHUB_TOKEN\` is in env) and successfully file GitHub issues on errors, OR
- **Fail loud** at startup with a clear \`ConfigError\` message naming the missing var — no more silent GitHub-notifier drops

## Deferred to follow-up

The executor has **four** separate \`flow_doctor.init()\` call sites (log_config.py, main.py, daemon.py, eod_reconcile.py) — four independent FlowDoctor instances with separate SQLite stores, rate limiters, and dedup states. This is architecturally bad but not blocking Monday's trading run. Tracked as a follow-up task; will be consolidated into a single shared instance in a separate PR.

## Test plan

- [x] Unit tests: 224 passing (214 existing + 10 log_config tests, no changes needed)
- [x] Staleness warning fires at 10 days old, silent at 6 days, no crash on malformed/None dates (sanity-checked locally)
- [ ] On ae-trading Monday boot: verify flow_doctor.init() succeeds with the new token reference
- [ ] On ae-trading Monday boot: verify signal_reader loads the Saturday 04-11 research signals successfully
- [ ] If the Saturday 04-11 pipeline doesn't run or fails, verify max_lookback=14 finds signals from 04-04 or earlier instead of crashing

## Related

- flow-doctor PR #6 (merged) — the fail-loud refactor
- flow-doctor PR #7 (merged) — pyproject.toml version bump
- flow-doctor 0.2.0 — published to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)