### PR TITLE
Uptime tracking for reliability-phase homepage

### DIFF
--- a/executor/backfill_uptime.py
+++ b/executor/backfill_uptime.py
@@ -1,0 +1,160 @@
+"""
+Backfill uptime/{date}.json for historical trading days.
+
+DAEMON_TICK log lines are new as of today, so historical days have no
+minute-level ib_connected signal. This script uses systemd journal entries
+for alpha-engine-daemon.service as a proxy — any journal line during market
+hours counts the minute as active. connected_minutes is set equal to
+active_minutes (best-effort; cannot distinguish broker disconnects
+retroactively).
+
+Runs on ae-trading (requires journalctl access).
+
+Usage:
+  python executor/backfill_uptime.py --start 2026-03-15 --end 2026-04-12
+  python executor/backfill_uptime.py --start 2026-03-15 --end 2026-04-12 --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import subprocess
+from datetime import date, datetime, time, timedelta
+
+import pytz
+
+from executor import config_loader
+from executor.market_hours import is_trading_day
+from executor.uptime_tracker import _MARKET_MINUTES, write_to_s3
+
+logger = logging.getLogger(__name__)
+
+_ET = pytz.timezone("US/Eastern")
+_MARKET_OPEN = time(9, 30)
+_MARKET_CLOSE = time(16, 0)
+
+_JOURNAL_UNIT = "alpha-engine-daemon.service"
+
+
+def journal_timestamps(day: date) -> list[datetime]:
+    """Return UTC timestamps of all journal entries for the daemon service on `day` (ET)."""
+    start_et = _ET.localize(datetime.combine(day, time(0, 0)))
+    end_et = start_et + timedelta(days=1)
+    since_utc = start_et.astimezone(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
+    until_utc = end_et.astimezone(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+    cmd = [
+        "journalctl", "-u", _JOURNAL_UNIT,
+        "--since", since_utc, "--until", until_utc,
+        "--output", "short-iso-precise", "--no-pager", "--utc",
+    ]
+    try:
+        out = subprocess.check_output(cmd, text=True, timeout=60)
+    except FileNotFoundError:
+        logger.error("journalctl not on PATH — backfill only works on ae-trading")
+        return []
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning("journalctl failed for %s: %s", day, e)
+        return []
+
+    timestamps: list[datetime] = []
+    for line in out.splitlines():
+        parts = line.split(" ", 1)
+        if not parts:
+            continue
+        token = parts[0]
+        try:
+            ts = datetime.fromisoformat(token.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if ts.tzinfo is None:
+            ts = pytz.utc.localize(ts)
+        timestamps.append(ts)
+    return timestamps
+
+
+def compute_backfill_metrics(timestamps: list[datetime], day: date) -> dict:
+    """Approximate minute-level uptime from journal timestamps. No ib_connected signal."""
+    market_open_et = _ET.localize(datetime.combine(day, _MARKET_OPEN))
+    market_close_et = _ET.localize(datetime.combine(day, _MARKET_CLOSE))
+
+    minutes_active: set[int] = set()
+    for ts in timestamps:
+        ts_et = ts.astimezone(_ET)
+        if not (market_open_et <= ts_et < market_close_et):
+            continue
+        minutes_active.add(int((ts_et - market_open_et).total_seconds() // 60))
+
+    active = len(minutes_active)
+    return {
+        "date": day.isoformat(),
+        "active_minutes": active,
+        "connected_minutes": active,
+        "market_minutes": _MARKET_MINUTES,
+        "uptime_pct": round(active / _MARKET_MINUTES, 4) if _MARKET_MINUTES else 0.0,
+        "crashes": 0,
+        "tick_cadence_sec": 0,
+        "source": "journalctl_backfill",
+    }
+
+
+def backfill_range(start: date, end: date, bucket: str, force: bool = False) -> list[dict]:
+    """Backfill every trading day in [start, end] inclusive. Returns list of written metrics."""
+    import boto3
+
+    s3 = boto3.client("s3")
+    written: list[dict] = []
+    cur = start
+
+    while cur <= end:
+        if not is_trading_day(cur):
+            logger.debug("Skipping %s: non-trading day", cur)
+            cur += timedelta(days=1)
+            continue
+
+        key = f"uptime/{cur.isoformat()}.json"
+        if not force:
+            try:
+                s3.head_object(Bucket=bucket, Key=key)
+                logger.info("Skipping %s: %s already present", cur, key)
+                cur += timedelta(days=1)
+                continue
+            except s3.exceptions.ClientError:
+                pass
+
+        timestamps = journal_timestamps(cur)
+        metrics = compute_backfill_metrics(timestamps, cur)
+        write_to_s3(metrics, bucket, s3_client=s3)
+        written.append(metrics)
+        cur += timedelta(days=1)
+
+    return written
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Backfill historical uptime data from systemd journal")
+    p.add_argument("--start", required=True, help="Start date (YYYY-MM-DD, inclusive)")
+    p.add_argument("--end", required=True, help="End date (YYYY-MM-DD, inclusive)")
+    p.add_argument("--force", action="store_true", help="Overwrite existing uptime/*.json")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    config = config_loader.load_config()
+    bucket = config.get("trades_bucket", "alpha-engine-research")
+
+    start = date.fromisoformat(args.start)
+    end = date.fromisoformat(args.end)
+    if end < start:
+        raise SystemExit("--end must be >= --start")
+
+    written = backfill_range(start, end, bucket, force=args.force)
+    logger.info("Backfill complete: wrote %d day(s) to s3://%s/uptime/", len(written), bucket)
+
+
+if __name__ == "__main__":
+    main()

--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -568,6 +568,10 @@ def run_daemon(dry_run: bool = False) -> None:
             order_book = OrderBook.load()
             order_book.merge_executed(executed_tickers)
 
+            # Per-tick structured log line consumed by uptime_tracker.
+            # Format is stable — parsers match on the DAEMON_TICK prefix.
+            logger.info("DAEMON_TICK ib_connected=%s", str(ibkr.ib.isConnected()).lower())
+
             # ── Heartbeat ─────────────────────────────────────────────
             _elapsed = _time.time() - _last_heartbeat
             if _elapsed >= _HEARTBEAT_INTERVAL:

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -641,6 +641,21 @@ def run(run_date: str | None = None) -> None:
     except Exception as _me:
         logger.warning("Data manifest write failed: %s", _me)
 
+    # ── Uptime metrics ─────────────────────────────────────────────────────
+    try:
+        from executor import uptime_tracker
+        metrics = uptime_tracker.run(bucket=trades_bucket)
+        logger.info(
+            "Uptime: active=%d/%d connected=%d crashes=%d uptime=%.1f%%",
+            metrics.get("active_minutes", 0),
+            metrics.get("market_minutes", 0),
+            metrics.get("connected_minutes", 0),
+            metrics.get("crashes", 0),
+            metrics.get("uptime_pct", 0) * 100,
+        )
+    except Exception as _ue:
+        logger.warning("Uptime tracker failed: %s", _ue)
+
     if fd:
         fd.log_summary(logger)
     conn.close()

--- a/executor/uptime_tracker.py
+++ b/executor/uptime_tracker.py
@@ -1,0 +1,174 @@
+"""
+Uptime tracker — computes daemon uptime during NYSE regular-session hours.
+
+Data source: DAEMON_TICK lines emitted by executor/daemon.py each poll cycle.
+A minute is "up" when a tick fired within tolerance AND ib_connected=true.
+
+Writes uptime/{date}.json to S3:
+    {
+      "date": "2026-04-13",
+      "active_minutes": 312,        # daemon was running
+      "connected_minutes": 295,     # daemon running AND IB Gateway connected
+      "market_minutes": 390,        # 9:30-16:00 ET = 6.5h
+      "uptime_pct": 0.756,          # connected_minutes / market_minutes
+      "crashes": 2,                 # gaps > 2.5x tick cadence during market hours
+      "tick_cadence_sec": 60,
+      "source": "tick_log"
+    }
+
+Assumes log timestamps are UTC (EC2 default). Intended to run on ae-trading
+at 1:20 PM PT inside eod_reconcile.py, after the daemon has stopped.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from datetime import date, datetime, time
+from typing import Iterable
+
+import pytz
+
+from executor.market_hours import is_trading_day
+
+logger = logging.getLogger(__name__)
+
+_ET = pytz.timezone("US/Eastern")
+_MARKET_OPEN = time(9, 30)
+_MARKET_CLOSE = time(16, 0)
+_MARKET_MINUTES = 6 * 60 + 30  # 390
+
+_TICK_RE = re.compile(r"DAEMON_TICK\s+ib_connected=(true|false)")
+_TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})[,.]?\d*")
+
+_DEFAULT_LOG = "/var/log/executor.log"
+_DEFAULT_TICK_SEC = 60
+_GAP_TOLERANCE_MULT = 2.5
+
+
+def _parse_ts(line: str) -> datetime | None:
+    """Parse the leading UTC timestamp from a log line."""
+    m = _TS_RE.match(line)
+    if not m:
+        return None
+    try:
+        ts_naive = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+    return pytz.utc.localize(ts_naive)
+
+
+def parse_tick_lines(lines: Iterable[str], day: date) -> list[tuple[datetime, bool]]:
+    """Return (ts_et, ib_connected) tuples for DAEMON_TICK lines falling on `day` (ET)."""
+    ticks: list[tuple[datetime, bool]] = []
+    for line in lines:
+        if "DAEMON_TICK" not in line:
+            continue
+        m = _TICK_RE.search(line)
+        if not m:
+            continue
+        ts_utc = _parse_ts(line)
+        if ts_utc is None:
+            continue
+        ts_et = ts_utc.astimezone(_ET)
+        if ts_et.date() != day:
+            continue
+        ticks.append((ts_et, m.group(1) == "true"))
+    ticks.sort(key=lambda x: x[0])
+    return ticks
+
+
+def compute_metrics(
+    ticks: list[tuple[datetime, bool]],
+    day: date,
+    tick_cadence: int = _DEFAULT_TICK_SEC,
+    source: str = "tick_log",
+) -> dict:
+    """Intersect tick events with the market-hours window and compute metrics."""
+    market_open_et = _ET.localize(datetime.combine(day, _MARKET_OPEN))
+    market_close_et = _ET.localize(datetime.combine(day, _MARKET_CLOSE))
+
+    window = [(ts, c) for ts, c in ticks if market_open_et <= ts < market_close_et]
+
+    minutes_active: set[int] = set()
+    minutes_connected: set[int] = set()
+    for ts, connected in window:
+        minute = int((ts - market_open_et).total_seconds() // 60)
+        minutes_active.add(minute)
+        if connected:
+            minutes_connected.add(minute)
+
+    gap_tol_sec = tick_cadence * _GAP_TOLERANCE_MULT
+    crashes = 0
+    if window:
+        prev_ts = window[0][0]
+        for ts, _ in window[1:]:
+            if (ts - prev_ts).total_seconds() > gap_tol_sec:
+                crashes += 1
+            prev_ts = ts
+
+    connected_minutes = len(minutes_connected)
+    return {
+        "date": day.isoformat(),
+        "active_minutes": len(minutes_active),
+        "connected_minutes": connected_minutes,
+        "market_minutes": _MARKET_MINUTES,
+        "uptime_pct": round(connected_minutes / _MARKET_MINUTES, 4),
+        "crashes": crashes,
+        "tick_cadence_sec": tick_cadence,
+        "source": source,
+    }
+
+
+def collect_uptime(
+    day: date | None = None,
+    log_path: str = _DEFAULT_LOG,
+    tick_cadence: int = _DEFAULT_TICK_SEC,
+) -> dict:
+    """Parse the executor log for `day` and return uptime metrics. No S3 I/O."""
+    if day is None:
+        day = datetime.now(_ET).date()
+
+    if not is_trading_day(day):
+        return {"date": day.isoformat(), "skipped": "non_trading_day"}
+
+    if not os.path.exists(log_path):
+        logger.warning("uptime_tracker: log not found at %s", log_path)
+        return compute_metrics([], day, tick_cadence)
+
+    with open(log_path, "r", errors="replace") as f:
+        ticks = parse_tick_lines(f, day)
+
+    logger.info("uptime_tracker: parsed %d ticks for %s", len(ticks), day)
+    return compute_metrics(ticks, day, tick_cadence)
+
+
+def write_to_s3(metrics: dict, bucket: str, s3_client=None) -> str:
+    """Write uptime metrics to s3://{bucket}/uptime/{date}.json. Returns the key."""
+    import boto3
+
+    s3 = s3_client or boto3.client("s3")
+    key = f"uptime/{metrics['date']}.json"
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(metrics, indent=2).encode(),
+        ContentType="application/json",
+    )
+    logger.info(
+        "uptime_tracker: wrote s3://%s/%s (uptime=%.1f%%)",
+        bucket, key, metrics.get("uptime_pct", 0) * 100,
+    )
+    return key
+
+
+def run(bucket: str, day: date | None = None, log_path: str = _DEFAULT_LOG) -> dict:
+    """End-to-end: collect uptime and write to S3. Returns metrics dict."""
+    metrics = collect_uptime(day=day, log_path=log_path)
+    if metrics.get("skipped"):
+        logger.info("uptime_tracker: skipped %s (%s)", metrics["date"], metrics["skipped"])
+        return metrics
+    write_to_s3(metrics, bucket)
+    return metrics

--- a/tests/test_backfill_uptime.py
+++ b/tests/test_backfill_uptime.py
@@ -1,0 +1,43 @@
+"""Unit tests for executor/backfill_uptime.py."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import pytz
+
+from executor import backfill_uptime as bf
+
+
+_ET = pytz.timezone("US/Eastern")
+_UTC = pytz.utc
+
+
+def test_compute_backfill_metrics_buckets_to_market_minutes():
+    day = date(2026, 4, 13)
+    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    # 120 journal entries spaced 1 minute apart inside market hours
+    timestamps = [
+        (market_open_et + timedelta(minutes=i)).astimezone(_UTC) for i in range(120)
+    ]
+    m = bf.compute_backfill_metrics(timestamps, day)
+    assert m["active_minutes"] == 120
+    assert m["connected_minutes"] == 120  # best-effort equals active for backfill
+    assert m["source"] == "journalctl_backfill"
+    assert m["uptime_pct"] == round(120 / 390, 4)
+
+
+def test_compute_backfill_metrics_ignores_outside_window():
+    day = date(2026, 4, 13)
+    # Pre-market 08:00 ET and post-close 17:00 ET — both should be excluded
+    before = _ET.localize(datetime(2026, 4, 13, 8, 0)).astimezone(_UTC)
+    after = _ET.localize(datetime(2026, 4, 13, 17, 0)).astimezone(_UTC)
+    inside = _ET.localize(datetime(2026, 4, 13, 10, 0)).astimezone(_UTC)
+    m = bf.compute_backfill_metrics([before, after, inside], day)
+    assert m["active_minutes"] == 1
+
+
+def test_compute_backfill_metrics_empty_yields_zero():
+    m = bf.compute_backfill_metrics([], date(2026, 4, 13))
+    assert m["active_minutes"] == 0
+    assert m["uptime_pct"] == 0.0

--- a/tests/test_uptime_tracker.py
+++ b/tests/test_uptime_tracker.py
@@ -1,0 +1,124 @@
+"""Unit tests for executor/uptime_tracker.py."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+
+import pytz
+
+from executor import uptime_tracker as ut
+
+
+_ET = pytz.timezone("US/Eastern")
+_UTC = pytz.utc
+
+
+def _make_tick_line(ts_utc: datetime, connected: bool) -> str:
+    """Render a log line in the same format the executor writes."""
+    return (
+        f"{ts_utc.strftime('%Y-%m-%d %H:%M:%S')},000 "
+        f"INFO [executor] DAEMON_TICK ib_connected={'true' if connected else 'false'}\n"
+    )
+
+
+def test_parse_tick_lines_roundtrip():
+    day = date(2026, 4, 13)
+    # 9:30 AM ET = 13:30 UTC (during EDT). Use April → EDT offset of 4h.
+    t_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    t_utc = t_et.astimezone(_UTC)
+
+    line = _make_tick_line(t_utc, connected=True)
+    ticks = ut.parse_tick_lines([line, "some unrelated log\n"], day)
+
+    assert len(ticks) == 1
+    ts_et, connected = ticks[0]
+    assert ts_et.hour == 9 and ts_et.minute == 30
+    assert connected is True
+
+
+def test_parse_tick_lines_filters_wrong_day():
+    day = date(2026, 4, 13)
+    # Tick from the next day's morning
+    t_et = _ET.localize(datetime(2026, 4, 14, 9, 31))
+    t_utc = t_et.astimezone(_UTC)
+    line = _make_tick_line(t_utc, True)
+    assert ut.parse_tick_lines([line], day) == []
+
+
+def test_compute_metrics_full_connected_session():
+    """One tick per minute for the full 6.5 hour window, all connected."""
+    day = date(2026, 4, 13)
+    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    ticks = [
+        (market_open_et + timedelta(minutes=i), True) for i in range(390)
+    ]
+
+    m = ut.compute_metrics(ticks, day)
+    assert m["active_minutes"] == 390
+    assert m["connected_minutes"] == 390
+    assert m["market_minutes"] == 390
+    assert m["uptime_pct"] == 1.0
+    assert m["crashes"] == 0
+
+
+def test_compute_metrics_half_session_missing():
+    """Daemon runs first half, dies at 12:45 ET — ~195 minutes up then gap."""
+    day = date(2026, 4, 13)
+    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    ticks = [(market_open_et + timedelta(minutes=i), True) for i in range(195)]
+
+    m = ut.compute_metrics(ticks, day)
+    assert m["connected_minutes"] == 195
+    assert m["uptime_pct"] == round(195 / 390, 4)
+    # No crashes recorded because no trailing tick exists to compare against;
+    # mid-day silence is captured by the missing minutes, not the crash counter.
+    assert m["crashes"] == 0
+
+
+def test_compute_metrics_mid_session_crash():
+    """Ticks stop at minute 100, resume at minute 200 — counts as one crash."""
+    day = date(2026, 4, 13)
+    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    before = [(market_open_et + timedelta(minutes=i), True) for i in range(100)]
+    after = [(market_open_et + timedelta(minutes=i), True) for i in range(200, 390)]
+    ticks = before + after
+
+    m = ut.compute_metrics(ticks, day)
+    assert m["connected_minutes"] == len(before) + len(after)
+    assert m["crashes"] == 1
+
+
+def test_compute_metrics_ib_disconnected_drops_connected_not_active():
+    """Daemon up but IB disconnected — active_minutes counts, connected_minutes does not."""
+    day = date(2026, 4, 13)
+    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
+    ticks = [
+        (market_open_et + timedelta(minutes=i), i >= 100) for i in range(390)
+    ]
+
+    m = ut.compute_metrics(ticks, day)
+    assert m["active_minutes"] == 390
+    assert m["connected_minutes"] == 290
+    assert m["uptime_pct"] == round(290 / 390, 4)
+
+
+def test_compute_metrics_empty_yields_zero():
+    day = date(2026, 4, 13)
+    m = ut.compute_metrics([], day)
+    assert m["active_minutes"] == 0
+    assert m["connected_minutes"] == 0
+    assert m["uptime_pct"] == 0.0
+    assert m["crashes"] == 0
+
+
+def test_collect_uptime_skips_non_trading_day():
+    # 2026-04-11 is a Saturday
+    m = ut.collect_uptime(day=date(2026, 4, 11), log_path="/nonexistent")
+    assert m.get("skipped") == "non_trading_day"
+
+
+def test_collect_uptime_missing_log_returns_zero_record(tmp_path):
+    m = ut.collect_uptime(day=date(2026, 4, 13), log_path=str(tmp_path / "nope.log"))
+    assert m["date"] == "2026-04-13"
+    assert m["connected_minutes"] == 0
+    assert m["uptime_pct"] == 0.0


### PR DESCRIPTION
## Summary
- Adds per-tick DAEMON_TICK log line to daemon for minute-level uptime resolution
- New executor/uptime_tracker.py parses DAEMON_TICK lines, intersects with NYSE 9:30-16:00 ET, writes uptime/{date}.json to S3
- Wired into eod_reconcile.py (runs 1:20 PM PT after daemon stops)
- backfill_uptime.py script for historical days using journalctl (approximate, no ib_connected)

## Context
Companion to dashboard PR — nousergon.ai needs an uptime KPI for the reliability-hardening phase framing so recruiters understand alpha is secondary until uptime ≥99%.

## Test plan
- [x] 238 tests pass (12 new: uptime_tracker + backfill_uptime)
- [ ] Verify first real uptime/{date}.json lands in S3 after tomorrow's EOD
- [ ] Run backfill for last 3 weeks once deployed to ae-trading

🤖 Generated with [Claude Code](https://claude.com/claude-code)