### PR TITLE
fix: suppress benign IB Error 10197 in flow-doctor

### DIFF
--- a/executor/log_config.py
+++ b/executor/log_config.py
@@ -27,6 +27,16 @@ _FLOW_DOCTOR_YAML_PATH = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), "flow-doctor.yaml"
 )
 
+# IB Gateway error codes that are benign for a delayed-data paper-trading
+# executor. IB emits these at ERROR level, but the daemon continues to
+# receive delayed ticks via the delayedLast/delayedClose fallbacks in
+# price_monitor.py. Suppress to prevent alert spam when Brian opens the
+# IB iOS app during market hours (competing live session preempts the
+# live feed; delayed keeps flowing).
+_FLOW_DOCTOR_EXCLUDE_PATTERNS = [
+    r"Error 10197",  # No market data during competing live session
+]
+
 # Singleton — populated once by setup_logging() and retrieved by call sites
 # via get_flow_doctor(). None until setup_logging() runs with FLOW_DOCTOR_ENABLED=1.
 _fd_instance: Optional[flow_doctor.FlowDoctor] = None
@@ -65,7 +75,11 @@ def _attach_flow_doctor(name: str) -> None:
     """Initialize the shared flow-doctor instance and attach a log handler."""
     global _fd_instance
     _fd_instance = flow_doctor.init(config_path=_FLOW_DOCTOR_YAML_PATH)
-    handler = flow_doctor.FlowDoctorHandler(_fd_instance, level=logging.ERROR)
+    handler = flow_doctor.FlowDoctorHandler(
+        _fd_instance,
+        level=logging.ERROR,
+        exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
+    )
     logging.getLogger().addHandler(handler)
 
 

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -102,6 +102,20 @@ class TestFlowDoctorSingleton:
                 assert "repo" not in call_args.kwargs
                 assert "notify" not in call_args.kwargs
 
+    def test_handler_passes_exclude_patterns(self):
+        """FlowDoctorHandler must be wired with the IB 10197 suppression pattern."""
+        mock_fd = MagicMock()
+        mock_handler = MagicMock(spec=logging.Handler)
+        mock_handler.level = logging.ERROR
+        with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):
+            with patch("executor.log_config.flow_doctor") as mock_module:
+                mock_module.init.return_value = mock_fd
+                mock_module.FlowDoctorHandler.return_value = mock_handler
+                setup_logging("main")
+                call_kwargs = mock_module.FlowDoctorHandler.call_args.kwargs
+                assert "exclude_patterns" in call_kwargs
+                assert any("10197" in p for p in call_kwargs["exclude_patterns"])
+
     def test_init_failure_propagates(self):
         """flow-doctor is a hard dep — init failures should propagate, not be swallowed."""
         with patch.dict(os.environ, {"FLOW_DOCTOR_ENABLED": "1"}):


### PR DESCRIPTION
## Summary
- IB emits Error 10197 ("No market data during competing live session") at ERROR level when the iOS app is opened during market hours, triggering flow-doctor alerts for what is operationally a no-op
- Daemon already handles this: `price_monitor.py:57-60` reads `delayedLast`/`delayedClose` fallbacks, and `reqMarketDataType(3)` is set in both market-data call sites, so delayed ticks continue flowing
- Wire `exclude_patterns` into `FlowDoctorHandler` via `log_config.py` to drop 10197 before it enters the flow-doctor pipeline; other IB errors (10089, disconnects) still alert normally

## Test plan
- [x] `pytest tests/test_log_config.py` — 13 pass (added `test_handler_passes_exclude_patterns`)
- [ ] After merge + deploy, open IB iOS during market hours and confirm no 10197 alert fires
- [ ] Spot-check daemon logs after iOS login: verify prices in `self.prices` keep updating past the 10197 warning (if they don't, revert and pursue second-user setup instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)