### PR TITLE
EC2: fetch alpha-engine-lib PAT from SSM

### DIFF
--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -18,22 +18,21 @@ log "=== boot-pull started ==="
 # ── Configure git auth for private alpha-engine-lib ──────────────────────────
 # requirements.txt in alpha-engine / alpha-engine-backtester pins
 # alpha-engine-lib from a private GitHub repo. pip install needs an HTTPS
-# auth path to clone it. Set the insteadOf rewrite idempotently on every
-# boot so a fresh EBS or a ~/.gitconfig reset doesn't silently break the
-# pip install step below.
-ENV_FILE="/home/ec2-user/.alpha-engine.env"
-if [ -f "$ENV_FILE" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-    set +a
-fi
-if [ -n "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
-    log "OK   git insteadOf rewrite configured for alpha-engine-lib"
+# auth path to clone it.
+#
+# The PAT lives in SSM as /alpha-engine/lib-token (SecureString). The EC2
+# instance role alpha-engine-executor-role grants ssm:GetParameter on
+# /alpha-engine/*. Fetching on every boot is idempotent and survives a
+# fresh EBS or ~/.gitconfig reset. Local shell var scope only; never
+# exported, never logged.
+AE_LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
+if [ -n "$AE_LIB_TOKEN" ]; then
+    git config --global url."https://x-access-token:${AE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+    log "OK   git insteadOf rewrite configured for alpha-engine-lib (ssm:/alpha-engine/lib-token)"
 else
-    log "FAIL ALPHA_ENGINE_LIB_TOKEN not set in $ENV_FILE — pip install of alpha-engine-lib will fail"
+    log "FAIL ssm:/alpha-engine/lib-token unreadable — pip install of alpha-engine-lib will fail"
 fi
+unset AE_LIB_TOKEN
 
 REPOS=(
     /home/ec2-user/alpha-engine-config

--- a/infrastructure/setup-trading-ec2.sh
+++ b/infrastructure/setup-trading-ec2.sh
@@ -35,25 +35,23 @@ if [ ! -d ".venv" ]; then
 fi
 
 # ── 2a. Configure git URL rewrite for private alpha-engine-lib ──────────────
-# requirements.txt pins alpha-engine-lib from a private GitHub repo.
-# pip needs an HTTPS auth path to clone it. ~/.netrc already covers
-# github.com with a PAT, but we set an explicit insteadOf rewrite with
-# ALPHA_ENGINE_LIB_TOKEN (from $ENV_FILE) so:
-#   (a) the PAT scope requirement is explicit (Contents: read on
-#       alpha-engine-lib must be granted — fail here rather than mid-pip),
-#   (b) the netrc PAT and the lib PAT can differ without surprise.
-if [ -f "$ENV_FILE" ]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "$ENV_FILE"
-    set +a
-fi
-if [ -z "${ALPHA_ENGINE_LIB_TOKEN:-}" ]; then
-    echo "ERROR: ALPHA_ENGINE_LIB_TOKEN not set in $ENV_FILE — required to pip install private alpha-engine-lib" >&2
-    echo "       Add ALPHA_ENGINE_LIB_TOKEN=<pat> to $ENV_FILE (Contents: read on alpha-engine-lib)" >&2
+# requirements.txt pins alpha-engine-lib from a private GitHub repo. pip
+# needs an HTTPS auth path to clone it. The PAT lives in SSM at
+# /alpha-engine/lib-token (SecureString); the EC2 instance role
+# alpha-engine-executor-role grants ssm:GetParameter on /alpha-engine/*.
+# Local shell var scope only; never exported, never logged. boot-pull.sh
+# refreshes the same insteadOf rewrite on every boot so a ~/.gitconfig
+# reset or fresh EBS recovers automatically.
+echo "Fetching alpha-engine-lib PAT from SSM..."
+AE_LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
+if [ -z "$AE_LIB_TOKEN" ]; then
+    echo "ERROR: ssm:/alpha-engine/lib-token unreadable — required to pip install private alpha-engine-lib" >&2
+    echo "       Create with: aws ssm put-parameter --name /alpha-engine/lib-token --type SecureString --value <PAT> --region us-east-1" >&2
+    echo "       PAT must have Contents:read on cipher813/alpha-engine-lib." >&2
     exit 1
 fi
-git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+git config --global url."https://x-access-token:${AE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
+unset AE_LIB_TOKEN
 
 echo "Installing dependencies..."
 .venv/bin/pip install --quiet --upgrade pip


### PR DESCRIPTION
## Summary
Centralize the alpha-engine-lib PAT in SSM (`/alpha-engine/lib-token`, SecureString) so EC2 pulls it on every boot. Rotation becomes one write instead of touching .env + 4 GitHub repo secrets.

- `boot-pull.sh`: SSM fetch → git insteadOf rewrite → unset shell var. Idempotent across boots; survives ~/.gitconfig reset or fresh EBS.
- `setup-trading-ec2.sh`: same pattern, hard-fails with an actionable error message if SSM returns empty.
- `alpha-engine-executor-role` already has `ssm:GetParameter` on `/alpha-engine/*` — no IAM change needed.
- PAT is held in a local shell var only; never exported, never logged.

Phase 1 scope: EC2 only. Phase 2 (GitHub Actions CI + spot_train.sh + spot_backtest.sh) is deferred.

## Prereq before merge
Create the SSM parameter:
```
aws ssm put-parameter --name /alpha-engine/lib-token --type SecureString --value <PAT> --region us-east-1
```
PAT must have Contents:read on `cipher813/alpha-engine-lib`.

## Test plan
- [ ] Create SSM parameter
- [ ] Re-run `bash infrastructure/setup-trading-ec2.sh` on trading instance — confirms SSM fetch succeeds + rewrite persists
- [ ] Tomorrow's 6:10 AM PT boot: `ae-trading "grep -E 'ssm:|deps updated|alpha-engine-lib' /var/log/boot-pull.log | tail"` shows the SSM fetch line + successful pip install

🤖 Generated with [Claude Code](https://claude.com/claude-code)