### PR TITLE
chore(deps): bump alpha-engine-lib pin v0.1.3 → v0.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ requests~=2.32
 #   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
 #   EC2: ~/.netrc covers github.com with a PAT that has Contents:read
 #        on alpha-engine-lib (confirm via git ls-remote before deploy).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.3
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.4


### PR DESCRIPTION
Keeps executor's lib pin in sync with backtester (v0.1.4) + predictor (v0.1.4 via its own matching bump PR). Pin-matrix drift across the three repos that backtester's spot clones caused the 2026-04-21 Saturday SF dry-run 80-minute burn: mixed pins across requirements.txt files led to the later install (v0.1.3) downgrading the earlier one (v0.1.4) in shared site-packages.

v0.1.4 is additive — adds alpha_engine_lib.arcticdb; no API removals or behavior changes. Executor doesn't (yet) import the new module; the roadmap P2 "migrate 6 ArcticDB sites to alpha_engine_lib.arcticdb" item will have executor.price_cache::_open_universe_library delegate to the lib helper later.