### PR TITLE
Rename uptime field: crashes → service_restarts

### DIFF
--- a/executor/backfill_uptime.py
+++ b/executor/backfill_uptime.py
@@ -162,8 +162,11 @@ def compute_backfill_metrics(
             total_seconds += (clipped_end - clipped_start).total_seconds()
 
     active_minutes = int(total_seconds // 60)
-    # Each interval after the first implies a restart/crash between them.
-    crashes = max(0, len(intervals) - 1)
+    # service_restarts: every interval after the first implies a transition
+    # from running → stopped → running between them. Mixes planned restarts
+    # (daily shutdown, maintenance) with unplanned ones (crash-and-recover),
+    # so not a clean "crashes" metric. Retained in JSON for analysis.
+    service_restarts = max(0, len(intervals) - 1)
 
     return {
         "date": day.isoformat(),
@@ -171,7 +174,7 @@ def compute_backfill_metrics(
         "connected_minutes": active_minutes,
         "market_minutes": _MARKET_MINUTES,
         "uptime_pct": round(active_minutes / _MARKET_MINUTES, 4) if _MARKET_MINUTES else 0.0,
-        "crashes": crashes,
+        "service_restarts": service_restarts,
         "tick_cadence_sec": 0,
         "source": "journalctl_intervals",
     }

--- a/executor/uptime_tracker.py
+++ b/executor/uptime_tracker.py
@@ -11,7 +11,7 @@ Writes uptime/{date}.json to S3:
       "connected_minutes": 295,     # daemon running AND IB Gateway connected
       "market_minutes": 390,        # 9:30-16:00 ET = 6.5h
       "uptime_pct": 0.756,          # connected_minutes / market_minutes
-      "crashes": 2,                 # gaps > 2.5x tick cadence during market hours
+      "service_restarts": 2,        # gaps > 2.5x tick cadence during market hours
       "tick_cadence_sec": 60,
       "source": "tick_log"
     }
@@ -101,12 +101,12 @@ def compute_metrics(
             minutes_connected.add(minute)
 
     gap_tol_sec = tick_cadence * _GAP_TOLERANCE_MULT
-    crashes = 0
+    service_restarts = 0
     if window:
         prev_ts = window[0][0]
         for ts, _ in window[1:]:
             if (ts - prev_ts).total_seconds() > gap_tol_sec:
-                crashes += 1
+                service_restarts += 1
             prev_ts = ts
 
     connected_minutes = len(minutes_connected)
@@ -116,7 +116,11 @@ def compute_metrics(
         "connected_minutes": connected_minutes,
         "market_minutes": _MARKET_MINUTES,
         "uptime_pct": round(connected_minutes / _MARKET_MINUTES, 4),
-        "crashes": crashes,
+        # service_restarts: count of daemon start↔stop transitions during
+        # market hours. Mixes planned maintenance restarts with crash-and-
+        # recover cycles; not a clean "crashes" signal. Retained in JSON
+        # for analysis but not surfaced on the homepage.
+        "service_restarts": service_restarts,
         "tick_cadence_sec": tick_cadence,
         "source": source,
     }

--- a/tests/test_backfill_uptime.py
+++ b/tests/test_backfill_uptime.py
@@ -27,7 +27,7 @@ def test_full_session_covered_by_single_interval():
     assert m["connected_minutes"] == 390
     assert m["market_minutes"] == 390
     assert m["uptime_pct"] == 1.0
-    assert m["crashes"] == 0
+    assert m["service_restarts"] == 0
     assert m["source"] == "journalctl_intervals"
 
 
@@ -70,7 +70,7 @@ def test_crash_and_recovery_counts_as_restart():
     ]
     m = bf.compute_backfill_metrics(intervals, day)
     assert m["active_minutes"] == 150 + 210
-    assert m["crashes"] == 1
+    assert m["service_restarts"] == 1
 
 
 def test_empty_intervals_yields_zero():
@@ -78,7 +78,7 @@ def test_empty_intervals_yields_zero():
     assert m["active_minutes"] == 0
     assert m["connected_minutes"] == 0
     assert m["uptime_pct"] == 0.0
-    assert m["crashes"] == 0
+    assert m["service_restarts"] == 0
 
 
 def test_quiet_daemon_still_counts_as_active():

--- a/tests/test_uptime_tracker.py
+++ b/tests/test_uptime_tracker.py
@@ -58,7 +58,7 @@ def test_compute_metrics_full_connected_session():
     assert m["connected_minutes"] == 390
     assert m["market_minutes"] == 390
     assert m["uptime_pct"] == 1.0
-    assert m["crashes"] == 0
+    assert m["service_restarts"] == 0
 
 
 def test_compute_metrics_half_session_missing():
@@ -72,7 +72,7 @@ def test_compute_metrics_half_session_missing():
     assert m["uptime_pct"] == round(195 / 390, 4)
     # No crashes recorded because no trailing tick exists to compare against;
     # mid-day silence is captured by the missing minutes, not the crash counter.
-    assert m["crashes"] == 0
+    assert m["service_restarts"] == 0
 
 
 def test_compute_metrics_mid_session_crash():
@@ -85,7 +85,7 @@ def test_compute_metrics_mid_session_crash():
 
     m = ut.compute_metrics(ticks, day)
     assert m["connected_minutes"] == len(before) + len(after)
-    assert m["crashes"] == 1
+    assert m["service_restarts"] == 1
 
 
 def test_compute_metrics_ib_disconnected_drops_connected_not_active():
@@ -108,7 +108,7 @@ def test_compute_metrics_empty_yields_zero():
     assert m["active_minutes"] == 0
     assert m["connected_minutes"] == 0
     assert m["uptime_pct"] == 0.0
-    assert m["crashes"] == 0
+    assert m["service_restarts"] == 0
 
 
 def test_collect_uptime_skips_non_trading_day():


### PR DESCRIPTION
## Summary
\"crashes\" in the uptime JSON was a misleading label — counted every daemon transition during market hours (planned shutdowns, systemd retries, IB reconnect cycles, and actual crashes, all mixed). Rename to \`service_restarts\` — accurate description, no quality implication.

## Schema change
Old: \`\"crashes\": N\`
New: \`\"service_restarts\": N\`

No consumer currently displays this (dashboard PR drops the surface). Kept in JSON for analysis.

## Deploy
After merge, re-run backfill with \`--force\` to rewrite existing S3 records:
\`\`\`
ae \"cd ~/alpha-engine && source .venv/bin/activate && PYTHONPATH=/home/ec2-user/alpha-engine python -m executor.backfill_uptime --start 2026-03-21 --end 2026-04-12 --force\"
\`\`\`

## Test plan
- [x] 245 tests pass
- [ ] Backfill --force writes records with \`service_restarts\` key (spot-check one file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)