### PR TITLE
Consolidate flow-doctor singleton and raise on signal read failure

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -232,16 +232,9 @@ def run_daemon(dry_run: bool = False) -> None:
     config = load_config()
     strategy_config = load_strategy_config(config)
 
-    # Flow Doctor: structured error capture (optional, never blocks)
-    fd = None
-    try:
-        import flow_doctor
-        fd = flow_doctor.init(config_path=os.path.join(
-            os.path.dirname(os.path.dirname(__file__)), "flow-doctor.yaml"))
-    except ImportError:
-        pass
-    except Exception as e:
-        logger.warning("flow-doctor init failed: %s", e)
+    # Flow Doctor: retrieve the shared instance owned by log_config
+    from executor.log_config import get_flow_doctor
+    fd = get_flow_doctor()
 
     global _allow_shorts
     _allow_shorts = config.get("allow_shorts", False)

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -256,16 +256,9 @@ def run(run_date: str | None = None) -> None:
     db_path = config["db_path"]
     trades_bucket = config["trades_bucket"]
 
-    # Flow Doctor: structured error capture (optional, never blocks)
-    fd = None
-    try:
-        import flow_doctor
-        fd = flow_doctor.init(config_path=os.path.join(
-            os.path.dirname(os.path.dirname(__file__)), "flow-doctor.yaml"))
-    except ImportError:
-        pass
-    except Exception as e:
-        logger.warning("flow-doctor init failed: %s", e)
+    # Flow Doctor: retrieve the shared instance owned by log_config
+    from executor.log_config import get_flow_doctor
+    fd = get_flow_doctor()
 
     if not config.get("email_sender") or not config.get("email_recipients"):
         logger.warning(

--- a/executor/log_config.py
+++ b/executor/log_config.py
@@ -4,8 +4,12 @@ Structured logging configuration for the executor.
 JSON mode activates when ALPHA_ENGINE_JSON_LOGS=1 (set on EC2 via systemd env).
 Text mode (default) preserves the current human-readable format for local dev.
 
-Flow Doctor integration: attaches an error-monitoring handler that captures
-ERROR+ log records, deduplicates, diagnoses via LLM, and creates GitHub issues.
+Flow Doctor integration: owns the single shared FlowDoctor instance for the
+entire executor process. All call sites (main.py, daemon.py, eod_reconcile.py)
+should call ``get_flow_doctor()`` instead of calling ``flow_doctor.init()``
+themselves — running four independent FlowDoctor instances with separate
+SQLite stores, rate limiters, and dedup states is a footgun.
+
 Enabled when FLOW_DOCTOR_ENABLED=1 (default on EC2).
 """
 
@@ -15,8 +19,17 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
+from typing import Optional
 
 import flow_doctor
+
+_FLOW_DOCTOR_YAML_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "flow-doctor.yaml"
+)
+
+# Singleton — populated once by setup_logging() and retrieved by call sites
+# via get_flow_doctor(). None until setup_logging() runs with FLOW_DOCTOR_ENABLED=1.
+_fd_instance: Optional[flow_doctor.FlowDoctor] = None
 
 
 class JSONFormatter(logging.Formatter):
@@ -38,22 +51,21 @@ class JSONFormatter(logging.Formatter):
         return json.dumps(log_entry, default=str)
 
 
+def get_flow_doctor() -> Optional[flow_doctor.FlowDoctor]:
+    """Return the shared flow-doctor instance, or None if not initialized.
+
+    Call sites use this to access flow-doctor without creating duplicate
+    instances. Returns None if setup_logging() was never called with
+    FLOW_DOCTOR_ENABLED=1, or if flow-doctor init failed.
+    """
+    return _fd_instance
+
+
 def _attach_flow_doctor(name: str) -> None:
-    """Attach flow-doctor handler to root logger (ERROR+ only)."""
-    fd = flow_doctor.init(
-        flow_name=f"alpha-engine-executor-{name}",
-        repo="cipher813/alpha-engine",
-        owner="@cipher813",
-        store={"type": "sqlite", "path": "flow_doctor.db"},
-        diagnosis={"enabled": True, "model": "claude-haiku-4-5-20251001"},
-        notify=[{"type": "github", "repo": "cipher813/alpha-engine"}],
-        rate_limits={
-            "max_diagnosed_per_day": 5,
-            "max_issues_per_day": 3,
-            "dedup_cooldown_minutes": 120,
-        },
-    )
-    handler = flow_doctor.FlowDoctorHandler(fd, level=logging.ERROR)
+    """Initialize the shared flow-doctor instance and attach a log handler."""
+    global _fd_instance
+    _fd_instance = flow_doctor.init(config_path=_FLOW_DOCTOR_YAML_PATH)
+    handler = flow_doctor.FlowDoctorHandler(_fd_instance, level=logging.ERROR)
     logging.getLogger().addHandler(handler)
 
 

--- a/executor/main.py
+++ b/executor/main.py
@@ -886,17 +886,9 @@ def run(
     signals_bucket = config["signals_bucket"]
     trades_bucket = config["trades_bucket"]
 
-    # ── Flow Doctor: structured error capture (optional, never blocks) ───
-    fd = None
-    if not simulate:
-        try:
-            import flow_doctor
-            fd = flow_doctor.init(config_path=os.path.join(
-                os.path.dirname(os.path.dirname(__file__)), "flow-doctor.yaml"))
-        except ImportError:
-            pass
-        except Exception as e:
-            logger.warning("flow-doctor init failed: %s", e)
+    # ── Flow Doctor: retrieve the shared instance owned by log_config ───
+    from executor.log_config import get_flow_doctor
+    fd = get_flow_doctor() if not simulate else None
 
     # ── 0. Check upstream health (warn + Telegram alert, never blocks) ───
     if not simulate:
@@ -943,13 +935,16 @@ def run(
         signals_raw, signals, run_date, predictions_by_ticker = _read_signals(
             config, signals_bucket, run_date, simulate, signals_override, conn,
         )
-    except (RuntimeError, Exception) as _sig_err:
+    except Exception as _sig_err:
         if fd:
             fd.report(_sig_err, severity="error", context={
                 "site": "signal_read", "run_date": run_date})
         if conn:
             conn.close()
-        return
+        # Re-raise so systemd marks the service as 'failed' (not 'inactive (dead)').
+        # Returning silently hides signal-read failures from systemctl status, which
+        # is how today's (2026-04-10) incident went undetected for 3 hours.
+        raise
     market_regime = signals["market_regime"]
     sector_ratings = signals["sector_ratings"]
 

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,4 +1,4 @@
-"""Tests for log_config — structured logging + flow-doctor integration."""
+"""Tests for log_config — structured logging + flow-doctor singleton."""
 
 import logging
 import os
@@ -6,7 +6,20 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from executor.log_config import setup_logging, _attach_flow_doctor, JSONFormatter
+import executor.log_config as log_config
+from executor.log_config import (
+    JSONFormatter,
+    get_flow_doctor,
+    setup_logging,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    """Ensure the singleton is reset between tests."""
+    log_config._fd_instance = None
+    yield
+    log_config._fd_instance = None
 
 
 class TestSetupLogging:
@@ -31,7 +44,7 @@ class TestSetupLogging:
             os.environ.pop("ALPHA_ENGINE_JSON_LOGS", None)
             os.environ.pop("FLOW_DOCTOR_ENABLED", None)
             setup_logging("daemon")
-            fmt = root = logging.getLogger().handlers[0].formatter._fmt
+            fmt = logging.getLogger().handlers[0].formatter._fmt
             assert "[daemon]" in fmt
 
     def test_clears_existing_handlers(self):
@@ -44,15 +57,34 @@ class TestSetupLogging:
         assert len(root.handlers) == 1
 
 
-class TestFlowDoctorIntegration:
-    def test_not_attached_when_disabled(self):
+class TestFlowDoctorSingleton:
+    def test_get_flow_doctor_returns_none_when_disabled(self):
+        """get_flow_doctor() should return None if setup was not called with FD enabled."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("FLOW_DOCTOR_ENABLED", None)
             setup_logging("test")
-            root = logging.getLogger()
-            assert len(root.handlers) == 1  # only StreamHandler
+            assert get_flow_doctor() is None
 
-    def test_attached_when_enabled(self):
+    def test_get_flow_doctor_returns_instance_when_enabled(self):
+        """get_flow_doctor() should return the shared instance after setup."""
+        mock_fd = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.ERROR
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch("executor.log_config.flow_doctor") as mock_module:
+                mock_module.init.return_value = mock_fd
+                mock_module.FlowDoctorHandler.return_value = mock_handler
+                setup_logging("main")
+                assert get_flow_doctor() is mock_fd
+
+    def test_setup_loads_from_yaml_not_inline_kwargs(self):
+        """Shared instance must load from flow-doctor.yaml, never inline kwargs.
+
+        The pre-consolidation log_config.py built a second FlowDoctor instance
+        from hardcoded inline kwargs that silently diverged from the YAML used
+        by main.py / daemon.py / eod_reconcile.py. This test pins the new
+        behavior so the regression doesn't return.
+        """
         mock_fd = MagicMock()
         mock_handler = MagicMock(spec=logging.Handler)
         mock_handler.level = logging.ERROR
@@ -62,17 +94,35 @@ class TestFlowDoctorIntegration:
                 mock_module.FlowDoctorHandler.return_value = mock_handler
                 setup_logging("main")
                 mock_module.init.assert_called_once()
-                call_kwargs = mock_module.init.call_args[1]
-                assert call_kwargs["flow_name"] == "alpha-engine-executor-main"
-                assert call_kwargs["repo"] == "cipher813/alpha-engine"
+                call_args = mock_module.init.call_args
+                # Must be called with config_path, not inline kwargs like repo/notify
+                assert "config_path" in call_args.kwargs
+                assert call_args.kwargs["config_path"].endswith("flow-doctor.yaml")
+                # Must NOT be called with the old inline kwargs
+                assert "repo" not in call_args.kwargs
+                assert "notify" not in call_args.kwargs
 
-    def test_init_failure_raises(self):
-        """flow-doctor is a hard dep — init failures should propagate."""
+    def test_init_failure_propagates(self):
+        """flow-doctor is a hard dep — init failures should propagate, not be swallowed."""
         with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
             with patch("executor.log_config.flow_doctor") as mock_module:
                 mock_module.init.side_effect = RuntimeError("config error")
                 with pytest.raises(RuntimeError, match="config error"):
                     setup_logging("test")
+
+    def test_singleton_is_shared_across_call_sites(self):
+        """Multiple get_flow_doctor() calls should return the same instance."""
+        mock_fd = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.ERROR
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch("executor.log_config.flow_doctor") as mock_module:
+                mock_module.init.return_value = mock_fd
+                mock_module.FlowDoctorHandler.return_value = mock_handler
+                setup_logging("main")
+                assert get_flow_doctor() is get_flow_doctor()
+                # And flow_doctor.init was called exactly once
+                mock_module.init.assert_called_once()
 
 
 class TestJSONFormatter:


### PR DESCRIPTION
## Summary

Two related executor bugs surfaced during today's (2026-04-10) incident:

1. **Four duplicate FlowDoctor instances.** `log_config.py` built one from hardcoded inline kwargs (silently diverging from the YAML), and `main.py` / `daemon.py` / `eod_reconcile.py` each called `flow_doctor.init()` independently. Four SQLite stores, four rate limiters, four dedup states — all in one process.
2. **`main.py` swallowed signal-read failures.** The `except` block called `fd.report()` and `return`ed normally, so systemd saw `status=0/SUCCESS` and marked the service `inactive (dead)` instead of `failed`. Today's incident went undetected for 3 hours via `systemctl status` alone because of this.

## Changes

- `executor/log_config.py` — now owns the single shared `FlowDoctor` instance via a module-level `_fd_instance` and a `get_flow_doctor()` accessor. Initializes from `flow-doctor.yaml` (not inline kwargs) so all call sites see identical config. `FLOW_DOCTOR_ENABLED=1` still gates init.
- `executor/main.py` — replaces inline `flow_doctor.init()` with `get_flow_doctor()`. `raise`s signal-read exceptions after `fd.report()` so systemd sees a non-zero exit code.
- `executor/daemon.py`, `executor/eod_reconcile.py` — same consolidation: retrieve the singleton instead of creating their own.
- `tests/test_log_config.py` — new regression tests pin the consolidation: singleton must load from YAML (not inline kwargs), must return same instance on repeated calls, init failures must propagate.

## Test plan

- [x] 226 tests pass locally
- [x] Dry-run import verified: `get_flow_doctor()` returns `None` when `FLOW_DOCTOR_ENABLED=0`, returns the shared instance when enabled
- [ ] On ae-trading after deploy: `sudo systemctl restart alpha-engine-morning` should show `failed` state on signal-read errors (not `inactive (dead)`)
- [ ] Single `/tmp/flow_doctor.db` should accumulate reports from main.py + daemon.py + eod_reconcile.py after the next full boot cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)