### PR TITLE
Add daily_data to _UPSTREAM_MAX_AGE_H (belt-and-suspenders with #53)

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -891,7 +891,12 @@ def run(
     #   research           — 192h (runs weekly Sat; grace covers Sat→next Fri)
     #   predictor_inference — 26h (runs every weekday morning; catches a Mon
     #                               miss without false-alarming on the weekend)
-    _UPSTREAM_MAX_AGE_H = {"research": 192, "predictor_inference": 26}
+    #   daily_data         — 26h (same weekday 13:05 UTC cadence as predictor;
+    #                               stamp written by alpha-engine-data after
+    #                               daily_closes.collect — catches ran-and-failed
+    #                               states that the direct LastModified check
+    #                               below would miss)
+    _UPSTREAM_MAX_AGE_H = {"research": 192, "predictor_inference": 26, "daily_data": 26}
 
     if not simulate:
         _health_failures: list[str] = []


### PR DESCRIPTION
## Summary

Closes the stamp-side of the belt-and-suspenders daily-data freshness architecture:

| Gate | Catches | Origin |
|---|---|---|
| \`_UPSTREAM_MAX_AGE_H\` stamp check (**this PR** adds \`daily_data: 26\`) | "ran and failed today" with structured reason | reads \`health/daily_data.json\` written by [alpha-engine-data#41](https://github.com/cipher813/alpha-engine-data/pull/41) |
| Direct \`LastModified\` on \`daily_closes/{date}.parquet\` ([#53](https://github.com/cipher813/alpha-engine/pull/53)) | "stamp green, blob stale" | head_object in main.py |

The stamp alone is insufficient — producer self-reporting can lie. The LastModified check alone misses structured failure state. Having both closes both holes.

## Change

One-liner in \`executor/main.py:894\` — adds \`"daily_data": 26\` to \`_UPSTREAM_MAX_AGE_H\`. 26h matches \`predictor_inference\` since both run at the same weekday 13:05 UTC cadence.

## Deploy order — IMPORTANT

1. **First: merge [alpha-engine-data#41](https://github.com/cipher813/alpha-engine-data/pull/41)** — data stamps start emitting on next weekday run (Mon 13:05 UTC)
2. **Wait** for at least one weekday DailyData run to produce \`health/daily_data.json\`
3. **Then: merge this PR** — executor begins enforcing the stamp gate

If this merges first, every executor run hard-fails with \`daily_data: no health data returned\` until DataPhase1 emits its first stamp. Keep this PR blocked until #41 has deployed AND been exercised on a weekday.

## Pairs with

- [alpha-engine#53](https://github.com/cipher813/alpha-engine/pull/53) — direct LastModified check on daily_closes.parquet
- [alpha-engine-data#41](https://github.com/cipher813/alpha-engine-data/pull/41) — emits \`health/daily_data.json\`
- [alpha-engine-predictor#33](https://github.com/cipher813/alpha-engine-predictor/pull/33) — same LastModified check on the predictor side

## Test plan

- [x] Full suite: **228 passed / 0 failed**
- [x] Pre-push dry-run gate passed
- [ ] Post-merge (after #41 has run on a weekday): next executor run logs \`daily_data: ok / age_hours: <small N>\` in upstream health check
- [ ] Failure injection: if DataPhase1 writes \`status: failed\` stamp, executor should hard-fail with Telegram notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)