### PR TITLE
feat(systemd): post-close DailyData timer on ae-trading

### DIFF
--- a/infrastructure/setup-trading-ec2.sh
+++ b/infrastructure/setup-trading-ec2.sh
@@ -92,6 +92,7 @@ SYSTEMD_DIR="$REPO_DIR/infrastructure/systemd"
 
 for unit in xvfb.service ibgateway.service alpha-engine-morning.service \
             alpha-engine-daemon.service alpha-engine-daemon.timer \
+            alpha-engine-daily-data.service alpha-engine-daily-data.timer \
             alpha-engine-eod.service alpha-engine-eod.timer; do
     sudo cp "$SYSTEMD_DIR/$unit" /etc/systemd/system/
 done
@@ -102,6 +103,7 @@ sudo systemctl enable xvfb.service
 sudo systemctl enable ibgateway.service
 sudo systemctl enable alpha-engine-morning.service
 sudo systemctl enable alpha-engine-daemon.service
+sudo systemctl enable alpha-engine-daily-data.timer
 sudo systemctl enable alpha-engine-eod.timer
 
 echo ""
@@ -112,7 +114,8 @@ echo "  1. xvfb.service           — virtual display for IB Gateway"
 echo "  2. ibgateway.service      — IB Gateway via IBC (needs 2FA on first login)"
 echo "  3. alpha-engine-morning   — order book planner (main.py)"
 echo "  4. alpha-engine-daemon    — intraday order executor"
-echo "  5. alpha-engine-eod       — EOD reconciliation (1:05 PM PT timer)"
+echo "  5. alpha-engine-daily-data — post-close OHLCV capture (1:05 PM PT timer)"
+echo "  6. alpha-engine-eod       — EOD reconciliation (1:20 PM PT timer)"
 echo ""
 echo "First login: IB Gateway will send a 2FA push to your phone."
 echo "Approve it within 2 minutes of instance start."

--- a/infrastructure/systemd/alpha-engine-daily-data.service
+++ b/infrastructure/systemd/alpha-engine-daily-data.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Alpha Engine Daily Data — post-close OHLCV capture for all tracked tickers
+# Runs before EOD reconcile so ArcticDB has today's real close populated
+# by the time alpha-engine-eod.service reads it.
+# No IB Gateway dependency — reads Polygon/FRED/yfinance, writes S3 + ArcticDB.
+
+[Service]
+Type=oneshot
+User=ec2-user
+WorkingDirectory=/home/ec2-user/alpha-engine-data
+# Pull latest code + env + run collector. Mirrors the command that used to run
+# in the weekday Step Function's DailyData SSM step (see alpha-engine-data
+# infrastructure/step_function_daily.json prior to 2026-04-17 label-bug fix).
+ExecStartPre=/usr/bin/git -C /home/ec2-user/alpha-engine-data pull --ff-only origin main
+ExecStart=/bin/bash -c 'set -a && source /home/ec2-user/.alpha-engine.env && set +a && source /home/ec2-user/alpha-engine-data/.venv/bin/activate && python weekly_collector.py --daily'
+StandardOutput=append:/var/log/daily-data.log
+StandardError=append:/var/log/daily-data.log
+Environment=AWS_REGION=us-east-1
+Environment=ALPHA_ENGINE_JSON_LOGS=1
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/systemd/alpha-engine-daily-data.timer
+++ b/infrastructure/systemd/alpha-engine-daily-data.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Trigger Alpha Engine Daily Data collection at 1:05 PM PT (post-close)
+
+[Timer]
+# 1:05 PM PT = 5 minutes after the 4:00 PM ET market close. Polygon's
+# grouped-daily endpoint has the completed session aggregate available
+# by then, so the collector writes today's actual close into ArcticDB
+# under index=T (not a T-1-mislabeled-as-T row, which was the pre-fix
+# pre-market failure mode — see 2026-04-17 incident).
+#
+# Ordered BEFORE alpha-engine-eod.timer (1:20 PM PT) so EOD reconcile
+# reads fresh same-day SPY + ticker closes from ArcticDB.
+OnCalendar=Mon..Fri 13:05 America/Los_Angeles
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/infrastructure/systemd/alpha-engine-eod.service
+++ b/infrastructure/systemd/alpha-engine-eod.service
@@ -1,7 +1,13 @@
 [Unit]
 Description=Alpha Engine EOD Reconciliation
-After=ibgateway.service
+After=ibgateway.service alpha-engine-daily-data.service
 Requires=ibgateway.service
+# Soft dependency on daily-data: EOD reads today's SPY + ticker closes from
+# ArcticDB, which the daily-data service populates at 1:05 PM PT (15 min
+# before EOD at 1:20 PM PT). If daily-data fails, EOD will hard-fail when
+# _spy_close/universe-lib reads find no row for run_date — by design, since
+# alpha against stale SPY is meaningless.
+Wants=alpha-engine-daily-data.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Companion to upcoming alpha-engine-data PR that removes DailyData from the morning weekday Step Function. See commit message for the 2026-04-17 incident context. Needs both PRs to merge + Monday deploy coordinated so the gap between 'old morning path disabled' and 'new post-close path enabled' is zero trading days.