### PR TITLE
Hard-fail executor on upstream health, gate daemon on market open

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -383,6 +383,13 @@ def run_daemon(dry_run: bool = False) -> None:
     trades_executed = 0
     executed_tickers: set = set()  # tracks tickers already traded today
 
+    # Track whether we reached the live trading window so the finally block
+    # can decide whether it's safe to fire the EOD pipeline. Pre-market exits
+    # (shutdown signal, early crash, etc.) must NOT trigger EOD — market-close
+    # side-effects like stopping the trading EC2 instance would then run
+    # before the market ever opened. This flag is the single gate.
+    market_opened = False
+
     try:
         # ── Wait for market open (daemon may start before 9:30 AM ET) ────
         if not is_market_hours():
@@ -392,6 +399,11 @@ def run_daemon(dry_run: bool = False) -> None:
             if _shutdown_requested:
                 return
             logger.info("Market is open — proceeding")
+
+        # Guard: Phase 0 urgent exits + live IB order placement must only run
+        # once the market is actually open. Reaching this line means the
+        # wait-for-open loop above exited on is_market_hours() == True.
+        market_opened = True
 
         # ── Phase 0: Execute urgent exits/covers immediately (no trigger delay) ──
         # Fetch current positions once for short-sell prevention checks
@@ -675,9 +687,17 @@ def run_daemon(dry_run: bool = False) -> None:
         )
         logger.info("Daemon shutdown complete | trades=%d", trades_executed)
 
-        # Trigger EOD pipeline Step Function
-        if not dry_run:
+        # Trigger EOD pipeline Step Function — only if the daemon actually
+        # made it into the live trading window. Pre-market exits (shutdown
+        # signal, crash during setup, IB connection failure) must not fire
+        # EOD: it would stop the trading EC2 instance before the market
+        # opens and email a bogus EOD summary. 2026-04-13 regression.
+        if not dry_run and market_opened:
             _trigger_eod_pipeline(config, run_date)
+        elif not dry_run:
+            logger.warning(
+                "Skipping EOD pipeline trigger: daemon exited before market opened"
+            )
 
 
 def _trigger_eod_pipeline(config: dict, run_date: str) -> None:

--- a/executor/main.py
+++ b/executor/main.py
@@ -890,43 +890,70 @@ def run(
     from executor.log_config import get_flow_doctor
     fd = get_flow_doctor() if not simulate else None
 
-    # ── 0. Check upstream health (warn + Telegram alert, never blocks) ───
+    # ── 0. Check upstream health — hard-fail if anything upstream is broken ──
+    # Running on stale signals or a failed predictor produces a degraded
+    # portfolio that contradicts the system's design. Per the "hard-fail until
+    # stable" standard, any unknown/failed/stale upstream must abort executor
+    # BEFORE we read signals or touch the order book. The trading instance
+    # will remain idle for the day and be stopped at 13:30 PT as usual.
+    # Per-module staleness tolerance (hours):
+    #   research           — 192h (runs weekly Sat; grace covers Sat→next Fri)
+    #   predictor_inference — 26h (runs every weekday morning; catches a Mon
+    #                               miss without false-alarming on the weekend)
+    _UPSTREAM_MAX_AGE_H = {"research": 192, "predictor_inference": 26}
+
     if not simulate:
-        _health_warnings = []
+        _health_failures: list[str] = []
         try:
             from executor.health_status import check_upstream_health
+            # Pass the loosest module tolerance as the library default so
+            # check_upstream_health doesn't prematurely mark research stale;
+            # we re-check per-module against _UPSTREAM_MAX_AGE_H below.
             upstream = check_upstream_health(
                 signals_bucket,
-                ["research", "predictor_inference"],
-                max_age_hours=48,
+                list(_UPSTREAM_MAX_AGE_H),
+                max_age_hours=max(_UPSTREAM_MAX_AGE_H.values()),
             )
-            for mod, info in upstream.items():
-                if info["status"] == "unknown":
-                    _health_warnings.append(f"{mod}: no health data found")
-                    logger.warning("Upstream %s: no health data found", mod)
-                elif info["status"] == "failed":
-                    _health_warnings.append(f"{mod}: last run FAILED")
-                    logger.warning("Upstream %s last run FAILED", mod)
-                elif info["stale"]:
-                    max_hrs = 192 if mod == "research" else 48  # 8 days vs 2 days
-                    if info["age_hours"] > max_hrs:
-                        msg = f"{mod}: {info['age_hours']:.0f}h ({info['age_hours']/24:.1f}d) stale"
-                        _health_warnings.append(msg)
-                        logger.warning("Upstream %s", msg)
         except Exception as _ue:
-            logger.debug("Upstream health check failed (non-blocking): %s", _ue)
+            # A health-check read failure is itself a reason to hard-fail —
+            # we don't know the state of upstream, so we refuse to trade.
+            upstream = {}
+            _health_failures.append(f"health-check error: {_ue}")
 
-        if _health_warnings:
+        for mod, max_hrs in _UPSTREAM_MAX_AGE_H.items():
+            info = upstream.get(mod)
+            if info is None:
+                _health_failures.append(f"{mod}: no health data returned")
+                continue
+            if info["status"] == "unknown":
+                _health_failures.append(f"{mod}: no health data found")
+            elif info["status"] == "failed":
+                _health_failures.append(f"{mod}: last run FAILED")
+            elif info["age_hours"] is None or info["age_hours"] < 0:
+                _health_failures.append(f"{mod}: last_success missing")
+            elif info["age_hours"] > max_hrs:
+                _health_failures.append(
+                    f"{mod}: {info['age_hours']:.0f}h ({info['age_hours']/24:.1f}d) stale "
+                    f"(max {max_hrs}h)"
+                )
+
+        if _health_failures:
+            msg = (
+                "Upstream health FAILED — executor aborting:\n"
+                + "\n".join(f"  - {w}" for w in _health_failures)
+            )
+            logger.error(msg)
             try:
                 from executor.notifier import send_daemon_status
                 send_daemon_status(
-                    "\u26a0\ufe0f *Upstream health warning*\n"
+                    "\u274c *Upstream health FAILED*\n"
                     f"Date: {run_date}\n"
-                    + "\n".join(f"- {w}" for w in _health_warnings)
-                    + "\n\nExecutor proceeding — check research/predictor."
+                    + "\n".join(f"- {w}" for w in _health_failures)
+                    + "\n\nExecutor aborted — no order book written."
                 )
             except Exception:
-                logger.debug("Upstream health warning Telegram notification failed", exc_info=True)
+                logger.debug("Upstream failure Telegram notification failed", exc_info=True)
+            raise RuntimeError(msg)
 
     conn = None if simulate else init_db(db_path)
 


### PR DESCRIPTION
## Summary
- **Daemon pre-market guard:** add \`market_opened\` flag set only after the wait-for-open loop exits naturally. Phase 0 urgent-exit IB orders and the EOD Step Function trigger in \`finally\` are both gated on this flag. Pre-market shutdowns (shutdown signal, crash during setup, IB connect failure) now exit cleanly without touching the trading EC2 lifecycle.
- **Upstream health hard-fail:** replace the warn-and-proceed upstream check in \`executor/main.py\` with a \`RuntimeError\` raise. Any unknown / failed / stale \`research\` (>192h) or \`predictor_inference\` (>26h) health now aborts executor before signals are read.

## Root cause (2026-04-13)
Daemon started 06:14 PT with the market closed, fell through to \`finally\` which unconditionally fired the EOD Step Function — stopping the trading EC2 and emailing a bogus EOD summary at 06:18 PT, 72 minutes before market open. Separately, executor saw \`predictor-inference: 72h stale\` and proceeded anyway — exactly the degraded-state behavior the "hard-fail until stable" standard prohibits.

## Test plan
- [x] \`pytest tests/test_daemon_phase0.py\` (14 passed)
- [x] \`pytest tests/\` full suite (212 passed)
- [ ] After merge: pull on trading EC2, verify next pipeline either aborts cleanly on stale predictor or runs normally when fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)