### PR TITLE
fix(config): drop risk.yaml.example from executor search path — hard-fail on miss

### DIFF
--- a/executor/config_loader.py
+++ b/executor/config_loader.py
@@ -13,6 +13,15 @@ Search order (example template NOT a fallback — copyable only):
   1. ~/alpha-engine-config/executor/risk.yaml  (EC2 — config repo cloned at home)
   2. {repo_root}/../alpha-engine-config/executor/risk.yaml  (local dev — sibling directory)
   3. {repo_root}/config/risk.yaml  (legacy fallback)
+
+Path resolution is deliberately LAZY — consumers call ``get_config_path()``
+or ``load_config()`` at runtime, not at import time. An import-time
+``CONFIG_PATH = get_config_path()`` would hard-fail any test, CI runner,
+or tooling that merely imports executor without needing to read config.
+The old module-level constant was only safe because the removed .example
+fallback guaranteed resolution — that's exactly the silent-fallthrough
+trap this PR closes. Callers that used to import ``CONFIG_PATH`` now
+import ``get_config_path`` and resolve inline.
 """
 
 import os
@@ -50,10 +59,7 @@ def get_config_path() -> str:
     )
 
 
-CONFIG_PATH = get_config_path()
-
-
 def load_config() -> dict:
-    """Load and return the risk.yaml config dict."""
-    with open(CONFIG_PATH) as f:
+    """Load and return the risk.yaml config dict. Resolves the path lazily."""
+    with open(get_config_path()) as f:
         return yaml.safe_load(f)

--- a/executor/config_loader.py
+++ b/executor/config_loader.py
@@ -1,13 +1,22 @@
 """
-Resolve and load risk.yaml from the private config repo or local fallback.
+Resolve and load risk.yaml from the private config repo or legacy local
+fallback. The example template is NEVER a valid fallback — it ships
+placeholder bucket names (``"your-research-bucket-name"``) that would
+silently point downstream consumers at nonexistent S3 buckets. Hit
+2026-04-20 via the backtester spot path: missing risk.yaml → this
+loader fell through to the example → executor built an ArcticDB URI
+against the placeholder bucket → 404 surfaced as a cryptic
+``KeyNotFoundException: Not found: [C:universe]`` ~100 lines deep in
+the executor-sim call chain.
 
-Search order:
+Search order (example template NOT a fallback — copyable only):
   1. ~/alpha-engine-config/executor/risk.yaml  (EC2 — config repo cloned at home)
   2. {repo_root}/../alpha-engine-config/executor/risk.yaml  (local dev — sibling directory)
   3. {repo_root}/config/risk.yaml  (legacy fallback)
 """
 
 import os
+
 import yaml
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
@@ -16,18 +25,28 @@ _SEARCH_PATHS = [
     os.path.expanduser("~/alpha-engine-config/executor/risk.yaml"),
     os.path.join(_REPO_ROOT, "..", "alpha-engine-config", "executor", "risk.yaml"),
     os.path.join(_REPO_ROOT, "config", "risk.yaml"),
-    os.path.join(_REPO_ROOT, "config", "risk.yaml.example"),
 ]
 
 
 def get_config_path() -> str:
-    """Return the first existing risk.yaml path."""
+    """Return the first existing risk.yaml path.
+
+    Raises ``FileNotFoundError`` with every candidate named if none
+    exist. The example template at ``config/risk.yaml.example`` is NOT
+    a candidate — copy it to ``config/risk.yaml`` and fill in real
+    values for the intended environment.
+    """
     for p in _SEARCH_PATHS:
         resolved = os.path.realpath(p)
         if os.path.isfile(resolved):
             return resolved
     raise FileNotFoundError(
-        f"risk.yaml not found in any of: {_SEARCH_PATHS}"
+        "executor risk.yaml not found in any of:\n  "
+        + "\n  ".join(_SEARCH_PATHS)
+        + "\nCopy config/risk.yaml.example → config/risk.yaml and fill in real "
+          "values, or clone alpha-engine-config so the config-repo paths resolve. "
+          "The .example template is intentionally NOT searched — it ships "
+          "placeholder bucket names that silently break downstream ArcticDB + S3 reads."
     )
 
 

--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -61,7 +61,7 @@ logger = logging.getLogger(__name__)
 #   "status" — IB order execution status: "Filled", "Rejected", "Timeout", etc.
 #   "signal" — trading action type from Research/strategy: "ENTER", "EXIT", "REDUCE", "COVER"
 
-from executor.config_loader import CONFIG_PATH
+from executor.config_loader import get_config_path
 
 # Order retry policy — applied uniformly to all order types (urgent exits, intraday exits, entries)
 MAX_ORDER_RETRIES = 3
@@ -221,7 +221,7 @@ def _place_order_with_retry(
 
 
 def load_config() -> dict:
-    with open(CONFIG_PATH) as f:
+    with open(get_config_path()) as f:
         return yaml.safe_load(f)
 
 

--- a/executor/emergency_shutdown.py
+++ b/executor/emergency_shutdown.py
@@ -31,7 +31,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from executor.config_loader import CONFIG_PATH, load_config as _load_config
+from executor.config_loader import load_config as _load_config
 
 
 def emergency_shutdown(execute: bool, stop_instance: bool) -> None:

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -36,7 +36,7 @@ _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath
 setup_logging("eod", flow_doctor_yaml=_FLOW_DOCTOR_YAML, exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS)
 logger = logging.getLogger(__name__)
 
-from executor.config_loader import CONFIG_PATH
+from executor.config_loader import load_config
 
 
 def _spy_close(run_date: str, config: dict | None = None) -> float:
@@ -305,8 +305,7 @@ def run(run_date: str | None = None) -> None:
     _health_start = _time.time()
     logger.info(f"EOD reconciliation | date={run_date}")
 
-    with open(CONFIG_PATH) as f:
-        config = yaml.safe_load(f)
+    config = load_config()
 
     db_path = config["db_path"]
     trades_bucket = config["trades_bucket"]

--- a/executor/liquidate_all.py
+++ b/executor/liquidate_all.py
@@ -30,7 +30,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-from executor.config_loader import CONFIG_PATH, load_config
+from executor.config_loader import load_config
 
 
 def liquidate(execute: bool, skip_confirm: bool) -> None:

--- a/executor/main.py
+++ b/executor/main.py
@@ -62,7 +62,7 @@ _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath
 setup_logging("main", flow_doctor_yaml=_FLOW_DOCTOR_YAML, exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS)
 logger = logging.getLogger(__name__)
 
-from executor.config_loader import CONFIG_PATH
+from executor.config_loader import get_config_path
 
 # S3-delivered executor params (loaded once per cold-start)
 _executor_params_cache: dict | None = None
@@ -210,7 +210,7 @@ def _merge_s3_params(config: dict, s3_params: dict) -> dict[str, Any]:
 
 
 def load_config() -> dict:
-    with open(CONFIG_PATH) as f:
+    with open(get_config_path()) as f:
         return yaml.safe_load(f)
 
 


### PR DESCRIPTION
## Summary

`executor/config_loader.py` included `config/risk.yaml.example` as its 4th search-path candidate. When real configs were missing, the loader silently fell through to the example — which ships placeholder bucket names like `"your-research-bucket-name"`. Any downstream S3/ArcticDB read against those placeholders fails cryptically far from the root cause.

## The incident

Hit 2026-04-20 via the alpha-engine-backtester spot path during the partial-execution SF dry-run:

1. ae-dashboard's `~/alpha-engine/config/risk.yaml` missing (moved during the 2026-04-07 config-repo split)
2. `spot_backtest.sh` couldn't SCP it, logged a WARNING, proceeded anyway
3. Spot cloned alpha-engine — `risk.yaml.example` is in the repo
4. Executor's `config_loader.py` fell through to the `.example` on the spot
5. `signals_bucket = "your-research-bucket-name"` on the spot's executor
6. Executor built an ArcticDB URI against the nonexistent bucket
7. S3 returned 404 with no body → arcticdb surfaced as `KeyNotFoundException: Not found: [C:universe]` ~100 lines deep in the executor-sim call chain

Took a full SSM-level investigation to unwind. `spot_backtest.sh` got its own fix in alpha-engine-backtester#39 (real config-repo path + hard-fail on miss), but this loader is the architecturally correct place to stop the silent fallthrough for every caller.

## Design rule

**Example files should never be included in prod search paths.** The `.example` stays in the repo as a copyable template — never a runtime fallback. Any caller missing a real risk.yaml must hard-fail with a named error at import time so the diagnosis is instantaneous instead of a stack-trace safari.

## Diff

```diff
 _SEARCH_PATHS = [
     os.path.expanduser("~/alpha-engine-config/executor/risk.yaml"),
     os.path.join(_REPO_ROOT, "..", "alpha-engine-config", "executor", "risk.yaml"),
     os.path.join(_REPO_ROOT, "config", "risk.yaml"),
-    os.path.join(_REPO_ROOT, "config", "risk.yaml.example"),
 ]
```

Error message now names every path tried AND explicitly tells the reader the `.example` is intentionally not searched, with guidance on how to populate a real risk.yaml.

## Verification

- Existing test suite green (272 passed)
- Local import resolves correctly to `~/Development/alpha-engine-config/executor/risk.yaml` (sibling-of-repo-root path)
- Hard-fail path produces the new explicit error in a worktree without the config repo

## Test plan

- [x] pytest suite green
- [x] Local python -c import + load verifies real path resolution
- [x] Worktree-without-config-repo verifies hard-fail message
- [ ] Next backtester spot run via SF exercises the executor config load path — combined with backtester #39, expected flow: real risk.yaml SCP'd → config_loader finds it → signals_bucket = "alpha-engine-research" → ArcticDB works.

## Composes with

- alpha-engine-backtester#39 — fixes `spot_backtest.sh` to SCP from the real config-repo path + hard-fail if absent. This PR is the caller-side safety net.
- Follow-up PR in alpha-engine-backtester adds a `BacktesterPreflight` check that validates executor config for placeholder values — defense in depth, not load-bearing after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)