### PR TITLE
Add alpha-engine-data to boot-pull REPOS on ae-trading

### DIFF
--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -39,6 +39,7 @@ REPOS=(
     /home/ec2-user/alpha-engine
     /home/ec2-user/alpha-engine-backtester
     /home/ec2-user/alpha-engine-dashboard
+    /home/ec2-user/alpha-engine-data
 )
 
 for repo in "${REPOS[@]}"; do


### PR DESCRIPTION
## Summary

Closes a deployment-plumbing gap introduced by today's OOM fix. When DailyData was moved from ae-dashboard (t3.micro) to ae-trading (t3.small), \`boot-pull.sh\`'s \`REPOS\` array was never updated. Net result: \`alpha-engine-data\` is checked out on the trading instance but never refreshes on boot, so commits merged to origin/main silently don't reach the DailyData SSM step.

## How this surfaced

Sequencing the daily_data health-stamp rollout:

- [alpha-engine-data#41](https://github.com/cipher813/alpha-engine-data/pull/41) merged ✓
- But HEAD on ae-trading was still \`0728d95\` (pre-#41) while origin/main was \`4a14d0b\`
- Friday's DailyData would have run with stale code → no \`health/daily_data.json\` emission → [alpha-engine#54](https://github.com/cipher813/alpha-engine/pull/54)'s \`daily_data: 26\` gate would hard-fail the executor on Friday morning

Tactical manual \`git pull\` already run to unblock Friday; this PR prevents the class-of-bug from recurring.

## Change

One-line append to the \`REPOS=( ... )\` array. \`boot-pull.sh\` already handles missing \`.git\` directories gracefully (\`SKIP\` log, no error), so this is safe even if alpha-engine-data isn't cloned on other instances.

## Test plan

- [x] \`bash -n infrastructure/boot-pull.sh\` — syntax OK
- [x] Pre-push dry-run gate passed
- [ ] Next ae-trading boot: \`/var/log/boot-pull.log\` shows \`Pulling /home/ec2-user/alpha-engine-data ...\` and \`OK\` line
- [ ] Verify future alpha-engine-data merges propagate automatically on next boot

## Blocks

- [alpha-engine#54](https://github.com/cipher813/alpha-engine/pull/54) — the \`daily_data\` stamp gate — should merge only after this PR deploys AND Friday's DailyData run produces the first stamp

## Audit opportunity (not in scope)

Other instances may have the same drift. Worth auditing ae-dashboard's boot/lifecycle scripts for similar stale REPOS lists — if any repo moved between instances post-deployment, its auto-pull plumbing needs to move with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)