### PR TITLE
feat(executor): defense-in-depth universe filter on buy_candidates

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -248,6 +248,14 @@ def _read_signals(
                 conn.close()
             raise
 
+    # Defense-in-depth universe filter — drop buy_candidates whose tickers
+    # aren't in the ArcticDB universe library. Research's population_selector
+    # (alpha-engine-research#41) is the primary guardrail; this catches
+    # anything that slipped past (manual edits, Research bug, universe-drift
+    # window). See filter_buy_candidates_to_universe for scope + rationale.
+    from executor.signal_reader import filter_buy_candidates_to_universe
+    signals_raw = filter_buy_candidates_to_universe(signals_raw, signals_bucket)
+
     signals = get_actionable_signals(signals_raw)
 
     # Alert if signals are stale (research didn't run recently)

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -149,6 +149,82 @@ def _warn_if_stale(signals_date: str | None, run_date: str | None) -> None:
         )
 
 
+def filter_buy_candidates_to_universe(
+    signals: dict,
+    signals_bucket: str,
+) -> dict:
+    """Drop buy_candidates whose tickers aren't in the ArcticDB universe library.
+
+    Defense-in-depth layer. Research's ``population_selector.
+    compute_exits_and_open_slots`` (alpha-engine-research#41) is the
+    primary universe guardrail — it drops non-S&P incumbents at the
+    exit-evaluator stage. This function is the caller-side net: if a
+    ticker somehow sneaks past (manual signals.json edit, a Research
+    bug, a universe-drift window where DataPhase1 hasn't repopulated
+    the ArcticDB library yet), dropping here prevents sizing positions
+    against data that doesn't exist.
+
+    Scope: ``buy_candidates`` only. The ``universe`` list (EXIT/REDUCE/
+    HOLD for existing holdings) is left unfiltered — if we somehow
+    hold a position outside the universe we still need to exit it,
+    and per-ticker ArcticDB reads for ATR/VWAP on those will surface
+    as clear named errors downstream if they fail.
+
+    If the ArcticDB read itself fails (library unreachable, IAM miss),
+    the filter is skipped with a WARNING — better to let the
+    executor's own ArcticDB reads surface that as their own, clearer
+    error than to block on a defense-in-depth layer.
+
+    Origin: 2026-04-20 — TSM + ASML persisted as population incumbents
+    despite being absent from constituents.json; manifested as
+    ``NoSuchVersionException`` deep in executor-sim replay.
+    """
+    buy = signals.get("buy_candidates") or []
+    if not buy:
+        return signals
+
+    try:
+        # Local import — avoids top-level circular (price_cache imports
+        # executor.market_hours which touches signal_reader indirectly).
+        from executor.price_cache import _open_universe_library
+        universe_lib = _open_universe_library(signals_bucket)
+        universe_symbols = set(universe_lib.list_symbols())
+    except Exception as exc:  # noqa: BLE001 — see docstring
+        logger.warning(
+            "Skipping buy-candidate universe filter — could not open ArcticDB "
+            "universe library: %s. Executor's direct ArcticDB reads will surface "
+            "any data issues as their own named errors downstream.",
+            exc,
+        )
+        return signals
+
+    allowed: list[dict] = []
+    dropped: list[str] = []
+    for entry in buy:
+        ticker = entry.get("ticker") if isinstance(entry, dict) else None
+        if ticker and ticker in universe_symbols:
+            allowed.append(entry)
+        elif ticker:
+            dropped.append(ticker)
+
+    if dropped:
+        logger.warning(
+            "[signal_reader] dropped %d buy_candidate(s) not in ArcticDB "
+            "universe: %s. Research's population_selector (alpha-engine-"
+            "research#41) should have caught these — the fact that they "
+            "reached here means one of: (a) Research bug, (b) manual edit "
+            "to signals.json, (c) universe-library drift window. Not hard-"
+            "failing because the remaining %d buy_candidate(s) are valid.",
+            len(dropped),
+            dropped,
+            len(allowed),
+        )
+        signals = dict(signals)  # shallow copy to avoid mutating caller's dict
+        signals["buy_candidates"] = allowed
+
+    return signals
+
+
 class UnscoredBuyCandidatesError(RuntimeError):
     """Raised when signals.json has buy_candidates that are missing from
     predictions.json — the GBM veto gate is structurally unreachable for

--- a/tests/test_signal_reader_universe_filter.py
+++ b/tests/test_signal_reader_universe_filter.py
@@ -1,0 +1,155 @@
+"""
+Tests for filter_buy_candidates_to_universe — the executor-side
+defense-in-depth guardrail that drops buy_candidates whose tickers
+aren't in the ArcticDB universe library.
+
+Origin: 2026-04-20 — Research emitted buy/enter signals for TSM +
+ASML despite those tickers being absent from every constituents.json
+and from the ArcticDB universe library. Research's Layer-1 fix
+(alpha-engine-research#41) stops the leak at source; this is the
+caller-side net that catches any future leak or manual signals.json
+edit that slips past.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from executor.signal_reader import filter_buy_candidates_to_universe
+
+
+def _fake_universe(symbols: list[str]) -> MagicMock:
+    """Build a MagicMock that mimics an ArcticDB library with list_symbols."""
+    lib = MagicMock()
+    lib.list_symbols.return_value = list(symbols)
+    return lib
+
+
+class TestFilterBuyCandidatesToUniverse:
+    def test_drops_ticker_not_in_universe(self):
+        signals = {
+            "buy_candidates": [
+                {"ticker": "AAPL", "signal": "ENTER"},
+                {"ticker": "TSM", "signal": "ENTER"},
+                {"ticker": "MSFT", "signal": "ENTER"},
+            ],
+            "universe": [{"ticker": "AAPL", "signal": "HOLD"}],
+        }
+        fake_lib = _fake_universe(["AAPL", "MSFT", "GOOG"])
+        with patch(
+            "executor.price_cache._open_universe_library",
+            return_value=fake_lib,
+        ):
+            result = filter_buy_candidates_to_universe(signals, "alpha-engine-research")
+
+        tickers = [b["ticker"] for b in result["buy_candidates"]]
+        assert "TSM" not in tickers
+        assert tickers == ["AAPL", "MSFT"]
+
+    def test_universe_list_unchanged(self):
+        """EXIT/REDUCE/HOLD for existing holdings are not filtered."""
+        signals = {
+            "buy_candidates": [{"ticker": "TSM", "signal": "ENTER"}],
+            "universe": [{"ticker": "TSM", "signal": "HOLD"}],  # existing holding
+        }
+        fake_lib = _fake_universe(["AAPL"])  # TSM absent
+        with patch(
+            "executor.price_cache._open_universe_library",
+            return_value=fake_lib,
+        ):
+            result = filter_buy_candidates_to_universe(signals, "alpha-engine-research")
+
+        assert result["buy_candidates"] == []  # dropped
+        # universe list untouched — executor can still process EXIT/HOLD
+        # for held positions, and per-ticker ArcticDB failures downstream
+        # will surface as their own named errors.
+        assert result["universe"] == [{"ticker": "TSM", "signal": "HOLD"}]
+
+    def test_empty_buy_candidates_skips_check(self):
+        """No buy_candidates → no ArcticDB call, identity return."""
+        signals = {"buy_candidates": [], "universe": [{"ticker": "AAPL"}]}
+        with patch(
+            "executor.price_cache._open_universe_library"
+        ) as open_lib:
+            result = filter_buy_candidates_to_universe(signals, "x")
+        open_lib.assert_not_called()
+        assert result is signals  # identity
+
+    def test_missing_buy_candidates_key_skips_check(self):
+        """signals.json without a buy_candidates key → identity return."""
+        signals = {"universe": [{"ticker": "AAPL"}]}
+        with patch(
+            "executor.price_cache._open_universe_library"
+        ) as open_lib:
+            result = filter_buy_candidates_to_universe(signals, "x")
+        open_lib.assert_not_called()
+        assert result is signals
+
+    def test_all_tickers_in_universe_returns_input_unchanged(self):
+        signals = {
+            "buy_candidates": [
+                {"ticker": "AAPL", "signal": "ENTER"},
+                {"ticker": "MSFT", "signal": "ENTER"},
+            ],
+        }
+        fake_lib = _fake_universe(["AAPL", "MSFT", "GOOG"])
+        with patch(
+            "executor.price_cache._open_universe_library",
+            return_value=fake_lib,
+        ):
+            result = filter_buy_candidates_to_universe(signals, "x")
+        # No drops, no mutation
+        assert [b["ticker"] for b in result["buy_candidates"]] == ["AAPL", "MSFT"]
+
+    def test_arcticdb_error_skips_filter_logs_warning(self, caplog):
+        """If ArcticDB is unreachable, skip the filter — don't block trading."""
+        signals = {"buy_candidates": [{"ticker": "TSM"}, {"ticker": "AAPL"}]}
+        with patch(
+            "executor.price_cache._open_universe_library",
+            side_effect=RuntimeError("S3 unreachable"),
+        ):
+            import logging
+            with caplog.at_level(logging.WARNING):
+                result = filter_buy_candidates_to_universe(signals, "x")
+        # Filter skipped — all entries pass through
+        assert [b["ticker"] for b in result["buy_candidates"]] == ["TSM", "AAPL"]
+        assert any(
+            "Skipping buy-candidate universe filter" in r.message
+            for r in caplog.records
+        )
+
+    def test_entry_without_ticker_key_ignored_gracefully(self):
+        """Malformed entry with no ticker field → dropped silently."""
+        signals = {
+            "buy_candidates": [
+                {"ticker": "AAPL", "signal": "ENTER"},
+                {"signal": "ENTER"},  # no ticker
+                {"ticker": "TSM", "signal": "ENTER"},
+            ]
+        }
+        fake_lib = _fake_universe(["AAPL"])
+        with patch(
+            "executor.price_cache._open_universe_library",
+            return_value=fake_lib,
+        ):
+            result = filter_buy_candidates_to_universe(signals, "x")
+        # AAPL kept, TSM dropped, malformed entry dropped
+        assert [b["ticker"] for b in result["buy_candidates"]] == ["AAPL"]
+
+    def test_caller_dict_not_mutated(self):
+        """filter returns shallow copy when changes made — doesn't mutate input."""
+        signals = {
+            "buy_candidates": [
+                {"ticker": "AAPL", "signal": "ENTER"},
+                {"ticker": "TSM", "signal": "ENTER"},
+            ],
+        }
+        original_candidates = list(signals["buy_candidates"])
+        fake_lib = _fake_universe(["AAPL"])
+        with patch(
+            "executor.price_cache._open_universe_library",
+            return_value=fake_lib,
+        ):
+            _ = filter_buy_candidates_to_universe(signals, "x")
+        # Caller's dict unchanged
+        assert signals["buy_candidates"] == original_candidates


### PR DESCRIPTION
## Summary

Layer 2 of the two-layer fix for the out-of-universe ticker bug. Layer 1 (alpha-engine-research#41) stops the leak at source by dropping grandfathered non-S&P incumbents at the Research exit-evaluator stage. This PR is the caller-side defense in depth: drop `buy_candidates` whose tickers aren't in the ArcticDB universe library before the executor sizes positions.

## Bug context (2026-04-20)

TSM + ASML persisted as Research population incumbents despite being absent from every `constituents.json` and from the ArcticDB universe library (912 symbols = S&P 500+400 + a few index ETFs). Post-Phase-7a executor ArcticDB rip-and-replace (alpha-engine#60, 2026-04-17) removed the silent-skip paths that had masked this for weeks. Partial-execution SF dry-run today surfaced it as `KeyNotFoundException` / `NoSuchVersionException` ~100 lines deep in simulate-mode replay.

## Scope

- Filters `buy_candidates` only.
- `universe` list (EXIT/REDUCE/HOLD for existing holdings) left unfiltered — if we somehow hold a position outside the universe we still need to exit it, and per-ticker ArcticDB reads for ATR/VWAP on those will surface as clear named errors downstream if they fail. Narrow scope keeps this from being a shotgun mute.
- If the ArcticDB read itself fails (library unreachable, IAM miss), the filter is skipped with a WARNING — better to let the executor's own ArcticDB reads surface that as clearer errors than to block on a defense-in-depth layer.

## Wire point

`executor/main.py::_read_signals` — runs immediately after signal read (both live + simulate paths), before `get_actionable_signals`. Applies to both the real executor run and the backtester's `executor_run(simulate=True)` call.

## Tests

8 new tests (`tests/test_signal_reader_universe_filter.py`):
- drops ticker not in universe
- universe list (held positions) unchanged
- empty / missing `buy_candidates` skips the ArcticDB call
- all-in-universe case is a no-op
- ArcticDB error skips filter with WARNING (defense doesn't block trading)
- malformed entries without ticker key dropped gracefully
- caller dict not mutated (shallow copy on change)

**280/280 suite passes (was 272; +8 new).**

## Layered defense summary

| Layer | Repo | File | Behavior |
|---|---|---|---|
| 1 — primary | alpha-engine-research | `data/population_selector.py` | `UNIVERSE_DROP` exit event at the exit-evaluator stage; non-S&P incumbents removed from Research's tracked population |
| 2 — defense in depth (this PR) | alpha-engine | `executor/signal_reader.py` | `buy_candidates` filtered at read time; catches anything that slipped past Layer 1 |

## Test plan

- [x] pytest suite green
- [ ] Next backtester spot run in SF — expected: TSM+ASML absent from signals.json (Layer 1 blocks them) OR if they appear, filter here drops them without crashing the simulate loop
- [ ] First real Saturday run post-merge logs UNIVERSE_DROP events for TSM+ASML in Research and zero drops in executor (since Layer 1 handled them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)