### PR TITLE
hotfix: dedupe systemd stop messages in backfill

### DIFF
--- a/executor/backfill_uptime.py
+++ b/executor/backfill_uptime.py
@@ -103,28 +103,42 @@ def journal_intervals(day: date) -> list[tuple[datetime, datetime]]:
 
     events.sort(key=lambda x: x[0])
 
+    # Walk events as a state machine. systemd emits multiple stop messages
+    # per real stop (Deactivated + Stopped + Main process exited), so we
+    # must dedupe rather than treat each as a separate transition. Same
+    # for consecutive starts from Start-only notifications.
     day_start_utc = start_et.astimezone(_UTC)
     day_end_utc = end_et.astimezone(_UTC)
     intervals: list[tuple[datetime, datetime]] = []
+    state = "unknown"  # "unknown" | "running" | "stopped"
     current_start: datetime | None = None
 
     for ts, kind in events:
-        if kind == "start":
-            if current_start is None:
+        if state == "unknown":
+            # First event tells us what the daemon was doing before day start.
+            if kind == "start":
+                state = "running"
                 current_start = ts
-            # else: double-start (no stop between) — keep the earlier start
-        else:  # stop
-            if current_start is None:
-                # Daemon was already running at day start
-                intervals.append((day_start_utc, ts))
             else:
-                # Only record if stop is after start (guards against clock skew)
-                if ts > current_start:
+                # Daemon was already running at day start — stop closes that
+                # implicit interval.
+                intervals.append((day_start_utc, ts))
+                state = "stopped"
+        elif state == "running":
+            if kind == "stop":
+                if current_start is not None and ts > current_start:
                     intervals.append((current_start, ts))
                 current_start = None
+                state = "stopped"
+            # else: start while running — duplicate, ignore
+        else:  # state == "stopped"
+            if kind == "start":
+                current_start = ts
+                state = "running"
+            # else: stop while stopped — duplicate, ignore
 
     # Unclosed interval: daemon still running at day end
-    if current_start is not None:
+    if state == "running" and current_start is not None:
         intervals.append((current_start, day_end_utc))
 
     return intervals

--- a/tests/test_backfill_uptime.py
+++ b/tests/test_backfill_uptime.py
@@ -90,3 +90,95 @@ def test_quiet_daemon_still_counts_as_active():
     m = bf.compute_backfill_metrics(intervals, day)
     assert m["active_minutes"] == 390
     assert m["uptime_pct"] == 1.0
+
+
+# ── Interval-extraction state machine tests ───────────────────────────────
+#
+# journal_intervals() makes a subprocess call, so these tests feed events
+# through a tiny helper that replicates the state-machine walk. Keeping the
+# state machine's logic in a module-level helper would be cleaner — but for
+# now we exercise it by monkeypatching subprocess output.
+
+
+def _fake_journalctl_output(events: list[tuple[datetime, str]]) -> str:
+    """Render (ts, 'start'|'stop') tuples as JSON lines journalctl would emit."""
+    import json
+    lines = []
+    for ts, kind in events:
+        msg = (
+            "Started alpha-engine-daemon.service - …"
+            if kind == "start"
+            else "Stopped alpha-engine-daemon.service - …"
+        )
+        lines.append(json.dumps({
+            "MESSAGE": msg,
+            "__REALTIME_TIMESTAMP": str(int(ts.timestamp() * 1_000_000)),
+        }))
+    return "\n".join(lines)
+
+
+def test_journal_intervals_dedupes_consecutive_stops(monkeypatch):
+    """systemd emits Deactivated + Stopped + Main-exited per real stop.
+    State machine must collapse them into one transition."""
+    day = date(2026, 4, 13)
+    # Start, then 3 back-to-back stop messages (as systemd really emits),
+    # then a fresh start, then one stop.
+    events = [
+        (_et(2026, 4, 13, 10, 0), "start"),
+        (_et(2026, 4, 13, 12, 0), "stop"),
+        (_et(2026, 4, 13, 12, 0, ), "stop"),  # duplicate
+        (_et(2026, 4, 13, 12, 0), "stop"),  # duplicate
+        (_et(2026, 4, 13, 13, 0), "start"),
+        (_et(2026, 4, 13, 15, 0), "stop"),
+    ]
+    monkeypatch.setattr(
+        bf.subprocess,
+        "check_output",
+        lambda *a, **kw: _fake_journalctl_output(events),
+    )
+    intervals = bf.journal_intervals(day)
+    # Two real intervals, no triple-counted (day_start, 12:00) ones.
+    assert len(intervals) == 2
+    m = bf.compute_backfill_metrics(intervals, day)
+    # 10:00 → 12:00 = 120 min; 13:00 → 15:00 = 120 min
+    assert m["active_minutes"] == 240
+    assert m["uptime_pct"] == round(240 / 390, 4)
+    # No runaway percentages
+    assert m["uptime_pct"] <= 1.0
+
+
+def test_journal_intervals_daemon_already_running_at_day_start(monkeypatch):
+    """If the first event is a stop, the daemon was running before day_start."""
+    day = date(2026, 4, 13)
+    events = [
+        (_et(2026, 4, 13, 10, 0), "stop"),
+        (_et(2026, 4, 13, 11, 0), "start"),
+        (_et(2026, 4, 13, 15, 0), "stop"),
+    ]
+    monkeypatch.setattr(
+        bf.subprocess,
+        "check_output",
+        lambda *a, **kw: _fake_journalctl_output(events),
+    )
+    intervals = bf.journal_intervals(day)
+    assert len(intervals) == 2
+    m = bf.compute_backfill_metrics(intervals, day)
+    # Day-start-to-10:00 clipped to (9:30, 10:00) = 30 min
+    # 11:00 to 15:00 = 240 min
+    assert m["active_minutes"] == 30 + 240
+
+
+def test_journal_intervals_daemon_still_running_at_day_end(monkeypatch):
+    """If the daemon starts and never stops, close the interval at day end."""
+    day = date(2026, 4, 13)
+    events = [(_et(2026, 4, 13, 10, 0), "start")]
+    monkeypatch.setattr(
+        bf.subprocess,
+        "check_output",
+        lambda *a, **kw: _fake_journalctl_output(events),
+    )
+    intervals = bf.journal_intervals(day)
+    assert len(intervals) == 1
+    m = bf.compute_backfill_metrics(intervals, day)
+    # 10:00 → 16:00 market close = 360 min
+    assert m["active_minutes"] == 360


### PR DESCRIPTION
## Summary
PR #34's backfill output was broken — uptime >100% (up to 13666.1% for 2026-03-24). systemd emits 3 messages per real stop (Deactivated, Stopped, Main-process-exited), and the pair-walker treated each as a separate transition, creating overlapping \`(day_start, stop_ts)\` intervals that double/triple-counted.

## Fix
Replace pair-walker with a 3-state machine (\`unknown\` → \`running\` → \`stopped\`). Consecutive same-kind events collapse to one transition. Pathological sequences can't produce uptime_pct > 1.0.

## Test coverage
- 3 duplicate stops count as 1 (the regression)
- First event = stop → daemon was already running before day_start
- No closing stop → interval runs to day_end
- Uptime ≤ 100% always

## Deploy
After merge:
\`\`\`
ae "sudo systemctl start boot-pull && cd ~/alpha-engine && source .venv/bin/activate && PYTHONPATH=/home/ec2-user/alpha-engine python -m executor.backfill_uptime --start 2026-03-21 --end 2026-04-12 --force"
\`\`\`
Overwrites the PR #34 records with correct values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)