### PR TITLE
Scope pytest collection to tests/ (fixes 11 collection errors)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,10 @@ dependencies = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["executor*"]
+
+[tool.pytest.ini_options]
+# Scope pytest to tests/ only. Without this, default discovery walks the whole
+# tree and pulls in executor/connection_test.py (a CLI script matching *_test.py)
+# plus any stray nested repo copies, causing sys.path collisions and spurious
+# ImportErrors for modules that exist only in the current tree.
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Fixes 11 pre-existing pytest collection errors on \`main\` by constraining discovery to \`tests/\`. Full suite goes from **11 errors / 53 collected** to **0 errors / 225 passed**.

## Root cause

pytest's default discovery walks the whole rootdir. Two concrete problems:

1. **\`executor/connection_test.py\`** (a CLI script for checking IB Gateway connectivity) matches the default \`*_test.py\` glob and gets collected as a test. When run in an environment without IB Gateway (e.g. CI, sandboxed local), it hits \`PermissionError\` opening port 4002.

2. **Stray package shadowing.** A gitignored nested clone at \`./alpha-engine/\` (March 17 snapshot) exposes a second \`executor/\` package on sys.path. Tests like \`from executor import uptime_tracker\` sometimes bind to the stale copy, which predates the module's existence → \`ImportError: cannot import name 'uptime_tracker'\`. Same failure mode for \`check_correlation\` in risk_guard. The path \`alpha-engine/alpha-engine/executor/__init__.py\` in the error messages is the smoking gun.

## Fix

Adds \`[tool.pytest.ini_options]\` to \`pyproject.toml\`:

\`\`\`toml
testpaths = [\"tests\"]
\`\`\`

pytest now only discovers under \`tests/\`, which is the intended test surface. \`executor/connection_test.py\` stays runnable as a CLI script (\`python executor/connection_test.py\`) but is no longer collected. Any future stray nested copies won't pollute collection.

## Test plan

- [x] \`pytest\` (no args) — was 11 errors / 53 collected, now **225 passed / 0 errors**
- [x] Pre-push dry-run gate passed
- [ ] Does not change any runtime code; safe to merge without redeploy

## Follow-up (not in this PR)

The stale nested clone at \`./alpha-engine/\` should be removed — it's gitignored, 1 month old, and its uncommitted WIP on \`position_sizer.py\` is a superseded draft of sizing logic that's already in main (ATR, confidence, p_up). Flagged separately since destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)