### PR TITLE
Rewrite backfill to use systemd intervals (fixes undercounting)

### DIFF
--- a/executor/backfill_uptime.py
+++ b/executor/backfill_uptime.py
@@ -2,11 +2,14 @@
 Backfill uptime/{date}.json for historical trading days.
 
 DAEMON_TICK log lines are new as of today, so historical days have no
-minute-level ib_connected signal. This script uses systemd journal entries
-for alpha-engine-daemon.service as a proxy — any journal line during market
-hours counts the minute as active. connected_minutes is set equal to
-active_minutes (best-effort; cannot distinguish broker disconnects
-retroactively).
+minute-level ib_connected signal. This script parses systemd start/stop
+events from the journal to reconstruct the intervals during which the
+daemon service was Active, then intersects those intervals with NYSE
+regular-session hours.
+
+connected_minutes is set equal to active_minutes (best-effort — cannot
+distinguish broker disconnects retroactively; Active periods with a dead
+IB socket count as connected).
 
 Runs on ae-trading (requires journalctl access).
 
@@ -18,7 +21,9 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
+import re
 import subprocess
 from datetime import date, datetime, time, timedelta
 
@@ -31,23 +36,42 @@ from executor.uptime_tracker import _MARKET_MINUTES, write_to_s3
 logger = logging.getLogger(__name__)
 
 _ET = pytz.timezone("US/Eastern")
+_UTC = pytz.utc
 _MARKET_OPEN = time(9, 30)
 _MARKET_CLOSE = time(16, 0)
 
 _JOURNAL_UNIT = "alpha-engine-daemon.service"
 
+# systemd emits these messages on unit state transitions. journalctl -u filters
+# to this unit so we don't need to re-check the unit name in the message.
+_START_RE = re.compile(r"Started .*alpha-engine-daemon")
+_STOP_RE = re.compile(
+    r"Stopped .*alpha-engine-daemon"
+    r"|Deactivated successfully"
+    r"|Main process exited"
+    r"|Failed with result"
+)
 
-def journal_timestamps(day: date) -> list[datetime]:
-    """Return UTC timestamps of all journal entries for the daemon service on `day` (ET)."""
+
+def journal_intervals(day: date) -> list[tuple[datetime, datetime]]:
+    """Return Active intervals (UTC) for the daemon service on `day` (ET).
+
+    Walks journalctl output in JSON format, pairs Start/Stop events into
+    [start, end] intervals. Handles two edge cases:
+      - Daemon already running at day start (stop appears before any start) →
+        interval opens at day start.
+      - Daemon still running at day end (start with no matching stop) →
+        interval closes at day end.
+    """
     start_et = _ET.localize(datetime.combine(day, time(0, 0)))
     end_et = start_et + timedelta(days=1)
-    since_utc = start_et.astimezone(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
-    until_utc = end_et.astimezone(pytz.utc).strftime("%Y-%m-%d %H:%M:%S")
+    since_utc = start_et.astimezone(_UTC).strftime("%Y-%m-%d %H:%M:%S")
+    until_utc = end_et.astimezone(_UTC).strftime("%Y-%m-%d %H:%M:%S")
 
     cmd = [
         "journalctl", "-u", _JOURNAL_UNIT,
         "--since", since_utc, "--until", until_utc,
-        "--output", "short-iso-precise", "--no-pager", "--utc",
+        "--output", "json", "--no-pager", "--utc",
     ]
     try:
         out = subprocess.check_output(cmd, text=True, timeout=60)
@@ -58,44 +82,84 @@ def journal_timestamps(day: date) -> list[datetime]:
         logger.warning("journalctl failed for %s: %s", day, e)
         return []
 
-    timestamps: list[datetime] = []
+    events: list[tuple[datetime, str]] = []
     for line in out.splitlines():
-        parts = line.split(" ", 1)
-        if not parts:
-            continue
-        token = parts[0]
         try:
-            ts = datetime.fromisoformat(token.replace("Z", "+00:00"))
-        except ValueError:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
             continue
-        if ts.tzinfo is None:
-            ts = pytz.utc.localize(ts)
-        timestamps.append(ts)
-    return timestamps
+        msg = entry.get("MESSAGE", "")
+        ts_raw = entry.get("__REALTIME_TIMESTAMP")
+        if not ts_raw:
+            continue
+        try:
+            ts = datetime.fromtimestamp(int(ts_raw) / 1_000_000, tz=_UTC)
+        except (ValueError, TypeError):
+            continue
+        if _START_RE.search(msg):
+            events.append((ts, "start"))
+        elif _STOP_RE.search(msg):
+            events.append((ts, "stop"))
+
+    events.sort(key=lambda x: x[0])
+
+    day_start_utc = start_et.astimezone(_UTC)
+    day_end_utc = end_et.astimezone(_UTC)
+    intervals: list[tuple[datetime, datetime]] = []
+    current_start: datetime | None = None
+
+    for ts, kind in events:
+        if kind == "start":
+            if current_start is None:
+                current_start = ts
+            # else: double-start (no stop between) — keep the earlier start
+        else:  # stop
+            if current_start is None:
+                # Daemon was already running at day start
+                intervals.append((day_start_utc, ts))
+            else:
+                # Only record if stop is after start (guards against clock skew)
+                if ts > current_start:
+                    intervals.append((current_start, ts))
+                current_start = None
+
+    # Unclosed interval: daemon still running at day end
+    if current_start is not None:
+        intervals.append((current_start, day_end_utc))
+
+    return intervals
 
 
-def compute_backfill_metrics(timestamps: list[datetime], day: date) -> dict:
-    """Approximate minute-level uptime from journal timestamps. No ib_connected signal."""
+def compute_backfill_metrics(
+    intervals: list[tuple[datetime, datetime]],
+    day: date,
+) -> dict:
+    """Sum the overlap between each interval and the market-hours window."""
     market_open_et = _ET.localize(datetime.combine(day, _MARKET_OPEN))
     market_close_et = _ET.localize(datetime.combine(day, _MARKET_CLOSE))
+    market_open_utc = market_open_et.astimezone(_UTC)
+    market_close_utc = market_close_et.astimezone(_UTC)
 
-    minutes_active: set[int] = set()
-    for ts in timestamps:
-        ts_et = ts.astimezone(_ET)
-        if not (market_open_et <= ts_et < market_close_et):
-            continue
-        minutes_active.add(int((ts_et - market_open_et).total_seconds() // 60))
+    total_seconds = 0.0
+    for interval_start, interval_end in intervals:
+        clipped_start = max(interval_start, market_open_utc)
+        clipped_end = min(interval_end, market_close_utc)
+        if clipped_end > clipped_start:
+            total_seconds += (clipped_end - clipped_start).total_seconds()
 
-    active = len(minutes_active)
+    active_minutes = int(total_seconds // 60)
+    # Each interval after the first implies a restart/crash between them.
+    crashes = max(0, len(intervals) - 1)
+
     return {
         "date": day.isoformat(),
-        "active_minutes": active,
-        "connected_minutes": active,
+        "active_minutes": active_minutes,
+        "connected_minutes": active_minutes,
         "market_minutes": _MARKET_MINUTES,
-        "uptime_pct": round(active / _MARKET_MINUTES, 4) if _MARKET_MINUTES else 0.0,
-        "crashes": 0,
+        "uptime_pct": round(active_minutes / _MARKET_MINUTES, 4) if _MARKET_MINUTES else 0.0,
+        "crashes": crashes,
         "tick_cadence_sec": 0,
-        "source": "journalctl_backfill",
+        "source": "journalctl_intervals",
     }
 
 
@@ -123,8 +187,8 @@ def backfill_range(start: date, end: date, bucket: str, force: bool = False) -> 
             except s3.exceptions.ClientError:
                 pass
 
-        timestamps = journal_timestamps(cur)
-        metrics = compute_backfill_metrics(timestamps, cur)
+        intervals = journal_intervals(cur)
+        metrics = compute_backfill_metrics(intervals, cur)
         write_to_s3(metrics, bucket, s3_client=s3)
         written.append(metrics)
         cur += timedelta(days=1)

--- a/tests/test_backfill_uptime.py
+++ b/tests/test_backfill_uptime.py
@@ -1,4 +1,4 @@
-"""Unit tests for executor/backfill_uptime.py."""
+"""Unit tests for executor/backfill_uptime.py interval-based computation."""
 
 from __future__ import annotations
 
@@ -13,31 +13,80 @@ _ET = pytz.timezone("US/Eastern")
 _UTC = pytz.utc
 
 
-def test_compute_backfill_metrics_buckets_to_market_minutes():
+def _et(y, m, d, H, M) -> datetime:
+    return _ET.localize(datetime(y, m, d, H, M)).astimezone(_UTC)
+
+
+def test_full_session_covered_by_single_interval():
+    """Daemon runs from 9:00 ET to 16:30 ET — full market window is covered."""
     day = date(2026, 4, 13)
-    market_open_et = _ET.localize(datetime(2026, 4, 13, 9, 30))
-    # 120 journal entries spaced 1 minute apart inside market hours
-    timestamps = [
-        (market_open_et + timedelta(minutes=i)).astimezone(_UTC) for i in range(120)
+    intervals = [(_et(2026, 4, 13, 9, 0), _et(2026, 4, 13, 16, 30))]
+
+    m = bf.compute_backfill_metrics(intervals, day)
+    assert m["active_minutes"] == 390
+    assert m["connected_minutes"] == 390
+    assert m["market_minutes"] == 390
+    assert m["uptime_pct"] == 1.0
+    assert m["crashes"] == 0
+    assert m["source"] == "journalctl_intervals"
+
+
+def test_interval_fully_outside_market_hours_ignored():
+    """Pre-market and post-close intervals contribute zero minutes."""
+    day = date(2026, 4, 13)
+    intervals = [
+        (_et(2026, 4, 13, 7, 0), _et(2026, 4, 13, 9, 0)),    # pre-market
+        (_et(2026, 4, 13, 17, 0), _et(2026, 4, 13, 18, 0)),  # post-close
     ]
-    m = bf.compute_backfill_metrics(timestamps, day)
-    assert m["active_minutes"] == 120
-    assert m["connected_minutes"] == 120  # best-effort equals active for backfill
-    assert m["source"] == "journalctl_backfill"
-    assert m["uptime_pct"] == round(120 / 390, 4)
-
-
-def test_compute_backfill_metrics_ignores_outside_window():
-    day = date(2026, 4, 13)
-    # Pre-market 08:00 ET and post-close 17:00 ET — both should be excluded
-    before = _ET.localize(datetime(2026, 4, 13, 8, 0)).astimezone(_UTC)
-    after = _ET.localize(datetime(2026, 4, 13, 17, 0)).astimezone(_UTC)
-    inside = _ET.localize(datetime(2026, 4, 13, 10, 0)).astimezone(_UTC)
-    m = bf.compute_backfill_metrics([before, after, inside], day)
-    assert m["active_minutes"] == 1
-
-
-def test_compute_backfill_metrics_empty_yields_zero():
-    m = bf.compute_backfill_metrics([], date(2026, 4, 13))
+    m = bf.compute_backfill_metrics(intervals, day)
     assert m["active_minutes"] == 0
     assert m["uptime_pct"] == 0.0
+
+
+def test_interval_clipped_at_market_open():
+    """Interval spanning pre-market to mid-session counts only from 9:30 ET."""
+    day = date(2026, 4, 13)
+    intervals = [(_et(2026, 4, 13, 8, 0), _et(2026, 4, 13, 10, 30))]  # 8:00 → 10:30 ET
+    m = bf.compute_backfill_metrics(intervals, day)
+    # 9:30 to 10:30 = 60 minutes
+    assert m["active_minutes"] == 60
+
+
+def test_interval_clipped_at_market_close():
+    """Interval spanning mid-session to post-close counts only up to 16:00 ET."""
+    day = date(2026, 4, 13)
+    intervals = [(_et(2026, 4, 13, 15, 0), _et(2026, 4, 13, 17, 0))]  # 15:00 → 17:00 ET
+    m = bf.compute_backfill_metrics(intervals, day)
+    # 15:00 to 16:00 = 60 minutes
+    assert m["active_minutes"] == 60
+
+
+def test_crash_and_recovery_counts_as_restart():
+    """Two intervals within market hours = one crash/restart between them."""
+    day = date(2026, 4, 13)
+    intervals = [
+        (_et(2026, 4, 13, 9, 30), _et(2026, 4, 13, 12, 0)),   # 150 min
+        (_et(2026, 4, 13, 12, 30), _et(2026, 4, 13, 16, 0)),  # 210 min
+    ]
+    m = bf.compute_backfill_metrics(intervals, day)
+    assert m["active_minutes"] == 150 + 210
+    assert m["crashes"] == 1
+
+
+def test_empty_intervals_yields_zero():
+    m = bf.compute_backfill_metrics([], date(2026, 4, 13))
+    assert m["active_minutes"] == 0
+    assert m["connected_minutes"] == 0
+    assert m["uptime_pct"] == 0.0
+    assert m["crashes"] == 0
+
+
+def test_quiet_daemon_still_counts_as_active():
+    """Regression: old backfill undercounted quiet daemons. Interval-based
+    treats the whole start→stop span as active regardless of log cadence."""
+    day = date(2026, 4, 13)
+    # Daemon ran all market hours but logged only twice (startup + shutdown)
+    intervals = [(_et(2026, 4, 13, 9, 29), _et(2026, 4, 13, 16, 1))]
+    m = bf.compute_backfill_metrics(intervals, day)
+    assert m["active_minutes"] == 390
+    assert m["uptime_pct"] == 1.0


### PR DESCRIPTION
## Summary
Previous backfill counted minute buckets that had any journal entry. Quiet daemons (hourly heartbeat + sparse order events) got reported as 0-3% uptime when they were actually up all day. This PR replaces that logic with systemd state-transition interval parsing.

## Method
Parse journalctl JSON output for messages matching: \`Started .*alpha-engine-daemon\`, \`Stopped .*alpha-engine-daemon\`, \`Deactivated successfully\`, \`Main process exited\`, \`Failed with result\`. Pair Start/Stop events into [start, end] intervals, intersect with NYSE 9:30-16:00 ET, sum overlap durations.

## Edge cases
- Daemon already running at day start (stop with no prior start) → interval opens at day start
- Daemon still running at day end (start with no matching stop) → interval closes at day end
- Double-start (no stop between) → keep earlier start
- Clock skew (stop before start) → discard

## Output format
\`source\` field changes from \`journalctl_backfill\` → \`journalctl_intervals\` so dashboard consumers can tell the new accurate records from old undercounting records. Run with \`--force\` to overwrite existing files once merged.

## Test plan
- [x] 242 tests pass (7 new)
- [ ] Re-run backfill on ae-trading with \`--force\` and compare 2026-03-24 before/after (was 24.4%, should jump significantly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)