### PR TITLE
feat(executor): hard-fail + CW metric on unscored buy_candidates

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -276,6 +276,17 @@ def _read_signals(
     else:
         predictions_by_ticker = {}
 
+    # Coverage guard: every buy_candidate must have a prediction row, otherwise
+    # the GBM veto gate is structurally unreachable for that ticker and we'd
+    # be sizing positions around a risk control. Skip in simulate mode (no
+    # live trading, predictions intentionally empty). The weekday Step Function
+    # coverage-gap Choice state is the self-healing mechanism; this guard is
+    # read-time defense-in-depth. Always emits CloudWatch metric (value 0 on
+    # success) so the alarm baseline is continuous.
+    if not simulate:
+        from executor.signal_reader import assert_predictions_cover_buy_candidates
+        assert_predictions_cover_buy_candidates(signals_raw, predictions_by_ticker)
+
     logger.info(
         f"Signals | regime={signals['market_regime']} "
         f"| ENTER={len(signals['enter'])} EXIT={len(signals['exit'])} "

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -149,6 +149,77 @@ def _warn_if_stale(signals_date: str | None, run_date: str | None) -> None:
         )
 
 
+class UnscoredBuyCandidatesError(RuntimeError):
+    """Raised when signals.json has buy_candidates that are missing from
+    predictions.json — the GBM veto gate is structurally unreachable for
+    those tickers, so sizing positions would route around a risk control.
+
+    Self-healing should happen upstream (weekday Step Function's coverage-gap
+    Choice state re-invokes predictor with --tickers). This error is the
+    read-time defense-in-depth backstop: if the gap reaches the executor, we
+    refuse to trade rather than bypass the veto.
+    """
+    def __init__(self, missing: list[str], n_buy: int, n_preds: int):
+        self.missing = missing
+        self.n_buy = n_buy
+        self.n_preds = n_preds
+        super().__init__(
+            f"Coverage gap: {len(missing)} of {n_buy} buy_candidate(s) "
+            f"not present in predictions.json (which has {n_preds} tickers). "
+            f"Missing: {', '.join(missing)}. "
+            "Refusing to size positions — GBM veto gate is unreachable for "
+            "these tickers. Re-run predictor with --tickers to close the gap."
+        )
+
+
+def _emit_unscored_count_metric(count: int) -> None:
+    """Emit CloudWatch metric AlphaEngine/Predictor/unscored_buy_candidates_count.
+
+    Best-effort; never raises. The hard-fail (UnscoredBuyCandidatesError) is
+    the functional guard — this metric + CloudWatch alarm is the long-term
+    guard against the self-healing mechanism silently regressing.
+    """
+    try:
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Predictor",
+            MetricData=[{
+                "MetricName": "unscored_buy_candidates_count",
+                "Value": float(count),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:  # noqa: BLE001 — observability, must never block trading path
+        logger.warning("CloudWatch metric emission failed: %s", exc)
+
+
+def assert_predictions_cover_buy_candidates(
+    signals: dict,
+    predictions_by_ticker: dict,
+) -> None:
+    """Verify every buy_candidate has a prediction row. Raise on gap.
+
+    Always emits the `unscored_buy_candidates_count` CloudWatch metric (even
+    with value 0) so alarm baselines are continuous.
+    """
+    buy = signals.get("buy_candidates") or []
+    buy_tickers = {
+        (e.get("ticker") or "").upper()
+        for e in buy if isinstance(e, dict) and e.get("ticker")
+    }
+    pred_tickers = {
+        (t or "").upper() for t in (predictions_by_ticker or {}).keys()
+    }
+    missing = sorted(buy_tickers - pred_tickers)
+    _emit_unscored_count_metric(len(missing))
+    if missing:
+        raise UnscoredBuyCandidatesError(
+            missing=missing,
+            n_buy=len(buy_tickers),
+            n_preds=len(pred_tickers),
+        )
+
+
 def get_actionable_signals(signals: dict) -> dict:
     """
     Filter signals to actionable entries by signal type.

--- a/tests/test_signal_reader_coverage.py
+++ b/tests/test_signal_reader_coverage.py
@@ -1,0 +1,123 @@
+"""Unit tests for executor.signal_reader coverage guard.
+
+Guards against the Research↔Predictor coverage gap first observed 2026-04-20.
+The guard refuses to size positions when buy_candidates has tickers missing
+from predictions.json — otherwise the GBM veto gate is unreachable for those
+tickers, routing position sizing around a risk control.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor.signal_reader import (
+    UnscoredBuyCandidatesError,
+    assert_predictions_cover_buy_candidates,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+def _signals(buy_tickers: list[str]) -> dict:
+    return {
+        "date": "2026-04-20",
+        "buy_candidates": [{"ticker": t, "signal": "ENTER"} for t in buy_tickers],
+        "universe": [{"ticker": t, "signal": "ENTER"} for t in buy_tickers],
+    }
+
+
+def _preds(pred_tickers: list[str]) -> dict:
+    return {t: {"ticker": t, "predicted_alpha": 0.01} for t in pred_tickers}
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+@patch("executor.signal_reader.boto3")
+def test_passes_when_all_buy_candidates_scored(mock_boto3):
+    signals = _signals(["AAPL", "MSFT"])
+    preds = _preds(["AAPL", "MSFT"])
+    # Should not raise
+    assert_predictions_cover_buy_candidates(signals, preds)
+    # Metric emitted with value 0 (continuous baseline)
+    mock_boto3.client.return_value.put_metric_data.assert_called_once()
+    call = mock_boto3.client.return_value.put_metric_data.call_args
+    assert call.kwargs["MetricData"][0]["Value"] == 0.0
+
+
+@patch("executor.signal_reader.boto3")
+def test_passes_when_predictions_is_superset(mock_boto3):
+    # Executor may have extra predictions (e.g. from a prior run's universe);
+    # only buy_candidate ⊆ predictions matters.
+    signals = _signals(["AAPL"])
+    preds = _preds(["AAPL", "MSFT", "GOOG"])
+    assert_predictions_cover_buy_candidates(signals, preds)
+
+
+@patch("executor.signal_reader.boto3")
+def test_empty_buy_candidates_is_no_op(mock_boto3):
+    signals = _signals([])
+    preds = _preds(["AAPL"])
+    assert_predictions_cover_buy_candidates(signals, preds)
+
+
+# ── Failure paths ────────────────────────────────────────────────────────────
+
+@patch("executor.signal_reader.boto3")
+def test_raises_with_missing_tickers_in_message(mock_boto3):
+    # Today's bug reproduced: 4 buy_candidates missing from predictions.
+    signals = _signals(["AAPL", "SNDK", "WDC", "BIIB", "XEL", "CTAS"])
+    preds = _preds(["AAPL", "CTAS"])
+    with pytest.raises(UnscoredBuyCandidatesError) as exc:
+        assert_predictions_cover_buy_candidates(signals, preds)
+    msg = str(exc.value)
+    assert "SNDK" in msg and "WDC" in msg and "BIIB" in msg and "XEL" in msg
+    assert "4" in msg  # count of missing
+    assert exc.value.missing == ["BIIB", "SNDK", "WDC", "XEL"]  # sorted
+    assert exc.value.n_buy == 6
+    assert exc.value.n_preds == 2
+
+
+@patch("executor.signal_reader.boto3")
+def test_metric_emitted_even_when_raising(mock_boto3):
+    signals = _signals(["AAPL", "SNDK"])
+    preds = _preds(["AAPL"])
+    with pytest.raises(UnscoredBuyCandidatesError):
+        assert_predictions_cover_buy_candidates(signals, preds)
+    # Metric must still be emitted before the raise (alarm relies on it)
+    mock_boto3.client.return_value.put_metric_data.assert_called_once()
+    call = mock_boto3.client.return_value.put_metric_data.call_args
+    assert call.kwargs["MetricData"][0]["Value"] == 1.0
+    assert call.kwargs["Namespace"] == "AlphaEngine/Predictor"
+
+
+@patch("executor.signal_reader.boto3")
+def test_case_insensitive_ticker_comparison(mock_boto3):
+    signals = {
+        "buy_candidates": [{"ticker": "aapl"}, {"ticker": "MSFT"}],
+        "universe": [],
+    }
+    preds = {"AAPL": {"predicted_alpha": 0.01}, "msft": {"predicted_alpha": 0.02}}
+    # Both should match despite case differences
+    assert_predictions_cover_buy_candidates(signals, preds)
+
+
+# ── Observability is best-effort ─────────────────────────────────────────────
+
+@patch("executor.signal_reader.boto3")
+def test_metric_emission_failure_does_not_block_success(mock_boto3):
+    # CloudWatch put_metric_data can fail (IAM, network) — must never block
+    # the executor's trading path.
+    mock_boto3.client.return_value.put_metric_data.side_effect = Exception("cw down")
+    signals = _signals(["AAPL"])
+    preds = _preds(["AAPL"])
+    # Happy path still succeeds despite CloudWatch failure
+    assert_predictions_cover_buy_candidates(signals, preds)
+
+
+@patch("executor.signal_reader.boto3")
+def test_metric_emission_failure_does_not_mask_hard_fail(mock_boto3):
+    mock_boto3.client.return_value.put_metric_data.side_effect = Exception("cw down")
+    signals = _signals(["AAPL", "SNDK"])
+    preds = _preds(["AAPL"])
+    # Coverage gap still raises even though CloudWatch failed
+    with pytest.raises(UnscoredBuyCandidatesError):
+        assert_predictions_cover_buy_candidates(signals, preds)


### PR DESCRIPTION
**Phase 3 of the Research↔Predictor coverage-gap closure.** Depends on alpha-engine-predictor PR #42 (Phase 1) for end-to-end self-healing, but the executor-side guard fires today on its own.

## Summary
- New `UnscoredBuyCandidatesError` raised by `signal_reader` when `buy_candidates ⊄ predictions`.
- New `assert_predictions_cover_buy_candidates()` helper called from `main._read_and_validate_signals` before sizing.
- CloudWatch metric `AlphaEngine/Predictor/unscored_buy_candidates_count` emitted every run (0 on success, >0 on gap). Continuous baseline for the Phase 4 alarm.
- 8 new tests, 272/272 full suite passes.

## Why
2026-04-20 daemon bought SNDK/WDC/BIIB/XEL at market open despite none being in predictions.json (21 predictions vs 28 buy_candidates). 4 of 5 live entries (~80% of capital) bypassed the GBM veto gate. Today this PR alone would have halted the executor with a clear error instead of routing around the risk control.

## Test plan
- [x] 272/272 unit tests pass
- [x] 8 new tests for the guard (happy path, hard-fail, case-insensitive, CW failure isolation, metric emission on both paths)
- [ ] End-to-end smoke: run executor dry-run against current signals.json — will pass today (Research and Predictor are now in sync post-#41/#42 rollout)

## Follow-ups in this PR chain
- **Phase 2** (alpha-engine-data): Step Function Choice state + re-invoke task. Once Phase 2 lands, this guard becomes the defense-in-depth backstop rather than the primary halt mechanism.
- **Phase 4** (infra): CloudWatch alarm on `unscored_buy_candidates_count > 0` over any 1h window → existing `alpha-engine-saturday-sf-failed` SNS topic (or dedicated).

## Status
**Draft.** Safe to merge alone — today signals.json and predictions.json are in sync, so the guard passes silently with metric = 0. Promote out of draft once Phase 2 (Step Function) ships; they should roll out together to avoid a window where the executor halts but the SF doesn't self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)