### PR TITLE
fix(executor): move order_book_summary.json out of signals/{date}/ namespace

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -737,7 +737,7 @@ def _write_order_book_summary(
 
     try:
         s3 = boto3.client("s3")
-        key = f"signals/{run_date}/order_book_summary.json"
+        key = f"order_books/{run_date}/summary.json"
         s3.put_object(
             Bucket=signals_bucket,
             Key=key,


### PR DESCRIPTION
## Summary
- Producer fix for the RAG ingest NoSuchKey failure surfaced by today's RAG smoke test.
- Executor's weekday morning-planner writes \`signals/{date}/order_book_summary.json\` into the **same prefix** Research uses for \`signals.json\`. The latest \`signals/{date}/\` prefix therefore isn't guaranteed to contain \`signals.json\` — any weekday run where morning-planner ran more recently than the last successful Saturday Research leaves the prefix with only \`order_book_summary.json\`.
- Downstream consumers that treat the lexicographically-latest \`signals/\` prefix as authoritative break. Concrete failure: \`rag/pipelines/ingest_sec_filings.py --from-signals\` crashed today on the RAG smoke test; latest prefix \`signals/2026-04-17/\` had only \`order_book_summary.json\`.
- This PR relocates the artifact to its own namespace: \`order_books/{run_date}/summary.json\`.

Root-cause origin: commit 8c7613a4 \`feat: write order_book_summary.json to S3 for public dashboard\`. Namespace collision was latent until the Saturday Research hang + weekday morning-planner activity combined to push a \`signals/{date}/\` prefix with no \`signals.json\` to the top of the sort order.

## Companion PR
Dashboard reader must be updated before or with this merge:
- alpha-engine-dashboard: \`fix/order-book-summary-new-path\` (reads new key only)

Merge order: dashboard PR first is safer (dashboard shows empty order-book briefly if it reads before executor writes to new path, vs. dashboard broken permanently if executor moves before dashboard). Either order is acceptable — transition window is a single weekday morning-plan write.

## Test plan
- [x] \`pytest tests/\` — 264 green
- [ ] After merge + weekday boot: confirm \`s3://alpha-engine-research/order_books/{date}/summary.json\` exists and \`signals/{date}/\` contains no new write
- [ ] Re-run RAG smoke (\`infrastructure/spot_data_weekly.sh --rag-smoke-only\` in alpha-engine-data) end-to-end green

🤖 Generated with [Claude Code](https://claude.com/claude-code)