### PR TITLE
Pin flow-doctor to 0.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ pyarrow~=14.0
 anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32
-flow-doctor[diagnosis]>=0.2.0,<0.3.0
+flow-doctor[diagnosis]>=0.3.0,<0.4.0


### PR DESCRIPTION
## Summary

Bumps the \`requirements.txt\` pin for flow-doctor from \`>=0.2.0,<0.3.0\` to \`>=0.3.0,<0.4.0\`.

flow-doctor 0.3.0 was published to PyPI 2026-04-10 with:

- **\`actions.target\` capture** — Notifier.send() now returns \`Optional[str]\`, and the dispatcher persists the target (GitHub issue URL, email recipients, Slack channel) in the actions table. Gives operators a direct link back to filed issues from the sqlite store. Breaking change to the Notifier subclass contract, but this repo doesn't subclass externally.
- **Conservative auto-fix defaults** — \`max_auto_remediations_per_day\` 5→2, \`fix_pr_min_confidence\` 0.8→0.85.
- **\`deny_repos\` field** — hard deny list for auto-fix. Not currently used here (the executor doesn't enable auto-fix) but will be relevant when we do.

## Impact on the executor right now

- **actions.target** starts getting populated with issue URLs on the next error-triggered flow-doctor report
- **Nothing else changes** at runtime until we enable auto-fix, at which point the new defaults and deny_repos become relevant

## Test plan

- [ ] CI passes (\`test\` required status check)
- [ ] After merge + deploy: ae-trading pip upgrade picks up 0.3.0
- [ ] Next error report filed by flow-doctor has a populated \`target\` column in the actions table

🤖 Generated with [Claude Code](https://claude.com/claude-code)