### PR TITLE
Fix EOD cash residualization + dividend attribution + NAV reconciliation

### DIFF
--- a/executor/eod_emailer.py
+++ b/executor/eod_emailer.py
@@ -93,6 +93,7 @@ def build_eod_email(
     data_warnings: list[str] | None = None,
     roundtrip_stats: dict | None = None,
     account_snapshot: dict | None = None,
+    nav_reconciliation: dict | None = None,
 ) -> tuple[str, str, str]:
     """
     Build the EOD email subject + (html_body, plain_body).
@@ -170,18 +171,28 @@ def build_eod_email(
         total_day_usd = sum(pos.get("daily_return_usd", 0) for pos in positions.values())
         total_alpha_usd = sum(pos.get("alpha_contribution_usd", 0) for pos in positions.values())
 
-        # Cash row: use IB's ground truth cash, fall back to NAV - positions.
-        # Cash daily return = total daily P&L minus sum of position P&L (the residual).
-        # This captures actual interest, dividends, and any other non-position changes.
+        # NAV change components (computed by eod_reconcile). Cash earns interest
+        # only — we do NOT stuff the NAV-vs-position residual into cash, since
+        # that absorbs bookkeeping noise and inflates apparent alpha.
+        recon = nav_reconciliation or {}
         cash = ib_cash if ib_cash is not None else (nav - total_mv if nav else 0)
-        # Total portfolio daily P&L from NAV change
         total_nav_change = nav * (daily_return / 100) if daily_return is not None else 0
-        cash_daily_usd = total_nav_change - total_day_usd
-        cash_daily_return_pct = (cash_daily_usd / cash * 100) if cash and cash > 0 else 0
-        cash_alpha_usd = cash_daily_usd - (cash * (spy_return or 0) / 100) if cash else 0
+        interest_usd = recon.get("interest_usd", 0.0) or 0.0
+        dividend_usd = recon.get("dividend_usd", 0.0) or 0.0
+        # Unattributed = NAV change - position P&L - interest - dividends.
+        # Nonzero values usually indicate pricing/snapshot mismatches, corporate
+        # actions, fees, or FX — surfaced separately so they stay visible.
+        unattributed_usd = recon.get(
+            "unattributed_usd",
+            total_nav_change - total_day_usd - interest_usd - dividend_usd,
+        )
 
-        # Grand totals including cash
-        grand_day_usd = total_day_usd + cash_daily_usd
+        # Cash α = interest earned, minus the opportunity cost of not holding
+        # SPY on that cash sleeve. Dividends are attributed to source positions,
+        # so they flow through position α. Unattributed noise is excluded.
+        cash_alpha_usd = interest_usd - (cash * (spy_return or 0) / 100) if cash else 0
+
+        grand_day_usd = total_day_usd + interest_usd + dividend_usd + unattributed_usd
         grand_alpha_usd = total_alpha_usd + cash_alpha_usd
         grand_alpha_pct = grand_alpha_usd / nav * 100 if nav else 0
 
@@ -208,22 +219,40 @@ def build_eod_email(
                 f"  {dr_str:>7}  ${daily_usd:>+8,.0f}  ${alpha_usd:>+8,.0f}  {alpha_pct_of_total:>+6.1f}%"
             )
 
-        # Cash row
+        # Cash row — balance + α from interest vs SPY, no fabricated daily return
         if abs(cash) > 1:
             cash_pct = cash / nav * 100 if nav else 0
             cash_alpha_pct_of_total = (cash_alpha_usd / grand_alpha_usd * 100) if grand_alpha_usd else 0
             html_parts.append(
                 f'<tr style="color:#888"><td><i>Cash</i></td><td></td>'
                 f'<td>${cash:,.0f}</td><td>{cash_pct:.1f}%</td>'
-                f'<td>{_pct(cash_daily_return_pct)}</td><td>{_dollar(cash_daily_usd)}</td>'
+                f'<td>—</td><td>—</td>'
                 f'<td>{_dollar(cash_alpha_usd)}</td><td>{_pct(cash_alpha_pct_of_total)}</td></tr>'
             )
             plain_parts.append(
                 f"  {'Cash':<6} {'':>5}  ${cash:>9,.0f}  {cash_pct:>5.1f}%"
-                f"  {_plain_pct(cash_daily_return_pct):>7}  ${cash_daily_usd:>+8,.0f}  ${cash_alpha_usd:>+8,.0f}  {cash_alpha_pct_of_total:>+6.1f}%"
+                f"  {'—':>7}  {'—':>9}  ${cash_alpha_usd:>+8,.0f}  {cash_alpha_pct_of_total:>+6.1f}%"
             )
 
-        # Totals row — should tie to Daily Summary
+        # Interest / Dividends / Unattributed rows — only show if non-trivial
+        def _extra_row(label: str, usd: float, style: str = "color:#888;font-style:italic"):
+            if abs(usd) < 1:
+                return
+            html_parts.append(
+                f'<tr style="{style}"><td>{label}</td><td></td><td></td><td></td>'
+                f'<td>—</td><td>{_dollar(usd)}</td><td>—</td><td>—</td></tr>'
+            )
+            plain_parts.append(f"  {label:<14} ${usd:>+8,.0f}")
+
+        _extra_row("Interest", interest_usd)
+        _extra_row("Dividends", dividend_usd)
+        _extra_row(
+            "Unattributed",
+            unattributed_usd,
+            style="color:#c00;font-style:italic",  # red — this should be small
+        )
+
+        # Totals row — ties to Daily Summary (NAV-based)
         html_parts.append(
             f'<tr style="font-weight:bold;border-top:2px solid #333">'
             f'<td>Total</td><td></td>'
@@ -377,6 +406,7 @@ def send_eod_email(
     roundtrip_stats: dict | None = None,
     trades_bucket: str = "",
     account_snapshot: dict | None = None,
+    nav_reconciliation: dict | None = None,
 ) -> None:
     subject, html_body, plain_body = build_eod_email(
         run_date, nav, daily_return, spy_return, alpha, positions, conn,
@@ -385,6 +415,7 @@ def send_eod_email(
         data_warnings=data_warnings,
         roundtrip_stats=roundtrip_stats,
         account_snapshot=account_snapshot,
+        nav_reconciliation=nav_reconciliation,
     )
 
     # Archive email HTML to S3

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -248,6 +248,31 @@ def _synthesize_rationales(contexts: list[dict]) -> dict[str, str]:
     return narratives
 
 
+def _resolve_prior_price(
+    prior_pos: dict | None,
+    pos: dict,
+    current_price: float,
+) -> float:
+    """Pick the right prior-day price for daily return computation.
+
+    Phase 3+ snapshots store an explicit `closing_price` from daily_closes,
+    which is the same source today's reconcile uses for current_price —
+    eliminating the IB-MV-vs-daily-closes mismatch that was dumping noise
+    into the cash residual. Falls back to MV/shares for legacy snapshots
+    and to avg_cost for positions opened today.
+    """
+    if prior_pos:
+        cp = prior_pos.get("closing_price")
+        if cp is not None:
+            return float(cp)
+        prior_mv = prior_pos.get("market_value", 0)
+        prior_shares = prior_pos.get("shares", 0)
+        if prior_shares:
+            return prior_mv / prior_shares
+    # No prior snapshot — position opened today, use avg_cost
+    return pos.get("avg_cost", current_price)
+
+
 def _apply_dividend_delta(
     pos: dict,
     prior_pos: dict | None,
@@ -427,20 +452,6 @@ def run(run_date: str | None = None) -> None:
         else f"NAV=${nav:,.2f} | prior_nav={prior_nav}"
     )
 
-    log_eod(conn, {
-        "date": run_date,
-        "portfolio_nav": nav,
-        "daily_return_pct": daily_return,
-        "spy_return_pct": spy_return,
-        "daily_alpha_pct": alpha,
-        "positions_snapshot": positions,
-        "spy_close": spy_price,
-        "total_cash": account.get("total_cash"),
-        "accrued_interest": account.get("accrued_interest"),
-        "unrealized_pnl": account.get("unrealized_pnl"),
-        "realized_pnl": account.get("realized_pnl"),
-    })
-
     # ── Load closing prices from daily_closes for accurate per-position returns ──
     closing_prices: dict[str, float] = {}
     try:
@@ -479,16 +490,13 @@ def run(run_date: str | None = None) -> None:
             current_price = closing_prices[ticker]
             pos["market_value"] = current_price * shares
             mv = pos["market_value"]
+        # Persist the canonical close so tomorrow's reconcile reads the same
+        # source for prior_price (not derived from possibly-stale IB MV).
+        pos["closing_price"] = current_price
 
         # Daily return: today's price vs yesterday's price (or entry price if new today)
         prior_pos = prior_positions.get(ticker)
-        if prior_pos:
-            prior_mv = prior_pos.get("market_value", 0)
-            prior_shares = prior_pos.get("shares", 0)
-            prior_price = prior_mv / prior_shares if prior_shares else 0
-        else:
-            # New position — use avg_cost (entry price) as the baseline
-            prior_price = pos.get("avg_cost", current_price)
+        prior_price = _resolve_prior_price(prior_pos, pos, current_price)
 
         if prior_price and prior_price > 0:
             pos["daily_return_pct"] = (current_price / prior_price - 1) * 100
@@ -508,6 +516,9 @@ def run(run_date: str | None = None) -> None:
         pos_spy = spy_return if spy_return is not None else 0
         pos["alpha_contribution_pct"] = weight * (pos["daily_return_pct"] - pos_spy)
         pos["alpha_contribution_usd"] = pos["alpha_contribution_pct"] / 100 * nav if nav else 0
+
+    # data_warnings is appended to here (NAV gap) and by _build_position_contexts
+    data_warnings: list[str] = []
 
     # ── NAV change reconciliation ───────────────────────────────────────────
     # Every dollar of NAV change must be attributable to a source: position
@@ -553,14 +564,36 @@ def run(run_date: str | None = None) -> None:
             total_nav_change, total_day_usd, interest_usd,
             dividend_usd, unattributed_usd,
         )
-        # Warn if unattributed is material (>0.05% of NAV). Phase 3 tightens this.
+        # Warn if unattributed is material (> max($100, 0.05% NAV)). Surface
+        # the gap in data_warnings so it appears in the EOD email, not only
+        # in server logs.
         if nav and abs(unattributed_usd) > max(100.0, 0.0005 * nav):
-            logger.warning(
-                "NAV reconciliation gap: $%.0f unattributed (%.3f%% of NAV). "
-                "Likely causes: stale prior-day prices, untracked corporate action, "
-                "fees, or FX.",
-                unattributed_usd, (unattributed_usd / nav) * 100,
+            msg = (
+                f"NAV reconciliation gap: ${unattributed_usd:+,.0f} unattributed "
+                f"({unattributed_usd / nav * 100:+.3f}% of NAV). Likely causes: "
+                "stale prior-day prices, untracked corporate action, fees, or FX."
             )
+            logger.warning(msg)
+            data_warnings.append(msg)
+
+    # Persist EOD snapshot AFTER positions are enriched with closing prices,
+    # accrued dividends, and per-position returns. Yesterday's reconcile now
+    # reads this snapshot via closing_price (same source as today's
+    # daily_closes), closing the source-mismatch gap that was causing NAV
+    # residuals to land in cash.
+    log_eod(conn, {
+        "date": run_date,
+        "portfolio_nav": nav,
+        "daily_return_pct": daily_return,
+        "spy_return_pct": spy_return,
+        "daily_alpha_pct": alpha,
+        "positions_snapshot": positions,
+        "spy_close": spy_price,
+        "total_cash": account.get("total_cash"),
+        "accrued_interest": account.get("accrued_interest"),
+        "unrealized_pnl": account.get("unrealized_pnl"),
+        "realized_pnl": account.get("realized_pnl"),
+    })
 
     # ── Sector attribution ──────────────────────────────────────────────────
     # Daily contribution = today's per-position P&L as % of NAV (not cumulative
@@ -614,12 +647,12 @@ def run(run_date: str | None = None) -> None:
     # Build position rationale narratives
     signals_bucket = config.get("signals_bucket", "alpha-engine-research")
     position_narratives = {}
-    data_warnings: list[str] = []
     try:
         if positions:
-            contexts, data_warnings = _build_position_contexts(positions, conn, signals_bucket, run_date)
+            contexts, ctx_warnings = _build_position_contexts(positions, conn, signals_bucket, run_date)
             position_narratives = _synthesize_rationales(contexts)
             logger.info(f"Position narratives generated for {len(position_narratives)} tickers")
+            data_warnings.extend(ctx_warnings)
     except Exception as e:
         logger.warning(f"Position rationale generation failed: {e}")
 

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -465,6 +465,55 @@ def run(run_date: str | None = None) -> None:
         pos["alpha_contribution_pct"] = weight * (pos["daily_return_pct"] - pos_spy)
         pos["alpha_contribution_usd"] = pos["alpha_contribution_pct"] / 100 * nav if nav else 0
 
+    # ── NAV change reconciliation ───────────────────────────────────────────
+    # Every dollar of NAV change must be attributable to a source: position
+    # MTM, interest, dividends, or (flagged) unattributed. Anything in the
+    # unattributed bucket indicates a pricing/snapshot mismatch, fee, FX,
+    # corporate action, or similar — surface it loudly instead of burying it
+    # in cash return.
+    nav_reconciliation: dict = {}
+    if prior_nav is not None:
+        total_nav_change = nav - prior_nav
+        total_day_usd = sum(p.get("daily_return_usd", 0) for p in positions.values())
+
+        # Interest: day-over-day delta in IB's AccruedCash
+        prior_accrued_row = conn.execute(
+            "SELECT accrued_interest FROM eod_pnl WHERE accrued_interest IS NOT NULL AND date < ? ORDER BY date DESC LIMIT 1",
+            (run_date,),
+        ).fetchone()
+        today_accrued = account.get("accrued_interest")
+        if today_accrued is not None and prior_accrued_row and prior_accrued_row[0] is not None:
+            interest_usd = float(today_accrued) - float(prior_accrued_row[0])
+        else:
+            interest_usd = 0.0
+
+        # Dividends: filled in by Phase 2 (per-ticker attribution). For now,
+        # any dividend cash flow lands in `unattributed` and is flagged.
+        dividend_usd = sum(p.get("dividend_usd", 0.0) for p in positions.values())
+
+        unattributed_usd = total_nav_change - total_day_usd - interest_usd - dividend_usd
+        nav_reconciliation = {
+            "nav_change_usd": total_nav_change,
+            "position_pnl_usd": total_day_usd,
+            "interest_usd": interest_usd,
+            "dividend_usd": dividend_usd,
+            "unattributed_usd": unattributed_usd,
+        }
+        logger.info(
+            "NAV recon: Δ=$%.0f | positions=$%.0f | interest=$%.0f | "
+            "dividends=$%.0f | unattributed=$%.0f",
+            total_nav_change, total_day_usd, interest_usd,
+            dividend_usd, unattributed_usd,
+        )
+        # Warn if unattributed is material (>0.05% of NAV). Phase 3 tightens this.
+        if nav and abs(unattributed_usd) > max(100.0, 0.0005 * nav):
+            logger.warning(
+                "NAV reconciliation gap: $%.0f unattributed (%.3f%% of NAV). "
+                "Likely causes: stale prior-day prices, untracked corporate action, "
+                "fees, or FX.",
+                unattributed_usd, (unattributed_usd / nav) * 100,
+            )
+
     # ── Sector attribution ──────────────────────────────────────────────────
     # Daily contribution = today's per-position P&L as % of NAV (not cumulative
     # unrealized, which has no relationship to the day's return).
@@ -616,6 +665,7 @@ def run(run_date: str | None = None) -> None:
             roundtrip_stats=roundtrip_stats,
             trades_bucket=trades_bucket,
             account_snapshot=account,
+            nav_reconciliation=nav_reconciliation,
         )
     except Exception as e:
         logger.error(f"EOD email failed: {e}")

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -248,6 +248,38 @@ def _synthesize_rationales(contexts: list[dict]) -> dict[str, str]:
     return narratives
 
 
+def _apply_dividend_delta(
+    pos: dict,
+    prior_pos: dict | None,
+    prior_price: float,
+    shares: int,
+) -> None:
+    """Attribute today's dividend accrual to the position.
+
+    Only positive accrual deltas (ex-dividend earnings) are added to
+    daily_return_usd — these represent new economic value earned today.
+
+    Negative deltas (accrual → cash reclassification on payout day) are
+    recorded in pos['dividend_paid_usd'] but NOT subtracted from position
+    P&L. The dividend was already earned on ex-dividend day; the payout
+    is a bookkeeping transfer that raises cash without changing portfolio
+    value. The reconciliation bucket uses dividend_paid_usd to explain
+    the cash inflow on the payout day.
+    """
+    today_div = float(pos.get("accrued_dividend", 0.0) or 0.0)
+    prior_div = float((prior_pos or {}).get("accrued_dividend", 0.0) or 0.0)
+    div_delta = today_div - prior_div
+    if div_delta > 0:
+        pos["dividend_usd"] = div_delta
+        pos["daily_return_usd"] = pos.get("daily_return_usd", 0.0) + div_delta
+        prior_mv = prior_price * shares if prior_price else 0
+        if prior_mv > 0:
+            pos["daily_return_pct"] = (pos["daily_return_usd"] / prior_mv) * 100
+    elif div_delta < 0:
+        # Accrual dropped — payout to cash. Don't double-count as position loss.
+        pos["dividend_paid_usd"] = -div_delta
+
+
 def run(run_date: str | None = None) -> None:
     run_date = run_date or str(date.today())
     _health_start = _time.time()
@@ -291,6 +323,12 @@ def run(run_date: str | None = None) -> None:
             account = ibkr.get_account_snapshot()
             nav = account["net_liquidation"]
             positions = ibkr.get_positions()
+            # Per-symbol accrued dividends — often {} for paper accounts.
+            # Stored in positions_snapshot to compute day-over-day deltas.
+            dividends_by_symbol = ibkr.get_accrued_dividends_by_symbol()
+            for _tkr, _accrued in dividends_by_symbol.items():
+                if _tkr in positions:
+                    positions[_tkr]["accrued_dividend"] = _accrued
             ibkr.disconnect()
             break
         except Exception as e:
@@ -459,6 +497,12 @@ def run(run_date: str | None = None) -> None:
             pos["daily_return_pct"] = 0.0
             pos["daily_return_usd"] = 0.0
 
+        # Dividend attribution: today's accrued dividend for this ticker vs
+        # yesterday's snapshot. Delta is the day's dividend income (or its
+        # reversal when paid to cash). Flows into position α instead of
+        # leaking into the cash residual.
+        _apply_dividend_delta(pos, prior_pos, prior_price, shares)
+
         # Alpha contribution: (weight * position_return) - (weight * SPY_return)
         weight = mv / nav if nav else 0
         pos_spy = spy_return if spy_return is not None else 0
@@ -487,11 +531,15 @@ def run(run_date: str | None = None) -> None:
         else:
             interest_usd = 0.0
 
-        # Dividends: filled in by Phase 2 (per-ticker attribution). For now,
-        # any dividend cash flow lands in `unattributed` and is flagged.
+        # Dividends earned today (accrual increase) are already added into
+        # each position's daily_return_usd, so they flow through total_day_usd.
+        # Payout-day cash inflow is exactly offset by accrual drop in IB's
+        # NetLiquidation, so NAV doesn't move from the payout itself — no
+        # reconciliation term needed. dividend_usd here is informational
+        # only, summing positive accrual deltas for the email.
         dividend_usd = sum(p.get("dividend_usd", 0.0) for p in positions.values())
 
-        unattributed_usd = total_nav_change - total_day_usd - interest_usd - dividend_usd
+        unattributed_usd = total_nav_change - total_day_usd - interest_usd
         nav_reconciliation = {
             "nav_change_usd": total_nav_change,
             "position_pnl_usd": total_day_usd,

--- a/executor/ibkr.py
+++ b/executor/ibkr.py
@@ -85,6 +85,33 @@ class IBKRClient:
             "realized_pnl": _float("RealizedPnL"),
         }
 
+    def get_accrued_dividends_by_symbol(self) -> dict[str, float]:
+        """Return per-symbol accrued dividends from IB Gateway.
+
+        Iterates accountValues() and collects entries where tag suggests
+        dividend accrual and modelCode carries the symbol. IB Gateway
+        formats vary across versions/accounts; paper accounts often
+        populate nothing. Returns {} in that case — callers should treat
+        missing data as zero dividends, not as failure.
+
+        Emits INFO log with count so we can observe behavior live vs paper.
+        """
+        self.ensure_connected()
+        dividend_tags = {"AccruedDividend", "DividendAccruals"}
+        result: dict[str, float] = {}
+        for av in self.ib.accountValues():
+            if av.tag in dividend_tags and av.modelCode:
+                try:
+                    val = float(av.value)
+                except (TypeError, ValueError):
+                    continue
+                if val == 0:
+                    continue
+                # modelCode may be "AAPL" or similar symbol-like key
+                result[av.modelCode] = result.get(av.modelCode, 0.0) + val
+        logger.info("Accrued dividends by symbol: %d entries", len(result))
+        return result
+
     def get_positions(self) -> dict[str, dict]:
         """
         Return current portfolio positions.

--- a/tests/test_eod_emailer.py
+++ b/tests/test_eod_emailer.py
@@ -162,3 +162,71 @@ class TestBuildEodEmail:
             conn=mock_db,
         )
         assert "—" in subject or "None" not in subject
+
+    def test_cash_row_does_not_absorb_nav_residual(self, mock_db):
+        """Regression: cash should NOT show a fabricated daily return.
+
+        Prior bug: cash_daily_usd = total_nav_change - total_day_usd absorbed
+        pricing/snapshot noise. On 2026-04-17, this produced a +2.27% daily
+        return on the cash sleeve and +$7,148 of bogus cash alpha (133% of
+        total alpha). Cash row must show '—' for daily return and only earn
+        α from actual interest.
+        """
+        positions = {
+            "AAPL": {
+                "shares": 10, "market_value": 1500,
+                "daily_return_pct": 0.01, "daily_return_usd": 0.15,
+                "alpha_contribution_usd": 0.05,
+            },
+        }
+        # NAV moved by $8000 but positions only contributed $0.15
+        # and reconciliation says only $50 is interest.
+        recon = {
+            "nav_change_usd": 8000.0,
+            "position_pnl_usd": 0.15,
+            "interest_usd": 50.0,
+            "dividend_usd": 0.0,
+            "unattributed_usd": 7949.85,
+        }
+        account = {"total_cash": 350000.0, "accrued_interest": 550.0}
+        _, html, plain = build_eod_email(
+            run_date="2026-04-08",
+            nav=1_031_666.0,
+            daily_return=0.76,
+            spy_return=0.25,
+            alpha=0.51,
+            positions=positions,
+            conn=mock_db,
+            account_snapshot=account,
+            nav_reconciliation=recon,
+        )
+        # Cash row must not claim a 2.27% daily return
+        assert "2.27%" not in html
+        # Unattributed gap must be surfaced (not hidden)
+        assert "Unattributed" in html
+        assert "7,950" in html or "7,949" in html
+        # Interest row should appear
+        assert "Interest" in html
+
+    def test_reconciliation_absent_falls_back_cleanly(self, mock_db):
+        """If nav_reconciliation isn't passed, cash alpha is ~0 (interest=0)."""
+        positions = {
+            "AAPL": {
+                "shares": 10, "market_value": 1500,
+                "daily_return_pct": 0.1, "daily_return_usd": 1.5,
+                "alpha_contribution_usd": 0.5,
+            },
+        }
+        _, html, _ = build_eod_email(
+            run_date="2026-04-08",
+            nav=100_000.0,
+            daily_return=0.1,
+            spy_return=0.05,
+            alpha=0.05,
+            positions=positions,
+            conn=mock_db,
+            account_snapshot={"total_cash": 98_500.0},
+        )
+        # No explicit reconciliation → no Interest/Dividends rows
+        assert "Interest</td>" not in html
+        assert "Dividends</td>" not in html

--- a/tests/test_eod_reconcile_logic.py
+++ b/tests/test_eod_reconcile_logic.py
@@ -4,7 +4,36 @@ from unittest.mock import patch
 
 import pytest
 
-from executor.eod_reconcile import _apply_dividend_delta, _synthesize_rationales
+from executor.eod_reconcile import (
+    _apply_dividend_delta,
+    _resolve_prior_price,
+    _synthesize_rationales,
+)
+
+
+class TestResolvePriorPrice:
+    """Phase 3: prior-day price source resolution."""
+
+    def test_prefers_explicit_closing_price(self):
+        prior = {"closing_price": 105.0, "market_value": 500.0, "shares": 10}
+        pos = {"avg_cost": 100.0}
+        # closing_price wins even though MV/shares would give 50
+        assert _resolve_prior_price(prior, pos, current_price=110.0) == 105.0
+
+    def test_falls_back_to_mv_over_shares_for_legacy_snapshot(self):
+        # Pre-Phase-3 snapshots have no closing_price
+        prior = {"market_value": 1050.0, "shares": 10}
+        pos = {"avg_cost": 100.0}
+        assert _resolve_prior_price(prior, pos, current_price=110.0) == 105.0
+
+    def test_uses_avg_cost_when_no_prior_snapshot(self):
+        # Position opened today — no prior snapshot
+        pos = {"avg_cost": 99.50}
+        assert _resolve_prior_price(None, pos, current_price=101.0) == 99.50
+
+    def test_falls_back_to_current_price_when_no_avg_cost(self):
+        # Degenerate case — position has no avg_cost either
+        assert _resolve_prior_price(None, {}, current_price=110.0) == 110.0
 
 
 class TestApplyDividendDelta:

--- a/tests/test_eod_reconcile_logic.py
+++ b/tests/test_eod_reconcile_logic.py
@@ -4,7 +4,45 @@ from unittest.mock import patch
 
 import pytest
 
-from executor.eod_reconcile import _synthesize_rationales
+from executor.eod_reconcile import _apply_dividend_delta, _synthesize_rationales
+
+
+class TestApplyDividendDelta:
+    """Day-over-day dividend accrual delta is attributed to the position."""
+
+    def test_no_accrual_is_noop(self):
+        pos = {"daily_return_usd": 1.5, "daily_return_pct": 0.1}
+        _apply_dividend_delta(pos, {"accrued_dividend": 0.0}, prior_price=150.0, shares=10)
+        assert pos["daily_return_usd"] == 1.5
+        assert "dividend_usd" not in pos
+
+    def test_new_accrual_added(self):
+        pos = {"accrued_dividend": 5.0, "daily_return_usd": 2.0, "daily_return_pct": 0.1}
+        _apply_dividend_delta(pos, {"accrued_dividend": 0.0}, prior_price=100.0, shares=10)
+        assert pos["dividend_usd"] == 5.0
+        assert pos["daily_return_usd"] == 7.0
+        # prior_mv = 1000, daily_usd = 7 → pct = 0.7%
+        assert pos["daily_return_pct"] == pytest.approx(0.7)
+
+    def test_dividend_payout_does_not_touch_position_pnl(self):
+        """On payout day, accrual drops to 0 and cash rises by the same amount.
+
+        IB's NetLiquidation is invariant to the payout (accrual↓ = cash↑), so
+        position P&L must NOT be reduced. The dividend was already earned on
+        the ex-dividend day. Record it in dividend_paid_usd for visibility.
+        """
+        pos = {"accrued_dividend": 0.0, "daily_return_usd": 2.0, "daily_return_pct": 0.2}
+        _apply_dividend_delta(pos, {"accrued_dividend": 5.0}, prior_price=100.0, shares=10)
+        assert "dividend_usd" not in pos
+        # daily_return_usd unchanged — payout is not a loss
+        assert pos["daily_return_usd"] == 2.0
+        assert pos["dividend_paid_usd"] == 5.0
+
+    def test_no_prior_snapshot_treats_accrual_as_new(self):
+        pos = {"accrued_dividend": 3.0, "daily_return_usd": 1.0}
+        _apply_dividend_delta(pos, None, prior_price=100.0, shares=5)
+        assert pos["dividend_usd"] == 3.0
+        assert pos["daily_return_usd"] == 4.0
 
 
 class TestSynthesizeRationales:

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -1,0 +1,53 @@
+"""Unit tests for executor/ibkr.py — IB Gateway wrapper helpers.
+
+IB connection logic is mocked; these tests cover the parsing layer only.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from executor.ibkr import IBKRClient
+
+
+def _client_with_account_values(values):
+    """Build an IBKRClient with a mocked ib.accountValues() response."""
+    client = IBKRClient.__new__(IBKRClient)
+    client.ib = MagicMock()
+    client.ib.isConnected.return_value = True
+    client.ib.accountValues.return_value = values
+    return client
+
+
+class TestAccruedDividendsBySymbol:
+    def test_empty_account_values(self):
+        client = _client_with_account_values([])
+        assert client.get_accrued_dividends_by_symbol() == {}
+
+    def test_parses_per_symbol_accruals(self):
+        client = _client_with_account_values([
+            SimpleNamespace(tag="AccruedDividend", value="12.50", currency="USD", modelCode="AAPL", account="DU123"),
+            SimpleNamespace(tag="DividendAccruals", value="7.25", currency="USD", modelCode="MSFT", account="DU123"),
+            # No modelCode — a total-level entry, must be ignored here
+            SimpleNamespace(tag="AccruedDividend", value="19.75", currency="USD", modelCode="", account="DU123"),
+            # Unrelated tag — must be ignored
+            SimpleNamespace(tag="NetLiquidation", value="100000", currency="USD", modelCode="", account="DU123"),
+        ])
+        result = client.get_accrued_dividends_by_symbol()
+        assert result == {"AAPL": 12.50, "MSFT": 7.25}
+
+    def test_skips_zero_and_non_numeric(self):
+        client = _client_with_account_values([
+            SimpleNamespace(tag="AccruedDividend", value="0", currency="USD", modelCode="AAPL", account="DU"),
+            SimpleNamespace(tag="AccruedDividend", value="not-a-number", currency="USD", modelCode="MSFT", account="DU"),
+            SimpleNamespace(tag="AccruedDividend", value="5.00", currency="USD", modelCode="GOOG", account="DU"),
+        ])
+        result = client.get_accrued_dividends_by_symbol()
+        assert result == {"GOOG": 5.00}
+
+    def test_sums_multiple_entries_for_same_symbol(self):
+        """IB sometimes splits a symbol across multiple AccountValue rows."""
+        client = _client_with_account_values([
+            SimpleNamespace(tag="AccruedDividend", value="3.00", currency="USD", modelCode="AAPL", account="DU"),
+            SimpleNamespace(tag="DividendAccruals", value="4.50", currency="USD", modelCode="AAPL", account="DU"),
+        ])
+        result = client.get_accrued_dividends_by_symbol()
+        assert result == {"AAPL": 7.50}


### PR DESCRIPTION
## Problem

The 2026-04-17 EOD email reported a +2.27% daily return on the cash sleeve and +$7,148 of alpha attributed to cash (**133% of total alpha**). Cash can't earn 830% APY. Investigating, the bug was in `eod_emailer.py`:

```python
cash_daily_usd = total_nav_change - total_day_usd   # ← residual catch-all
```

This absorbed every dollar of NAV motion not captured in per-position daily P&L — pricing mismatches, corporate actions, fees, stale snapshots, dividends — and called it "cash return." Then line 181 folded that noise into alpha, contaminating the attribution table (though the headline NAV-based α stayed correct).

Real position α on the same day: **−$1,779** vs. the +$5,369 reported.

## Fix (3 phases)

### Phase 1 (this commit) — stop residualizing into cash
- Cash row shows balance + α from real interest only (no fabricated daily return)
- New explicit rows: **Interest** (from IB `AccruedCash` day-over-day delta), **Dividends** (Phase 2), **Unattributed** (highlighted red, with log warning when > max(\$100, 0.05% NAV))
- Grand α = Σ position α + cash α (interest vs SPY). Unattributed noise is surfaced, not absorbed.

### Phase 2 — attribute dividends to source positions
Fetch per-symbol `DividendAccruals` from IB, track day-over-day delta, add to each position's `daily_return_usd` so dividends flow through position α instead of leaking into the residual.

### Phase 3 — fix per-position prior-price source + tighten reconciliation
Verify yesterday's stored snapshot prices match today's `daily_closes` source. Add a hard assertion/warning in `data_warnings` when unattributed NAV gap exceeds threshold — makes pricing mismatches visible in the email itself, not just logs.

## Testing

- 246 tests passing, +2 regression tests for the cash-residual bug
- Pre-push executor dry-run gate passed
- Phase 2 and 3 will land as separate commits on this PR before merge

## Impact

Restores alpha attribution integrity. Headline NAV-based α unchanged (it's computed from (NAV - prior NAV) / prior NAV - SPY, which is correct). The attribution table will now tie to NAV change with named reconciliation buckets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)