### PR TITLE
fix(eod): fetch SPY close via yfinance, not ArcticDB

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -40,32 +40,37 @@ from executor.config_loader import CONFIG_PATH
 
 
 def _spy_close(run_date: str, config: dict | None = None) -> float:
-    """Fetch SPY close for run_date from ArcticDB universe library.
+    """Fetch SPY's actual session close for run_date via yfinance.
 
-    ArcticDB is the single source of truth — no parquet, polygon, or
-    yfinance fallback. Hard-fails if SPY is missing, stale, or has no
-    close for run_date, because EOD alpha is meaningless without a
-    reliable SPY reference.
+    EOD reconcile runs ~20 min after the 4:00 PM ET close, so yfinance
+    has the authoritative close for run_date. This path intentionally
+    bypasses ArcticDB: the universe/macro libraries are populated by
+    DataPhase1 at 6:05 AM PT using polygon's grouped-daily endpoint,
+    which silently returns T-1's aggregate when queried pre-market.
+    That write stamps T-1 data under index=T, so ArcticDB's "SPY close
+    for T" row is actually T-1's close — poisoning EOD alpha by exactly
+    one session. See incident 2026-04-17.
+
+    Hard-fails if yfinance returns no row for run_date (per
+    feedback_no_silent_fails / feedback_hard_fail_until_stable).
     """
-    from executor.price_cache import _open_universe_library
-    bucket = (config or {}).get("trades_bucket", "alpha-engine-research")
-    universe = _open_universe_library(bucket)
-    try:
-        df = universe.read("SPY").data
-    except Exception as e:
-        raise RuntimeError(f"ArcticDB read failed for SPY: {e}") from e
-    if df.empty or "Close" not in df.columns:
-        raise RuntimeError("ArcticDB SPY frame empty or missing Close column")
+    os.environ.setdefault("XDG_CACHE_HOME", "/tmp")
+    import yfinance as yf  # imported late so XDG_CACHE_HOME takes effect
     target = pd.Timestamp(run_date).normalize()
-    idx = df.index.normalize() if hasattr(df.index, "normalize") else df.index
-    matches = df[idx == target]
+    start = (target - pd.Timedelta(days=10)).strftime("%Y-%m-%d")
+    end = (target + pd.Timedelta(days=1)).strftime("%Y-%m-%d")
+    hist = yf.Ticker("SPY").history(start=start, end=end, auto_adjust=False)
+    if hist.empty:
+        raise RuntimeError(f"yfinance returned no SPY data for {start}..{end}")
+    idx = hist.index.tz_localize(None).normalize() if hist.index.tz is not None else hist.index.normalize()
+    matches = hist[idx == target]
     if matches.empty:
         raise RuntimeError(
-            f"ArcticDB has no SPY close for {run_date} (latest: "
-            f"{pd.Timestamp(df.index[-1]).date()})"
+            f"yfinance has no SPY close for {run_date} "
+            f"(latest available: {idx[-1].date()})"
         )
     close = float(matches["Close"].iloc[-1])
-    logger.info("[data_source=arcticdb] SPY close for %s: $%.2f", run_date, close)
+    logger.info("[data_source=yfinance] SPY close for %s: $%.2f", run_date, close)
     return close
 
 
@@ -406,32 +411,25 @@ def run(run_date: str | None = None) -> None:
     else:
         daily_return = ((nav - prior_nav) / prior_nav * 100)
 
-    # SPY return for the day
+    # SPY return for the day — always re-fetch both endpoints via yfinance.
+    # The cached eod_pnl.spy_close values are poisoned on rows written before
+    # the 2026-04-17 fix (see _spy_close docstring): they were sourced from
+    # ArcticDB and are T-1's close under date=T. Don't trust them.
     spy_price = _spy_close(run_date, config)
     spy_return = None
     if spy_price:
-        # Try cached prior SPY close from eod_pnl first
-        spy_prior_row = conn.execute(
-            "SELECT spy_close FROM eod_pnl WHERE spy_close IS NOT NULL AND date < ? ORDER BY date DESC LIMIT 1",
+        prior_date_row = conn.execute(
+            "SELECT date FROM eod_pnl WHERE date < ? ORDER BY date DESC LIMIT 1",
             (run_date,),
         ).fetchone()
-        if spy_prior_row and spy_prior_row[0]:
-            spy_return = (spy_price / spy_prior_row[0] - 1) * 100
-        else:
-            # Fallback: fetch SPY close for the actual prior eod_pnl date
-            # (avoids period="2d" which only gets 1 day regardless of gaps)
-            prior_date_row = conn.execute(
-                "SELECT date FROM eod_pnl WHERE date < ? ORDER BY date DESC LIMIT 1",
-                (run_date,),
-            ).fetchone()
-            if prior_date_row:
-                prior_spy = _spy_close(prior_date_row[0])
-                if prior_spy:
-                    spy_return = (spy_price / prior_spy - 1) * 100
-                else:
-                    logger.warning("Could not fetch SPY close for prior date %s", prior_date_row[0])
+        if prior_date_row:
+            prior_spy = _spy_close(prior_date_row[0])
+            if prior_spy:
+                spy_return = (spy_price / prior_spy - 1) * 100
             else:
-                logger.warning("No prior eod_pnl row — cannot compute SPY return")
+                logger.warning("Could not fetch SPY close for prior date %s", prior_date_row[0])
+        else:
+            logger.warning("No prior eod_pnl row — cannot compute SPY return")
 
     alpha = (daily_return - spy_return) if (daily_return is not None and spy_return is not None) else None
 

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -40,81 +40,60 @@ def _make_prediction(ticker, direction="UP", confidence=0.75, alpha=0.02):
 # ── _spy_close ───────────────────────────────────────────────────────────────
 
 
-def _mock_universe_with(symbols: dict[str, "pd.DataFrame"]):
-    """Build a mock ArcticDB universe library.
-
-    symbols maps ticker → DataFrame. universe.read(ticker) returns a
-    SimpleNamespace with .data = the frame. Missing tickers raise.
-    """
-    import pandas as pd  # noqa: F401 — used by caller's frames
-    from types import SimpleNamespace
-
-    lib = MagicMock()
-
-    def _read(sym):
-        if sym not in symbols:
-            raise KeyError(f"no such symbol: {sym}")
-        return SimpleNamespace(data=symbols[sym])
-
-    lib.read.side_effect = _read
-    return lib
+def _mock_yf_ticker(hist_df):
+    """Build a mock yfinance.Ticker whose .history() returns hist_df."""
+    ticker = MagicMock()
+    ticker.history.return_value = hist_df
+    mod = MagicMock()
+    mod.Ticker.return_value = ticker
+    return mod
 
 
-def test_spy_close_reads_from_arcticdb():
-    """_spy_close returns the SPY close for run_date via ArcticDB universe."""
+def test_spy_close_reads_from_yfinance():
+    """_spy_close returns the SPY close for run_date via yfinance."""
     import pandas as pd
 
     df = pd.DataFrame(
         {"Close": [447.00, 450.25]},
         index=pd.to_datetime(["2026-03-26", "2026-03-27"]),
     )
-    with patch(
-        "executor.price_cache._open_universe_library",
-        return_value=_mock_universe_with({"SPY": df}),
-    ):
+    with patch.dict("sys.modules", {"yfinance": _mock_yf_ticker(df)}):
         result = _spy_close("2026-03-27")
     assert result == pytest.approx(450.25)
 
 
-def test_spy_close_hard_fails_when_symbol_missing():
-    """_spy_close raises when ArcticDB has no SPY symbol — no fallback."""
-    with patch(
-        "executor.price_cache._open_universe_library",
-        return_value=_mock_universe_with({}),
-    ):
-        with pytest.raises(RuntimeError, match="ArcticDB read failed for SPY"):
+def test_spy_close_handles_tz_aware_index():
+    """yfinance frequently returns a tz-aware DatetimeIndex — must still match."""
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {"Close": [447.00, 450.25]},
+        index=pd.to_datetime(["2026-03-26", "2026-03-27"]).tz_localize("America/New_York"),
+    )
+    with patch.dict("sys.modules", {"yfinance": _mock_yf_ticker(df)}):
+        result = _spy_close("2026-03-27")
+    assert result == pytest.approx(450.25)
+
+
+def test_spy_close_hard_fails_when_empty():
+    """_spy_close raises when yfinance returns an empty history."""
+    import pandas as pd
+
+    with patch.dict("sys.modules", {"yfinance": _mock_yf_ticker(pd.DataFrame())}):
+        with pytest.raises(RuntimeError, match="returned no SPY data"):
             _spy_close("2026-03-27")
 
 
 def test_spy_close_hard_fails_when_date_missing():
-    """_spy_close raises when run_date has no row in ArcticDB — no fallback."""
+    """_spy_close raises when run_date has no row in yfinance response."""
     import pandas as pd
 
     df = pd.DataFrame(
         {"Close": [447.00]},
         index=pd.to_datetime(["2026-03-26"]),
     )
-    with patch(
-        "executor.price_cache._open_universe_library",
-        return_value=_mock_universe_with({"SPY": df}),
-    ):
+    with patch.dict("sys.modules", {"yfinance": _mock_yf_ticker(df)}):
         with pytest.raises(RuntimeError, match="no SPY close for 2026-03-27"):
-            _spy_close("2026-03-27")
-
-
-def test_spy_close_hard_fails_when_close_column_missing():
-    """_spy_close raises when the SPY frame has no Close column."""
-    import pandas as pd
-
-    df = pd.DataFrame(
-        {"Open": [447.00]},
-        index=pd.to_datetime(["2026-03-27"]),
-    )
-    with patch(
-        "executor.price_cache._open_universe_library",
-        return_value=_mock_universe_with({"SPY": df}),
-    ):
-        with pytest.raises(RuntimeError, match="empty or missing Close"):
             _spy_close("2026-03-27")
 
 


### PR DESCRIPTION
## Summary

- EOD reconcile was reporting alpha off by exactly one session
- Root cause: DataPhase1 at 6:05 AM PT calls Polygon's grouped-daily endpoint, which silently returns T-1's aggregate when queried pre-market. That gets stamped as index=T in ArcticDB's universe + macro libraries. EOD reconcile at 1:20 PM PT read ArcticDB SPY for today and got yesterday's close
- Switch `_spy_close` to yfinance live. EOD runs 20 min after 4:00 PM ET close, so yfinance has the authoritative close by then
- Drop the `eod_pnl.spy_close` cache path — historical rows are poisoned with the same one-day shift

## Impact today (2026-04-17)

| | Before (shipped) | After (this PR) |
|---|---|---|
| SPY close used | 701.66 (really 4/16) | 710.14 (real 4/17) |
| SPY return | +0.25% | +1.21% |
| Alpha | +0.52% (wrong sign) | -0.44% |

## Scope

This PR ONLY fixes the executor's EOD alpha computation. It does not fix the upstream daily_closes -> ArcticDB misalignment, which still poisons any other consumer reading ArcticDB's today-SPY/ETF close (predictor features are most likely affected). That's a separate problem needing its own fix in alpha-engine-data.

## Test plan

- [x] 264/264 existing tests pass
- [x] Rewrote 4 `_spy_close` tests to mock yfinance (added tz-aware index coverage)
- [x] Live sanity check: `_spy_close("2026-04-17")` returns 710.14, matches Yahoo
- [ ] Patch today's 2026-04-17 row in `s3://alpha-engine-research/trades/eod_pnl.csv` (separate operational step)
- [ ] Verify EOD reconcile on Monday 2026-04-20 writes correct alpha