### PR TITLE
Cut over systemd units from .env to SSM

### DIFF
--- a/infrastructure/systemd/alpha-engine-daemon.service
+++ b/infrastructure/systemd/alpha-engine-daemon.service
@@ -7,7 +7,6 @@ Requires=ibgateway.service
 Type=simple
 User=ec2-user
 WorkingDirectory=/home/ec2-user/alpha-engine
-EnvironmentFile=/home/ec2-user/.alpha-engine.env
 ExecStartPre=/home/ec2-user/alpha-engine/infrastructure/wait-for-ibgateway.sh
 ExecStart=/home/ec2-user/alpha-engine/.venv/bin/python -m executor.daemon
 ExecStartPost=/bin/bash /home/ec2-user/alpha-engine/infrastructure/emit-heartbeat.sh executor-daemon-start
@@ -18,6 +17,9 @@ RestartSec=30
 StandardOutput=append:/var/log/daemon.log
 StandardError=append:/var/log/daemon.log
 Environment=PYTHONPATH=/home/ec2-user/alpha-engine
+Environment=AWS_REGION=us-east-1
+Environment=ALPHA_ENGINE_JSON_LOGS=1
+Environment=FLOW_DOCTOR_ENABLED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/infrastructure/systemd/alpha-engine-eod.service
+++ b/infrastructure/systemd/alpha-engine-eod.service
@@ -7,9 +7,11 @@ Requires=ibgateway.service
 Type=oneshot
 User=ec2-user
 WorkingDirectory=/home/ec2-user/alpha-engine
-EnvironmentFile=/home/ec2-user/.alpha-engine.env
 ExecStart=/home/ec2-user/alpha-engine/.venv/bin/python executor/eod_reconcile.py
 ExecStartPost=/bin/bash /home/ec2-user/alpha-engine/infrastructure/emit-heartbeat.sh executor-eod
 StandardOutput=append:/var/log/eod.log
 StandardError=append:/var/log/eod.log
 Environment=PYTHONPATH=/home/ec2-user/alpha-engine
+Environment=AWS_REGION=us-east-1
+Environment=ALPHA_ENGINE_JSON_LOGS=1
+Environment=FLOW_DOCTOR_ENABLED=1

--- a/infrastructure/systemd/alpha-engine-morning.service
+++ b/infrastructure/systemd/alpha-engine-morning.service
@@ -7,7 +7,6 @@ Requires=ibgateway.service
 Type=oneshot
 User=ec2-user
 WorkingDirectory=/home/ec2-user/alpha-engine
-EnvironmentFile=/home/ec2-user/.alpha-engine.env
 # Give IB Gateway 30s to authenticate via TOTP and become ready
 ExecStartPre=/home/ec2-user/alpha-engine/infrastructure/wait-for-ibgateway.sh
 ExecStart=/home/ec2-user/alpha-engine/.venv/bin/python executor/main.py
@@ -15,6 +14,9 @@ ExecStartPost=/bin/bash /home/ec2-user/alpha-engine/infrastructure/emit-heartbea
 StandardOutput=append:/var/log/executor.log
 StandardError=append:/var/log/executor.log
 Environment=PYTHONPATH=/home/ec2-user/alpha-engine
+Environment=AWS_REGION=us-east-1
+Environment=ALPHA_ENGINE_JSON_LOGS=1
+Environment=FLOW_DOCTOR_ENABLED=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Drop \`EnvironmentFile=/home/ec2-user/.alpha-engine.env\` from daemon/eod/morning systemd units
- Add \`Environment=\` directives for non-secret flags: AWS_REGION, ALPHA_ENGINE_JSON_LOGS=1, FLOW_DOCTOR_ENABLED=1
- Secrets now come exclusively from SSM via \`ssm_secrets.load_secrets()\` which each entry point already calls

## Depends on
- Companion PRs in backtester, predictor, dashboard repos (\`load_secrets()\` adds)
- \`/alpha-engine/FLOW_DOCTOR_GITHUB_TOKEN\` seeded in SSM
- Land this PR **last** — it's the one that actually removes the .env dependency

## Post-merge deploy
\`\`\`
ae \"sudo systemctl daemon-reload && sudo rm /home/ec2-user/.alpha-engine.env && sudo systemctl restart alpha-engine-daemon\"
\`\`\`

## Test plan
- [x] 238 tests pass locally
- [ ] Verify daemon starts cleanly on ae-trading after .env removal
- [ ] Check \`os.environ[\"GMAIL_APP_PASSWORD\"]\` populated via SSM in EOD email flow
- [ ] Confirm journal no longer shows \"Ignoring invalid environment assignment\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)