### PR TITLE
ATR-scaled pullback trigger + unified ATR via feature store

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -43,7 +43,7 @@ from executor.risk_guard import check_order, compute_drawdown_multiplier
 from executor.signal_reader import get_actionable_signals, read_signals_with_fallback
 from executor.strategies.config import load_strategy_config
 from executor.strategies.exit_manager import evaluate_exits, SECTOR_ETF_MAP
-from executor.price_cache import load_daily_vwap, load_price_histories
+from executor.price_cache import load_atr_14_pct, load_daily_vwap, load_price_histories
 from executor.trade_logger import backup_to_s3, get_entry_dates, init_db, log_trade, log_shadow_book_block
 
 from alpha_engine_lib.logging import setup_logging
@@ -298,6 +298,7 @@ def _plan_entries(
     peak_nav: float,
     current_positions: dict,
     price_histories: dict | None,
+    atr_map: dict,
     dd_multiplier: float,
     signal_age_days: int,
     earnings_by_ticker: dict,
@@ -367,15 +368,12 @@ def _plan_entries(
             blocked.append({**_shadow_base, "block_reason": "no price available"})
             continue
 
-        # Compute ATR % for ATR-based sizing
-        atr_pct = None
-        if config.get("atr_sizing_enabled", True) and price_histories:
-            ticker_history = price_histories.get(ticker, [])
-            if ticker_history:
-                from executor.strategies.exit_manager import _compute_atr
-                atr_val = _compute_atr(ticker_history, period=14)
-                if atr_val and current_price > 0:
-                    atr_pct = atr_val / current_price
+        # Read ATR % from the feature-store map (load_atr_14_pct in main()).
+        # Previously computed inline via _compute_atr(ticker_history); switched
+        # to the feature-store value 2026-04-16 so executor and predictor use
+        # the same ATR definition. atr_map is guaranteed populated for every
+        # enter_signal ticker by load_atr_14_pct's hard-fail contract.
+        atr_pct = atr_map.get(ticker) if config.get("atr_sizing_enabled", True) else None
 
         # Get prediction confidence for confidence-weighted sizing
         pred_confidence = pred_data.get("prediction_confidence")
@@ -482,10 +480,26 @@ def _plan_entries(
                 "thesis_summary": sig.get("thesis_summary"),
             })
         elif not dry_run:
-            # Write approved entry to order book — daemon executes via technical triggers
-            from executor.strategies.exit_manager import _compute_atr
+            # Write approved entry to order book — daemon executes via technical triggers.
+            # ATR sourced from feature-store atr_map (load_atr_14_pct) — single source
+            # of truth across executor. atr_dollar = atr_pct × current_price so the
+            # trailing-stop calculation downstream (bracket_orders.py) keeps its dollar
+            # semantics. Pullback threshold scales by atr_pct so high-vol and low-vol
+            # names each get a trigger calibrated to their own realized volatility.
             ticker_hist = (price_histories or {}).get(ticker, [])
-            atr_dollar = _compute_atr(ticker_hist, period=14) if ticker_hist else None
+            ticker_atr_pct = atr_map.get(ticker)
+            # atr_map is populated for every enter_signal ticker by load_atr_14_pct's
+            # hard-fail contract — if ticker is missing here the morning planner
+            # would have aborted earlier. Treat the key-miss as an internal assertion.
+            if ticker_atr_pct is None:
+                raise RuntimeError(
+                    f"atr_map missing {ticker} at order-book write — load_atr_14_pct "
+                    "contract violated. Abort rather than ship an entry with a bogus "
+                    "zero ATR."
+                )
+            atr_dollar = ticker_atr_pct * current_price
+            pullback_atr_mult = strategy_config.get("intraday_pullback_atr_multiple", 1.0)
+            scaled_pullback_pct = ticker_atr_pct * pullback_atr_mult
 
             pred = predictions_by_ticker.get(ticker, {})
             ob.add_entry({
@@ -495,9 +509,17 @@ def _plan_entries(
                 "current_price": current_price,
                 "dollar_size": sizing["dollar_size"],
                 "position_pct": sizing["position_pct"],
-                "atr_value": atr_dollar or 0,
+                "atr_value": atr_dollar,
+                "atr_pct": ticker_atr_pct,
                 "triggers": {
-                    "pullback_pct": strategy_config.get("intraday_pullback_pct", 0.02),
+                    # Per-ticker ATR-scaled pullback. Formerly a flat 0.02 (2%)
+                    # that was too tight for low-vol names like KO (ATR ~0.8%,
+                    # pullback never fires) and too loose for high-vol like RKLB
+                    # (ATR ~5%, pullback fires on noise). Now each name gets a
+                    # threshold = pullback_atr_multiple × its own ATR(14).
+                    "pullback_pct": scaled_pullback_pct,
+                    "pullback_atr_multiple": pullback_atr_mult,
+                    "atr_pct": ticker_atr_pct,
                     "vwap_discount": strategy_config.get("intraday_vwap_discount_pct", 0.005),
                     "vwap": vwap_map.get(ticker),
                     "support_level": _compute_support_level(ticker_hist, strategy_config),
@@ -731,6 +753,7 @@ def _write_stops_and_finalize(
     ibkr,
     ob: OrderBook,
     price_histories: dict | None,
+    atr_map: dict,
     strategy_config: dict,
     conn,
     run_date: str,
@@ -738,7 +761,11 @@ def _write_stops_and_finalize(
     signals_bucket: str | None = None,
 ) -> None:
     """Write stop records for held positions, detect shorts, save order book, notify."""
-    from executor.strategies.exit_manager import _compute_atr
+    # ATR previously computed inline via _compute_atr(ticker_hist). Since
+    # 2026-04-16 the executor reads atr_14_pct from the feature-store map
+    # (load_atr_14_pct in main()) — same definition the predictor and sizing
+    # path use. atr_dollar derives from entry_price × atr_pct so trailing stops
+    # stay in dollar-denominated semantics (bracket_orders consumes dollars).
 
     # Add stop records for all current positions
     current_pos = ibkr.get_positions()
@@ -750,13 +777,20 @@ def _write_stops_and_finalize(
         urgent_exit_tickers = {u["ticker"] for u in ob.pending_urgent_exits()}
         if t in urgent_exit_tickers:
             continue
-        ticker_hist = (price_histories or {}).get(t, [])
-        atr_val = _compute_atr(ticker_hist, period=14) if ticker_hist else None
         entry_price = pos.get("avg_cost", 0)
         atr_mult = strategy_config.get("intraday_trailing_stop_atr_multiple", 2.0)
-        if not atr_val or atr_val <= 0:
-            logger.warning("No ATR for %s — skipping stop (no price history)", t)
+        ticker_atr_pct = atr_map.get(t)
+        if not ticker_atr_pct or ticker_atr_pct <= 0 or entry_price <= 0:
+            # load_atr_14_pct's hard-fail covers signal tickers + held positions
+            # at the top of main(); if we still hit a missing value here it's
+            # either a position that wasn't in the held-set at ATR load time
+            # (race condition) or entry_price <=0 from IBKR — skip this stop.
+            logger.warning(
+                "No ATR or invalid entry_price for %s — skipping stop (atr_pct=%s, entry_price=%s)",
+                t, ticker_atr_pct, entry_price,
+            )
             continue
+        atr_val = ticker_atr_pct * entry_price
         stop_price = round(entry_price - atr_val * atr_mult, 2)
         ob.add_stop({
             "ticker": t,
@@ -1067,6 +1101,26 @@ def run(
         # Load previous day's VWAP from daily_closes for intraday entry triggers
         vwap_map = load_daily_vwap(signals_bucket, run_date)
 
+        # Single source of truth for ATR across the executor. Replaces per-call-site
+        # _compute_atr(ticker_hist) invocations (position sizing, pullback-trigger
+        # scaling, trailing stops) with the predictor's feature-store atr_14_pct,
+        # so executor and predictor agree on the ATR definition. Hard-fails on
+        # missing ticker or stale data — feedback_hard_fail_until_stable.
+        # Scope: signal tickers (ENTER) + held positions (for trailing stops).
+        #
+        # ETF tickers are intentionally excluded — they're used for sector-relative
+        # exit veto via price_histories, not for ATR-based execution.
+        atr_tickers = [s["ticker"] for s in signals.get("enter", [])]
+        atr_tickers += list(current_positions.keys())
+        atr_tickers = sorted(set(atr_tickers))
+        if atr_tickers:
+            atr_map = load_atr_14_pct(
+                tickers=atr_tickers,
+                signals_bucket=signals_bucket,
+            )
+        else:
+            atr_map = {}
+
         # Separate sector ETF histories for exit manager
         sector_etf_histories = {
             t: price_histories[t] for t in SECTOR_ETF_MAP.values()
@@ -1186,6 +1240,7 @@ def run(
             peak_nav=peak_nav,
             current_positions=current_positions,
             price_histories=price_histories,
+            atr_map=atr_map,
             dd_multiplier=dd_multiplier,
             signal_age_days=signal_age_days,
             earnings_by_ticker=earnings_by_ticker,
@@ -1225,7 +1280,7 @@ def run(
         # ── 6. Write stop records and save order book for daemon ────────────────
         if not simulate and not dry_run:
             try:
-                _write_stops_and_finalize(ibkr, ob, price_histories, strategy_config, conn, run_date, blocked_entries, signals_bucket)
+                _write_stops_and_finalize(ibkr, ob, price_histories, atr_map, strategy_config, conn, run_date, blocked_entries, signals_bucket)
             except Exception as e:
                 logger.warning("Failed to write order book: %s", e)
 

--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -16,9 +16,20 @@ S3 layout:
 
 from __future__ import annotations
 
+# arcticdb MUST be imported before pandas on macOS to prime its bundled
+# aws-c-common allocator before pyarrow (pulled in by pandas) loads its
+# own copy. The two copies otherwise collide and arcticdb's S3Storage
+# constructor segfaults with `aws_fatal_assert: allocator != ((void*)0)`
+# on the first get_library() call. Linux runtimes (Lambda, EC2 Amazon
+# Linux) are unaffected — dynamic linker resolves differently. arcticdb
+# is a hard dep of the executor as of 2026-04-16 via requirements.txt;
+# no fallback path, no optional import — feedback_no_silent_fails.
+import arcticdb as _arcticdb  # noqa: F401  (kept for its side effect on import ordering)
+
 import io
 import logging
-from datetime import date, timedelta
+import os
+from datetime import date, datetime, timedelta, timezone
 
 import boto3
 import pandas as pd
@@ -26,6 +37,13 @@ import pandas as pd
 from executor.market_hours import is_trading_day
 
 logger = logging.getLogger(__name__)
+
+
+# Max staleness (in trading days) of the ATR feature before we hard-fail.
+# 1 = yesterday's close is acceptable; anything older is treated as a
+# pipeline-broken state and aborts the morning planner. Aligns with the
+# predictor's own DailyData dependency expectation.
+_ATR_MAX_STALENESS_TRADING_DAYS = 1
 
 
 def _load_histories_from_arcticdb(
@@ -123,6 +141,146 @@ def load_price_histories(
 
     logger.info("[data_source=legacy] Price histories loaded for %d/%d tickers from S3 slim cache", len(histories), len(tickers))
     return histories
+
+
+def load_atr_14_pct(
+    tickers: list[str],
+    signals_bucket: str,
+    max_staleness_trading_days: int = _ATR_MAX_STALENESS_TRADING_DAYS,
+    reference_date: date | None = None,
+) -> dict[str, float]:
+    """
+    Read the most recent `atr_14_pct` value per ticker from the ArcticDB
+    universe library. Single source of truth for ATR across the executor —
+    pullback trigger scaling, position sizing, and trailing stops all
+    consume from this map to eliminate intra-executor ATR-definition drift
+    (previously each call site computed its own ATR via _compute_atr from
+    raw OHLC, which could subtly diverge from the predictor's feature
+    store definition of atr_14_pct).
+
+    Values are stored in ArcticDB as decimals (e.g. 0.0238 = 2.38%),
+    consistent with how the pullback trigger config's pullback_pct is
+    interpreted, so no unit conversion is needed downstream.
+
+    Hard-fails per feedback_hard_fail_until_stable:
+      - arcticdb import failure (missing dep) → ImportError raised
+      - ArcticDB connection/library access failure → original exception
+        propagated (no silent fallback)
+      - Any requested ticker missing `atr_14_pct` column → RuntimeError
+      - Any requested ticker whose most-recent row is older than
+        `max_staleness_trading_days` → RuntimeError
+      - Any ticker with a non-finite or non-positive atr_14_pct → RuntimeError
+
+    Args:
+        tickers: Tickers to look up. Must all be present in universe library.
+        signals_bucket: S3 bucket hosting the ArcticDB store (same as
+                        research/predictor).
+        max_staleness_trading_days: Reject data older than this many trading
+                                    days from reference_date.
+        reference_date: Date to measure staleness against. Defaults to today
+                        (UTC). Pass an explicit date in tests.
+
+    Returns:
+        {ticker: atr_14_pct} for every requested ticker. Raises if any
+        fails validation.
+    """
+    if not tickers:
+        return {}
+
+    # Use the module-level binding that was imported first at the top of
+    # this file. Hard-fail on missing dep per no-silent-fail — arcticdb is
+    # a required dep in requirements.txt since 2026-04-16.
+    adb = _arcticdb
+
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    uri = (
+        f"s3s://s3.{region}.amazonaws.com:{signals_bucket}"
+        f"?path_prefix=arcticdb&aws_auth=true"
+    )
+    arctic = adb.Arctic(uri)
+    universe = arctic.get_library("universe")
+
+    ref = reference_date or datetime.now(timezone.utc).date()
+    staleness_cutoff = _n_trading_days_back(ref, max_staleness_trading_days)
+
+    atr_map: dict[str, float] = {}
+    missing_feature: list[str] = []
+    missing_symbol: list[str] = []
+    stale: list[tuple[str, str]] = []
+    invalid: list[tuple[str, float]] = []
+
+    for ticker in tickers:
+        try:
+            df = universe.read(ticker).data
+        except Exception as e:
+            missing_symbol.append(f"{ticker} ({e.__class__.__name__})")
+            continue
+
+        if "atr_14_pct" not in df.columns:
+            missing_feature.append(ticker)
+            continue
+
+        if df.empty:
+            missing_symbol.append(f"{ticker} (empty frame)")
+            continue
+
+        last_dt = df.index[-1]
+        last_date = last_dt.date() if hasattr(last_dt, "date") else pd.Timestamp(last_dt).date()
+        if last_date < staleness_cutoff:
+            stale.append((ticker, str(last_date)))
+            continue
+
+        val = float(df["atr_14_pct"].iloc[-1])
+        if not (val == val and val > 0):  # NaN-safe positivity check
+            invalid.append((ticker, val))
+            continue
+
+        atr_map[ticker] = val
+
+    problems = []
+    if missing_symbol:
+        problems.append(f"missing_symbol={missing_symbol}")
+    if missing_feature:
+        problems.append(f"missing_feature={missing_feature}")
+    if stale:
+        problems.append(
+            f"stale (older than {max_staleness_trading_days} trading day"
+            f"{'s' if max_staleness_trading_days != 1 else ''} before "
+            f"{ref}, cutoff={staleness_cutoff})={stale}"
+        )
+    if invalid:
+        problems.append(f"non-finite-or-non-positive={invalid}")
+
+    if problems:
+        raise RuntimeError(
+            "load_atr_14_pct failed validation — executor morning planner cannot "
+            "proceed without a trustworthy ATR for every signal ticker. "
+            f"Requested {len(tickers)} tickers, resolved {len(atr_map)}. "
+            "Problems: " + "; ".join(problems)
+        )
+
+    logger.info(
+        "[data_source=arcticdb] Loaded atr_14_pct for %d/%d tickers (cutoff=%s)",
+        len(atr_map), len(tickers), staleness_cutoff,
+    )
+    return atr_map
+
+
+def _n_trading_days_back(ref: date, n: int) -> date:
+    """Walk back `n` trading days from `ref` (inclusive of today if it's
+    a trading day). Weekend/holiday skipping uses the same calendar the
+    rest of the executor consults."""
+    current = ref
+    remaining = n
+    # Start on a trading day
+    while not is_trading_day(current):
+        current -= timedelta(days=1)
+    while remaining > 0:
+        current -= timedelta(days=1)
+        while not is_trading_day(current):
+            current -= timedelta(days=1)
+        remaining -= 1
+    return current
 
 
 def load_daily_vwap(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,13 @@ yfinance~=0.2.54
 numpy<2
 pandas~=2.2
 pyarrow~=14.0
+# arcticdb: reads atr_14_pct from the universe library at morning planner time.
+# Single source of truth for ATR across the executor — pullback trigger scaling,
+# position sizing, and trailing stops all consume the feature-store value so
+# executor and predictor agree on the ATR definition. See executor/price_cache.py
+# load_atr_14_pct. Version range kept loose to avoid pinning pain with the
+# predictor/backtester venvs which share the same S3-backed store.
+arcticdb~=6.12
 anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32

--- a/tests/test_price_cache_atr.py
+++ b/tests/test_price_cache_atr.py
@@ -1,0 +1,178 @@
+"""Tests for executor.price_cache.load_atr_14_pct.
+
+The hard-fail contract is the thing this test suite most cares about:
+the morning planner must not silently ship a degenerate 0.0 ATR for any
+signal ticker, because the pullback-trigger and trailing-stop
+calculations downstream assume a positive, fresh value. If the feature
+store is missing a column or stale, the planner should abort loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+# Inject a fake arcticdb module so local test runs work without the real
+# arcticdb install (EC2 deploy pulls it via requirements.txt). Tests that
+# call load_atr_14_pct patch sys.modules["arcticdb"].Arctic to return a
+# mock Arctic instance.
+if "arcticdb" not in sys.modules:
+    _fake_arcticdb = MagicMock()
+    sys.modules["arcticdb"] = _fake_arcticdb
+
+from executor import price_cache  # noqa: E402
+from executor.price_cache import _n_trading_days_back, load_atr_14_pct  # noqa: E402
+
+
+def _mock_arctic_lib(ticker_rows: dict[str, pd.DataFrame]):
+    """Build a mock arcticdb.Arctic → universe library that returns
+    the given DataFrame for each ticker read."""
+    lib = MagicMock()
+
+    def _read(ticker):
+        if ticker not in ticker_rows:
+            raise KeyError(f"no such symbol: {ticker}")
+        result = MagicMock()
+        result.data = ticker_rows[ticker]
+        return result
+
+    lib.read.side_effect = _read
+
+    arctic = MagicMock()
+    arctic.get_library.return_value = lib
+    return arctic
+
+
+def _df(atr_values: list[float], last_date: date) -> pd.DataFrame:
+    """Synthesize a universe DataFrame with an atr_14_pct column ending
+    on `last_date`. Index is a DatetimeIndex of consecutive business
+    days working backward from last_date."""
+    n = len(atr_values)
+    index = pd.bdate_range(end=pd.Timestamp(last_date), periods=n)
+    return pd.DataFrame({"atr_14_pct": atr_values}, index=index)
+
+
+class TestLoadAtr14Pct:
+    def test_returns_map_of_latest_values(self):
+        ref = date(2026, 4, 16)  # Thursday
+        rows = {
+            "AAPL": _df([0.020, 0.022, 0.024], last_date=ref),
+            "KO": _df([0.008, 0.009, 0.010], last_date=ref),
+        }
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                result = load_atr_14_pct(
+                    tickers=["AAPL", "KO"],
+                    signals_bucket="test-bucket",
+                    reference_date=ref,
+                )
+        assert result == {"AAPL": 0.024, "KO": 0.010}
+
+    def test_empty_ticker_list_returns_empty_map_no_arctic_call(self):
+        """No tickers means no ArcticDB connection — cheap short-circuit."""
+        with patch.object(price_cache._arcticdb, "Arctic") as mock_arctic:
+            result = load_atr_14_pct(tickers=[], signals_bucket="test-bucket")
+            assert result == {}
+            mock_arctic.assert_not_called()
+
+    def test_hard_fails_on_missing_ticker(self):
+        """Contract: every requested ticker must resolve. If one is missing,
+        raise — we must not silently ship a zero ATR into the order book."""
+        ref = date(2026, 4, 16)
+        rows = {"AAPL": _df([0.024], last_date=ref)}
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                with pytest.raises(RuntimeError, match="missing_symbol.*UNKNOWN"):
+                    load_atr_14_pct(
+                        tickers=["AAPL", "UNKNOWN"],
+                        signals_bucket="test-bucket",
+                        reference_date=ref,
+                    )
+
+    def test_hard_fails_on_missing_atr_column(self):
+        """If a ticker has a frame but no atr_14_pct column (e.g. partial
+        backfill or a new symbol not yet feature-computed), fail loud."""
+        ref = date(2026, 4, 16)
+        no_atr = pd.DataFrame(
+            {"Close": [100.0]}, index=pd.bdate_range(end=pd.Timestamp(ref), periods=1),
+        )
+        rows = {"BROKEN": no_atr}
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                with pytest.raises(RuntimeError, match="missing_feature.*BROKEN"):
+                    load_atr_14_pct(
+                        tickers=["BROKEN"],
+                        signals_bucket="test-bucket",
+                        reference_date=ref,
+                    )
+
+    def test_hard_fails_on_stale_data(self):
+        """Data older than max_staleness_trading_days must abort. Stale ATR
+        feeding the pullback trigger would recalibrate to conditions that
+        no longer apply."""
+        ref = date(2026, 4, 16)
+        stale_date = date(2026, 4, 10)  # Friday, >1 trading day back from Wed 4/16
+        rows = {"STALE": _df([0.02], last_date=stale_date)}
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                with pytest.raises(RuntimeError, match="stale"):
+                    load_atr_14_pct(
+                        tickers=["STALE"],
+                        signals_bucket="test-bucket",
+                        reference_date=ref,
+                        max_staleness_trading_days=1,
+                    )
+
+    def test_hard_fails_on_non_positive_atr(self):
+        """ATR should never be zero or negative for any real-world ticker —
+        if we see one, the feature-compute pipeline upstream is broken
+        and we shouldn't ship bogus signals into the trading path."""
+        ref = date(2026, 4, 16)
+        rows = {"ZEROATR": _df([0.0], last_date=ref)}
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                with pytest.raises(RuntimeError, match="non-finite-or-non-positive"):
+                    load_atr_14_pct(
+                        tickers=["ZEROATR"],
+                        signals_bucket="test-bucket",
+                        reference_date=ref,
+                    )
+
+    def test_hard_fails_on_nan_atr(self):
+        ref = date(2026, 4, 16)
+        rows = {"NAN": _df([float("nan")], last_date=ref)}
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            with patch.object(price_cache._arcticdb, "Arctic", return_value=_mock_arctic_lib(rows)):
+                with pytest.raises(RuntimeError, match="non-finite-or-non-positive"):
+                    load_atr_14_pct(
+                        tickers=["NAN"],
+                        signals_bucket="test-bucket",
+                        reference_date=ref,
+                    )
+
+
+class TestNTradingDaysBack:
+    def test_one_trading_day_back_from_weekday(self):
+        """If ref is a weekday and is_trading_day returns True for every
+        weekday, n=1 means yesterday (weekday)."""
+        ref = date(2026, 4, 16)  # Thursday
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            assert _n_trading_days_back(ref, 1) == date(2026, 4, 15)
+
+    def test_zero_trading_days_back_returns_ref_if_trading_day(self):
+        ref = date(2026, 4, 16)
+        with patch.object(price_cache, "is_trading_day", return_value=True):
+            assert _n_trading_days_back(ref, 0) == ref
+
+    def test_skips_weekends(self):
+        """Monday - 1 trading day should land on the previous Friday, not Sunday."""
+        monday = date(2026, 4, 13)  # Mon
+        # Mock is_trading_day to reflect reality: Sat/Sun are not trading days
+        def _is_td(d):
+            return d.weekday() < 5
+        with patch.object(price_cache, "is_trading_day", side_effect=_is_td):
+            assert _n_trading_days_back(monday, 1) == date(2026, 4, 10)  # Friday


### PR DESCRIPTION
## Summary

Directly addresses the conservatism asymmetry the session started with (portfolio barely moves while SPY swings ±5%) at the execution layer:

- **Per-ticker ATR-scaled pullback trigger.** Flat 2% pullback threshold replaced with `atr_14_pct × intraday_pullback_atr_multiple` (default 1.0). KO (ATR 0.8%) and RKLB (ATR 5%) each get a trigger calibrated to their own realized volatility instead of one threshold miscalibrated for both.
- **Unified ATR across the executor** via the predictor's feature store. Three call sites previously ran `_compute_atr(ticker_hist)` — position sizing, entry trigger scaling, trailing-stop records. All three now read `atr_14_pct` from ArcticDB, same definition predictor/backtester/evaluator use. Eliminates intra-executor and cross-module ATR-definition drift.

## Hard-fail contract (per `feedback_hard_fail_until_stable`)

`load_atr_14_pct` aborts the morning planner loud when:
- `arcticdb` import fails (propagates ImportError)
- Any signal ticker has no `atr_14_pct` column
- Any signal ticker's most-recent row is > N trading days old (default N=1)
- Any signal ticker has NaN / zero / negative `atr_14_pct`

Better to break the 6:25 AM planner run and leave yesterday's order book in place than to ship entries with a bogus 0.0 ATR into the daemon.

## Out of scope (follow-up PR)

`exit_manager._check_atr_trailing_stop` still calls `_compute_atr` at daemon runtime to dynamically update trailing-stop levels against highest-high-since-entry. That's a separate decision loop from the morning planner's trail_atr seed. Unifying it with the feature-store ATR means routing `atr_pct` through the order book / daemon's price_history cache — bigger refactor, kept out of this PR.

## macOS dev note

`import arcticdb` is now at the TOP of `executor/price_cache.py`, before `import pandas`. Required on macOS — the two bundled aws-c-common copies otherwise collide on arcticdb's S3Storage constructor (`aws_fatal_assert`). Linux (EC2/Lambda) is unaffected; the pinning is purely for local dev ergonomics. No fallback path, no optional import — arcticdb is a hard dep in `requirements.txt`.

## Test plan
- [x] `pytest tests/` — 244/244 pass (+10 new for `load_atr_14_pct` hard-fail contract: missing ticker, missing column, stale, zero, NaN; plus the trading-day-back helper)
- [x] `python executor/main.py --simulate --dry-run` — clean end-to-end
- [ ] EC2 deploy: next boot-pull installs `arcticdb~=6.12` via requirements.txt
- [ ] First post-deploy morning planner: confirm log `[data_source=arcticdb] Loaded atr_14_pct for N/N tickers` where N matches ENTER + held-position counts
- [ ] Order book entries should have per-ticker `pullback_pct` varying by name (sanity check: low-vol KO-class < 0.015, high-vol RKLB-class > 0.04)

🤖 Generated with [Claude Code](https://claude.com/claude-code)