### PR TITLE
fix: read SPY from ArcticDB macro library (was wrongly pointing at un…

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -40,18 +40,23 @@ from executor.config_loader import CONFIG_PATH
 
 
 def _spy_close(run_date: str, config: dict | None = None) -> float:
-    """Fetch SPY close for run_date from ArcticDB universe library.
+    """Fetch SPY close for run_date from ArcticDB macro library.
+
+    SPY lives in the `macro` library (per alpha-engine-data's
+    daily_append writer), NOT the `universe` library. Reading from
+    universe was a bug: universe has only the per-ticker watchlist
+    symbols, no index ETFs.
 
     ArcticDB is the single source of truth — no parquet, polygon, or
     yfinance fallback. Hard-fails if SPY is missing, stale, or has no
     close for run_date, because EOD alpha is meaningless without a
     reliable SPY reference.
     """
-    from executor.price_cache import _open_universe_library
+    from executor.price_cache import _open_macro_library
     bucket = (config or {}).get("trades_bucket", "alpha-engine-research")
-    universe = _open_universe_library(bucket)
+    macro = _open_macro_library(bucket)
     try:
-        df = universe.read("SPY").data
+        df = macro.read("SPY").data
     except Exception as e:
         raise RuntimeError(f"ArcticDB read failed for SPY: {e}") from e
     if df.empty or "Close" not in df.columns:

--- a/executor/main.py
+++ b/executor/main.py
@@ -985,26 +985,29 @@ def run(
                 logger.debug("Upstream failure Telegram notification failed", exc_info=True)
             raise RuntimeError(msg)
 
-        # Direct freshness check on the ArcticDB universe library. The
+        # Direct freshness check on the ArcticDB macro library. The
         # stamp-based check_upstream_health above covers predictor/research
         # "did it run"; this catches the "stamp green but data blob is
         # yesterday's" failure mode (partial writes, retries skipping
-        # DataPhase1). SPY is the canary — always present, written by the
-        # daily_closes collector. If SPY has no row dated run_date, the
-        # data pipeline did not complete for today and the executor must
-        # abort before any signals are read.
+        # DataPhase1). SPY is the canary — written by the daily_append
+        # post-close job to the macro library (NOT universe). If SPY has
+        # no row for the last closed trading day, the post-close pipeline
+        # did not complete and the executor must abort before any signals
+        # are read.
         try:
             import pandas as _pd
-            from executor.price_cache import _open_universe_library
-            _universe = _open_universe_library(signals_bucket)
-            _spy_df = _universe.read("SPY").data
-            _target = _pd.Timestamp(run_date).normalize()
+            from executor.price_cache import _open_macro_library
+            from alpha_engine_lib.trading_calendar import last_closed_trading_day
+            _macro = _open_macro_library(signals_bucket)
+            _spy_df = _macro.read("SPY").data
+            _expected_min = _pd.Timestamp(last_closed_trading_day()).normalize()
             _idx = _spy_df.index.normalize() if hasattr(_spy_df.index, "normalize") else _spy_df.index
-            if _spy_df.empty or (_idx == _target).sum() == 0:
+            if _spy_df.empty or (_idx >= _expected_min).sum() == 0:
                 _latest = _pd.Timestamp(_spy_df.index[-1]).date() if not _spy_df.empty else "EMPTY"
                 raise RuntimeError(
-                    f"ArcticDB universe has no SPY row for {run_date} "
-                    f"(latest: {_latest}). DataPhase1 did not complete."
+                    f"ArcticDB macro has no SPY row >= {_expected_min.date()} "
+                    f"(latest: {_latest}). Post-close daily-data job did not "
+                    f"complete for the last closed trading day."
                 )
         except Exception as _freshness_err:
             msg = f"ArcticDB freshness check FAILED — executor aborting: {_freshness_err}"

--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -43,7 +43,10 @@ _ATR_MAX_STALENESS_TRADING_DAYS = 1
 def _open_universe_library(signals_bucket: str):
     """Open the ArcticDB `universe` library for reads.
 
-    Single connection helper used by every read path in the executor.
+    Per-ticker OHLCV + features. Does NOT include SPY/VIX/sector ETFs —
+    those live in the `macro` library; use ``_open_macro_library`` for
+    those.
+
     Hard-fails on connection/library errors per feedback_no_silent_fails.
     """
     adb = _arcticdb  # already imported at module top for macOS allocator prime
@@ -54,6 +57,26 @@ def _open_universe_library(signals_bucket: str):
     )
     arctic = adb.Arctic(uri)
     return arctic.get_library("universe")
+
+
+def _open_macro_library(signals_bucket: str):
+    """Open the ArcticDB `macro` library for reads.
+
+    Market-wide time series: SPY, VIX, VIX3M, TNX, IRX, GLD, USO, and
+    the XL* sector ETFs. Written by alpha-engine-data's daily_append
+    and builders.backfill. SPY in particular is what the morning
+    freshness gate and EOD reconcile check.
+
+    Hard-fails on connection/library errors per feedback_no_silent_fails.
+    """
+    adb = _arcticdb
+    region = os.environ.get("AWS_REGION", "us-east-1")
+    uri = (
+        f"s3s://s3.{region}.amazonaws.com:{signals_bucket}"
+        f"?path_prefix=arcticdb&aws_auth=true"
+    )
+    arctic = adb.Arctic(uri)
+    return arctic.get_library("macro")
 
 
 def load_price_histories(

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ requests~=2.32
 #   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
 #   EC2: ~/.netrc covers github.com with a PAT that has Contents:read
 #        on alpha-engine-lib (confirm via git ls-remote before deploy).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.2
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.3

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -69,7 +69,7 @@ def test_spy_close_reads_from_arcticdb():
         index=pd.to_datetime(["2026-03-26", "2026-03-27"]),
     )
     with patch(
-        "executor.price_cache._open_universe_library",
+        "executor.price_cache._open_macro_library",
         return_value=_mock_universe_with({"SPY": df}),
     ):
         result = _spy_close("2026-03-27")
@@ -79,7 +79,7 @@ def test_spy_close_reads_from_arcticdb():
 def test_spy_close_hard_fails_when_symbol_missing():
     """_spy_close raises when ArcticDB has no SPY symbol — no fallback."""
     with patch(
-        "executor.price_cache._open_universe_library",
+        "executor.price_cache._open_macro_library",
         return_value=_mock_universe_with({}),
     ):
         with pytest.raises(RuntimeError, match="ArcticDB read failed for SPY"):
@@ -95,7 +95,7 @@ def test_spy_close_hard_fails_when_date_missing():
         index=pd.to_datetime(["2026-03-26"]),
     )
     with patch(
-        "executor.price_cache._open_universe_library",
+        "executor.price_cache._open_macro_library",
         return_value=_mock_universe_with({"SPY": df}),
     ):
         with pytest.raises(RuntimeError, match="no SPY close for 2026-03-27"):
@@ -111,7 +111,7 @@ def test_spy_close_hard_fails_when_close_column_missing():
         index=pd.to_datetime(["2026-03-27"]),
     )
     with patch(
-        "executor.price_cache._open_universe_library",
+        "executor.price_cache._open_macro_library",
         return_value=_mock_universe_with({"SPY": df}),
     ):
         with pytest.raises(RuntimeError, match="empty or missing Close"):


### PR DESCRIPTION
…iverse)

SPY lives in the macro library per alpha-engine-data's daily_append writer — it is NOT in the universe library. Two executor code paths were reading SPY from universe and getting E_NO_SUCH_VERSION:

1. executor/main.py ArcticDB freshness gate (line 1000)
2. executor/eod_reconcile.py _spy_close

Observed on the 2026-04-20 manual SF rerun after the staleness-check fix landed: upstream-health gate now passed (predictor/research/daily stamps all fresh), but the next line tripped on
``_universe.read("SPY")`` → NoSuchVersionException.

Fixes:
- price_cache.py: add _open_macro_library helper (mirrors _open_universe_library); update _open_universe_library docstring to note it does NOT include SPY/VIX/sector ETFs.
- main.py freshness gate: read SPY from macro lib, compare against last_closed_trading_day() (time-aware, symmetric with predictor Lambda's fix) — not run_date equality, so Monday pre-close runs correctly accept Friday's SPY row.
- eod_reconcile._spy_close: read SPY from macro lib. EOD's strict equality vs run_date stays correct because EOD fires post-close.
- requirements.txt: bump alpha-engine-lib pin v0.1.2 → v0.1.3 for last_closed_trading_day.
- tests/test_eod_reconcile.py: update 4 mock targets from _open_universe_library to _open_macro_library.

Per-ticker close reads (non-SPY position lookups) still use the universe library — only market-wide series move to macro.