### PR TITLE
Suppress benign IB Error 10349 (TIF coerced to DAY)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -51,8 +51,8 @@ from executor.strategies.config import load_strategy_config
 from executor.trade_logger import init_db, log_trade, get_unmatched_entry
 
 from alpha_engine_lib.logging import setup_logging
-# See executor/main.py for the rationale on IB Error 10197 suppression.
-_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197"]
+# See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
+_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
 setup_logging("daemon", flow_doctor_yaml=_FLOW_DOCTOR_YAML, exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS)
 logger = logging.getLogger(__name__)

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -30,8 +30,8 @@ from executor.trade_logger import (
 )
 
 from alpha_engine_lib.logging import setup_logging
-# See executor/main.py for the rationale on IB Error 10197 suppression.
-_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197"]
+# See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
+_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
 setup_logging("eod", flow_doctor_yaml=_FLOW_DOCTOR_YAML, exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS)
 logger = logging.getLogger(__name__)

--- a/executor/main.py
+++ b/executor/main.py
@@ -47,12 +47,17 @@ from executor.price_cache import load_daily_vwap, load_price_histories
 from executor.trade_logger import backup_to_s3, get_entry_dates, init_db, log_trade, log_shadow_book_block
 
 from alpha_engine_lib.logging import setup_logging
-# Suppress benign IB Error 10197 ("No market data during competing live
-# session") — the daemon keeps receiving delayed ticks via the
-# delayedLast fallback in price_monitor.py, so flow-doctor's ERROR
-# alert is spam rather than signal. Every executor entrypoint passes
-# the same pattern list so all three fire through the shared handler.
-_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197"]
+# Suppress benign IB Error codes that don't represent real failures:
+#   10197 — "No market data during competing live session". The daemon
+#     keeps receiving delayed ticks via the delayedLast fallback in
+#     price_monitor.py, so flow-doctor's ERROR alert is spam.
+#   10349 — "Order TIF was set to DAY based on order preset". IB echoes
+#     this back every time the preset matches the submitted TIF=DAY
+#     (ibkr.py sets DAY defensively after the HSY cancel cycle on
+#     2026-04-13). The order is still placed and filled.
+# Every executor entrypoint passes the same pattern list so all three
+# fire through the shared handler.
+_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
 setup_logging("main", flow_doctor_yaml=_FLOW_DOCTOR_YAML, exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS)
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,10 @@ anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32
 # alpha-engine-lib provides setup_logging + BasePreflight. Executor
-# passes exclude_patterns=[r"Error 10197"] to setup_logging to suppress
-# benign IB Gateway noise when the iOS app steals the live-data
-# session (see daemon.py / main.py / eod_reconcile.py).
+# passes exclude_patterns=[r"Error 10197", r"Error 10349"] to suppress
+# benign IB Gateway noise (10197 = iOS app steals live-data session,
+# 10349 = TIF coerced to DAY per order preset — order still placed).
+# See daemon.py / main.py / eod_reconcile.py.
 # Private repo — pip install needs ALPHA_ENGINE_LIB_TOKEN:
 #   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
 #   EC2: ~/.netrc covers github.com with a PAT that has Contents:read


### PR DESCRIPTION
## Summary

- IB Gateway raises Error 10349 ("Order TIF was set to DAY based on order preset") every time the submitted TIF matches the preset. `ibkr.py` sets `order.tif = \"DAY\"` defensively after the HSY cancel cycle on 2026-04-13, so this fires on every order.
- The order is still placed and filled — the error is informational, not a rejection. Flow-doctor classifies it as ERROR level and emails on every occurrence.
- Adds \`r\"Error 10349\"\` to \`_FLOW_DOCTOR_EXCLUDE_PATTERNS\` in all three executor entrypoints, alongside the existing \`Error 10197\` suppression.

## Test plan

- [ ] Confirm diff only touches comment + pattern list (no behavior change).
- [ ] After deploy (git pull on trading EC2), verify next executor run does not email a 10349 ERROR alert.
- [ ] Confirm orders still place + fill normally — IB still overrides TIF regardless of the alert suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)