### PR TITLE
Gate executor on daily_closes LastModified, not just stamp health

### DIFF
--- a/executor/health_status.py
+++ b/executor/health_status.py
@@ -88,6 +88,42 @@ def read_health(bucket: str, module_name: str) -> dict | None:
         return None
 
 
+def verify_s3_object_fresh(
+    s3_client,
+    bucket: str,
+    key: str,
+    run_date: str,
+    max_age_hours: float = 12,
+) -> None:
+    """Assert an S3 object exists and, when run_date is today (UTC), was
+    written within the last max_age_hours.
+
+    Raises RuntimeError on missing or stale. Backfill runs (run_date in the
+    past) only get the existence check — historical writes are legitimately
+    old. This guards against silent upstream staleness where a partial write
+    or Step Function retry leaves yesterday's blob at today's key, which
+    check_upstream_health (stamp-based) would miss.
+    """
+    try:
+        resp = s3_client.head_object(Bucket=bucket, Key=key)
+    except Exception as exc:
+        raise RuntimeError(
+            f"s3://{bucket}/{key} not found — upstream did not run or failed."
+        ) from exc
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if run_date != today:
+        return  # backfill: skip freshness
+
+    age = datetime.now(timezone.utc) - resp["LastModified"]
+    age_hours = age.total_seconds() / 3600
+    if age_hours > max_age_hours:
+        raise RuntimeError(
+            f"s3://{bucket}/{key} is stale ({age_hours:.1f}h old, "
+            f"max {max_age_hours:.0f}h) — upstream did not refresh today's file."
+        )
+
+
 def check_upstream_health(
     bucket: str,
     modules: list[str],

--- a/executor/main.py
+++ b/executor/main.py
@@ -946,6 +946,34 @@ def run(
                 logger.debug("Upstream failure Telegram notification failed", exc_info=True)
             raise RuntimeError(msg)
 
+        # Direct freshness check on today's daily_closes parquet. The stamp-based
+        # check_upstream_health above covers predictor/research "did it run"; this
+        # catches the "stamp says green but the actual data blob is yesterday's"
+        # failure mode (partial writes, Step Function retries skipping DataPhase1).
+        try:
+            import boto3
+            from executor.health_status import verify_s3_object_fresh
+            verify_s3_object_fresh(
+                boto3.client("s3"),
+                signals_bucket,
+                f"predictor/daily_closes/{run_date}.parquet",
+                run_date,
+                max_age_hours=12,
+            )
+        except RuntimeError as _freshness_err:
+            msg = f"daily_closes freshness check FAILED — executor aborting: {_freshness_err}"
+            logger.error(msg)
+            try:
+                from executor.notifier import send_daemon_status
+                send_daemon_status(
+                    "\u274c *daily_closes stale/missing*\n"
+                    f"Date: {run_date}\n"
+                    f"{_freshness_err}\n\nExecutor aborted — no order book written."
+                )
+            except Exception:
+                logger.debug("daily_closes freshness Telegram notification failed", exc_info=True)
+            raise RuntimeError(msg) from _freshness_err
+
     conn = None if simulate else init_db(db_path)
 
     # ── 1. Read signals from S3 (or use injected override) ──────────────────

--- a/tests/test_health_status.py
+++ b/tests/test_health_status.py
@@ -1,0 +1,57 @@
+"""Unit tests for executor.health_status — freshness utilities."""
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from executor.health_status import verify_s3_object_fresh
+
+
+def _s3_mock(last_modified=None, raise_exc=None):
+    s3 = MagicMock()
+    if raise_exc is not None:
+        s3.head_object.side_effect = raise_exc
+    else:
+        s3.head_object.return_value = {"LastModified": last_modified}
+    return s3
+
+
+class TestVerifyS3ObjectFresh:
+
+    def test_missing_object_raises_runtime_error(self):
+        s3 = _s3_mock(raise_exc=Exception("NoSuchKey"))
+        with pytest.raises(RuntimeError, match="not found"):
+            verify_s3_object_fresh(s3, "bucket", "key", "2026-04-16")
+
+    def test_fresh_today_passes(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        recent = datetime.now(timezone.utc) - timedelta(minutes=30)
+        s3 = _s3_mock(last_modified=recent)
+        verify_s3_object_fresh(s3, "bucket", "key", today)
+
+    def test_stale_today_raises_runtime_error(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        yesterday_write = datetime.now(timezone.utc) - timedelta(hours=25)
+        s3 = _s3_mock(last_modified=yesterday_write)
+        with pytest.raises(RuntimeError, match="stale"):
+            verify_s3_object_fresh(s3, "bucket", "key", today)
+
+    def test_backfill_skips_freshness_check(self):
+        """Historical run_date: existence-only, LastModified irrelevant."""
+        old_write = datetime.now(timezone.utc) - timedelta(days=30)
+        s3 = _s3_mock(last_modified=old_write)
+        verify_s3_object_fresh(s3, "bucket", "key", "2026-03-10")
+
+    def test_just_under_threshold_today_passes(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        almost_stale = datetime.now(timezone.utc) - timedelta(hours=11, minutes=59)
+        s3 = _s3_mock(last_modified=almost_stale)
+        verify_s3_object_fresh(s3, "bucket", "key", today)
+
+    def test_custom_max_age_hours(self):
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        three_hours_old = datetime.now(timezone.utc) - timedelta(hours=3)
+        s3 = _s3_mock(last_modified=three_hours_old)
+        verify_s3_object_fresh(s3, "bucket", "key", today, max_age_hours=6)
+        with pytest.raises(RuntimeError, match="stale"):
+            verify_s3_object_fresh(s3, "bucket", "key", today, max_age_hours=2)


### PR DESCRIPTION
## Summary

Closes the same silent-upstream-staleness class of bug as [alpha-engine-predictor#33](https://github.com/cipher813/alpha-engine-predictor/pull/33), but on the executor side.

The existing \`_UPSTREAM_MAX_AGE_H\` gate at \`executor/main.py:894\` checks stamp-based health (\`last_success\` in \`health/predictor_inference.json\`, 26h threshold). That catches "predictor didn't run" but **not** "predictor ran on yesterday's \`daily_closes\` because DataPhase1 wrote stale data to today's key." The stamp ticks green while the data is wrong.

Today's (2026-04-16) OOM incident is the class of failure this guards against.

## Change

New \`verify_s3_object_fresh()\` helper in \`executor/health_status.py\`, called from \`main.py\` immediately after the existing upstream gate:

- For today's run, \`predictor/daily_closes/{run_date}.parquet\` must exist AND \`LastModified\` must be within 12h.
- Backfills (\`--date\` in the past) keep existence-only — historical files are legitimately old.
- On failure: logs + Telegram notification + \`RuntimeError\` (mirrors the existing upstream gate's hard-fail pattern).

## Test plan

- [x] 6 new tests in \`tests/test_health_status.py\` — missing, fresh, stale, backfill skip, boundary, custom max_age
- [x] Full suite: **234 passed / 0 failed**
- [x] Pre-push dry-run gate passed
- [ ] Post-merge: next weekday executor run on ae-trading — gate fires if today's daily_closes is older than 12h; Telegram should show a clear age-in-hours message before the RuntimeError

## Pairs with

- [alpha-engine-predictor#33](https://github.com/cipher813/alpha-engine-predictor/pull/33) — same gate on the predictor's \`load_prices\` stage

## Follow-up (not in this PR)

- Per-module health stamp for \`daily_data\` in \`alpha-engine-data/collectors/daily_closes.py\` → would let us add \`daily_data: 24\` to \`_UPSTREAM_MAX_AGE_H\`. Complementary to this PR's direct check, not a replacement — the direct check catches failures the stamp would miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)