### PR TITLE
Fix uptime_tracker to read daemon.log and parse JSON lines

### DIFF
--- a/executor/uptime_tracker.py
+++ b/executor/uptime_tracker.py
@@ -43,13 +43,15 @@ _MARKET_MINUTES = 6 * 60 + 30  # 390
 _TICK_RE = re.compile(r"DAEMON_TICK\s+ib_connected=(true|false)")
 _TS_RE = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})[,.]?\d*")
 
-_DEFAULT_LOG = "/var/log/executor.log"
+# The daemon's systemd unit redirects stdout/stderr to /var/log/daemon.log;
+# DAEMON_TICK lines live there, not in executor.log (which holds main.py).
+_DEFAULT_LOG = "/var/log/daemon.log"
 _DEFAULT_TICK_SEC = 60
 _GAP_TOLERANCE_MULT = 2.5
 
 
 def _parse_ts(line: str) -> datetime | None:
-    """Parse the leading UTC timestamp from a log line."""
+    """Parse the leading UTC timestamp from a legacy-text log line."""
     m = _TS_RE.match(line)
     if not m:
         return None
@@ -60,22 +62,55 @@ def _parse_ts(line: str) -> datetime | None:
     return pytz.utc.localize(ts_naive)
 
 
+def _parse_tick_line(line: str) -> tuple[datetime, bool] | None:
+    """Extract (ts_utc, ib_connected) from a DAEMON_TICK line in either the
+    legacy text format or the current JSON format emitted by
+    alpha_engine_lib.logging. Returns None for anything else.
+    """
+    if "DAEMON_TICK" not in line:
+        return None
+
+    stripped = line.lstrip()
+    if stripped.startswith("{") and '"msg"' in stripped:
+        try:
+            rec = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        msg = rec.get("msg", "")
+        tick = _TICK_RE.search(msg)
+        if not tick:
+            return None
+        ts_raw = rec.get("ts")
+        if not isinstance(ts_raw, str):
+            return None
+        try:
+            ts = datetime.fromisoformat(ts_raw)
+        except ValueError:
+            return None
+        ts_utc = pytz.utc.localize(ts) if ts.tzinfo is None else ts.astimezone(pytz.utc)
+        return ts_utc, tick.group(1) == "true"
+
+    tick = _TICK_RE.search(line)
+    if not tick:
+        return None
+    ts_utc = _parse_ts(line)
+    if ts_utc is None:
+        return None
+    return ts_utc, tick.group(1) == "true"
+
+
 def parse_tick_lines(lines: Iterable[str], day: date) -> list[tuple[datetime, bool]]:
     """Return (ts_et, ib_connected) tuples for DAEMON_TICK lines falling on `day` (ET)."""
     ticks: list[tuple[datetime, bool]] = []
     for line in lines:
-        if "DAEMON_TICK" not in line:
+        parsed = _parse_tick_line(line)
+        if parsed is None:
             continue
-        m = _TICK_RE.search(line)
-        if not m:
-            continue
-        ts_utc = _parse_ts(line)
-        if ts_utc is None:
-            continue
+        ts_utc, connected = parsed
         ts_et = ts_utc.astimezone(_ET)
         if ts_et.date() != day:
             continue
-        ticks.append((ts_et, m.group(1) == "true"))
+        ticks.append((ts_et, connected))
     ticks.sort(key=lambda x: x[0])
     return ticks
 

--- a/tests/test_uptime_tracker.py
+++ b/tests/test_uptime_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import date, datetime, time, timedelta
 
 import pytz
@@ -34,6 +35,47 @@ def test_parse_tick_lines_roundtrip():
     ts_et, connected = ticks[0]
     assert ts_et.hour == 9 and ts_et.minute == 30
     assert connected is True
+
+
+def _make_json_tick_line(ts_utc: datetime, connected: bool) -> str:
+    """Render a DAEMON_TICK line in the JSON format emitted by alpha_engine_lib.logging."""
+    return json.dumps({
+        "ts": ts_utc.isoformat(),
+        "level": "INFO",
+        "module": "daemon",
+        "func": "run_daemon",
+        "msg": f"DAEMON_TICK ib_connected={'true' if connected else 'false'}",
+    }) + "\n"
+
+
+def test_parse_tick_lines_json_format():
+    """Parser handles the JSON format written by the new alpha_engine_lib.logging."""
+    day = date(2026, 4, 13)
+    t_et = _ET.localize(datetime(2026, 4, 13, 10, 15))
+    t_utc = t_et.astimezone(_UTC)
+
+    line = _make_json_tick_line(t_utc, connected=True)
+    ticks = ut.parse_tick_lines([line, "{\"msg\": \"other\"}\n"], day)
+
+    assert len(ticks) == 1
+    ts_et, connected = ticks[0]
+    assert ts_et.hour == 10 and ts_et.minute == 15
+    assert connected is True
+
+
+def test_parse_tick_lines_mixed_formats():
+    """Text and JSON lines coexist during rollout — both get parsed."""
+    day = date(2026, 4, 13)
+    t1 = _ET.localize(datetime(2026, 4, 13, 9, 30)).astimezone(_UTC)
+    t2 = _ET.localize(datetime(2026, 4, 13, 9, 31)).astimezone(_UTC)
+
+    ticks = ut.parse_tick_lines(
+        [_make_tick_line(t1, True), _make_json_tick_line(t2, False)],
+        day,
+    )
+    assert len(ticks) == 2
+    assert ticks[0][1] is True
+    assert ticks[1][1] is False
 
 
 def test_parse_tick_lines_filters_wrong_day():


### PR DESCRIPTION
Two compounding regressions introduced by commit 6cc493e (swap executor/log_config.py for alpha_engine_lib.logging) left every uptime record since 4/13 writing connected_minutes=0:

1. **Wrong file.** The tracker was reading /var/log/executor.log, but the daemon's systemd unit redirects stdout/stderr to /var/log/daemon.log. The old log_config.py added a file handler that mirrored to executor.log; the new lib doesn't, so only the systemd redirect remains. Point _DEFAULT_LOG at daemon.log.

2. **Format change.** alpha_engine_lib.logging emits JSON by default on EC2 (ALPHA_ENGINE_JSON_LOGS=1). Lines start with `{` and the timestamp lives under the "ts" key, which the old text-format regex never matched. Add a JSON branch in _parse_tick_line; the legacy text path still works so mid-day rollouts keep parsing.

Verified against the live /var/log/daemon.log: 584 DAEMON_TICK records across 4/13 (180) and 4/14 (404) were previously invisible to the tracker.

Tests added for JSON-only and mixed-format inputs; all 11 tracker tests pass.