### PR TITLE
fix(infra): boot-pull reconciles timer enable state on every boot

### DIFF
--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -139,7 +139,6 @@ fi
 SYSTEMD_SRC="/home/ec2-user/alpha-engine/infrastructure/systemd"
 if [ -d "$SYSTEMD_SRC" ]; then
     CHANGED=false
-    NEW_TIMERS=()
     for unit in "$SYSTEMD_SRC"/*.service "$SYSTEMD_SRC"/*.timer; do
         [ -f "$unit" ] || continue
         name=$(basename "$unit")
@@ -148,7 +147,6 @@ if [ -d "$SYSTEMD_SRC" ]; then
             sudo cp "$unit" /etc/systemd/system/
             log "OK   systemd: installed $name (new)"
             CHANGED=true
-            [[ "$name" == *.timer ]] && NEW_TIMERS+=("$name")
         elif ! diff -q "$unit" "$target" >/dev/null 2>&1; then
             sudo cp "$unit" /etc/systemd/system/
             log "OK   systemd: updated $name"
@@ -158,14 +156,40 @@ if [ -d "$SYSTEMD_SRC" ]; then
     if $CHANGED; then
         sudo systemctl daemon-reload
         log "OK   systemd: daemon-reload"
-        for timer in "${NEW_TIMERS[@]}"; do
-            if sudo systemctl enable --now "$timer" >> "$LOG" 2>&1; then
-                log "OK   systemd: enabled + started $timer"
-            else
-                log "WARN systemd: failed to enable $timer"
-            fi
-        done
     fi
+
+    # Reconcile timer enable state. Every timer shipped in the repo
+    # MUST be enabled. `systemctl enable` is idempotent on already-
+    # enabled timers, and recreates the `timers.target.wants/` symlink
+    # on any timer that was disabled or whose symlink was lost. Fixes
+    # three failure modes the prior new-install-only enable path could
+    # not recover from:
+    #
+    # 1. Manual `systemctl disable` (intentional debugging, accidental).
+    # 2. EBS volume state where unit files exist on disk but
+    #    `timers.target.wants/` is empty.
+    # 3. New timers added to `infrastructure/systemd/` after the
+    #    one-shot `setup-trading-ec2.sh` run already completed — they
+    #    get `cp`'d by boot-pull but the previous "enable only on first
+    #    install" branch missed them because the target file already
+    #    existed.
+    #
+    # 2026-04-21 SNDK EOD incident: `alpha-engine-eod.timer` was
+    # disabled for an unknown reason. boot-pull's previous logic only
+    # enabled timers inside the `[ ! -f "$target" ]` branch, so the
+    # disabled state persisted for two boots. EOD emails silently
+    # stopped firing until manual SSM intervention re-enabled the
+    # timer. This reconciliation pass makes every boot self-healing
+    # for timer-enable drift.
+    for unit in "$SYSTEMD_SRC"/*.timer; do
+        [ -f "$unit" ] || continue
+        name=$(basename "$unit")
+        if sudo systemctl enable --now "$name" >> "$LOG" 2>&1; then
+            log "OK   systemd: enable reconciled $name"
+        else
+            log "WARN systemd: enable reconcile failed: $name"
+        fi
+    done
 fi
 
 # Config files are now in the alpha-engine-config private repo (pulled above).

--- a/tests/test_boot_pull_timer_reconcile.py
+++ b/tests/test_boot_pull_timer_reconcile.py
@@ -1,0 +1,67 @@
+"""Regression: boot-pull.sh must enable every shipped timer on every boot.
+
+2026-04-21 SNDK EOD incident: `alpha-engine-eod.timer` was disabled on
+the trading instance for an unknown reason. boot-pull.sh's old logic
+only ran `systemctl enable` inside the "new install" branch (`[ ! -f
+"$target" ]`), so a unit file that existed on disk but was disabled
+could never be re-enabled. EOD emails silently stopped firing for two
+boots until manual SSM intervention.
+
+The fix is a reconciliation pass that `systemctl enable`s every
+`*.timer` shipped in `infrastructure/systemd/` on every boot.
+`systemctl enable` is idempotent on already-enabled timers, and
+restores the `timers.target.wants/` symlink on disabled-but-present
+timers. Covers manual disables, EBS volume state drift, and
+post-setup additions of new timer units.
+
+These tests lock the reconciliation so a future well-intentioned
+refactor doesn't re-introduce the enable-only-on-new-install bug.
+"""
+
+from pathlib import Path
+
+
+_BOOT_PULL = Path(__file__).parent.parent / "infrastructure" / "boot-pull.sh"
+
+
+def _source() -> str:
+    return _BOOT_PULL.read_text()
+
+
+def test_boot_pull_exists():
+    assert _BOOT_PULL.exists(), f"boot-pull.sh missing at {_BOOT_PULL}"
+
+
+def test_reconcile_loop_enables_every_timer():
+    """Must iterate every *.timer and call `systemctl enable` on each."""
+    src = _source()
+    # The reconciliation loop signature: a for-loop over *.timer files
+    # that calls systemctl enable on each.
+    assert 'for unit in "$SYSTEMD_SRC"/*.timer' in src, (
+        "boot-pull.sh must have a dedicated loop over *.timer for the "
+        "reconciliation pass — not just the combined service+timer "
+        "install loop. Every boot must re-assert enable state on every "
+        "shipped timer."
+    )
+    assert "systemctl enable" in src, (
+        "reconcile loop must call `systemctl enable` (idempotent no-op "
+        "when already enabled; re-creates timers.target.wants symlink "
+        "when disabled)."
+    )
+
+
+def test_no_new_timers_only_enable_path():
+    """The old NEW_TIMERS-only enable path must be gone.
+
+    The 2026-04-21 bug was that `systemctl enable` only ran for timers
+    whose target file did not exist on disk (i.e. first install).
+    A disabled-but-present timer had no code path to re-enable.
+    """
+    src = _source()
+    # NEW_TIMERS tracker must be gone — the reconcile loop replaced it.
+    assert "NEW_TIMERS" not in src, (
+        "NEW_TIMERS tracker found in boot-pull.sh — this is the "
+        "'enable only on first install' bug that caused the 2026-04-21 "
+        "EOD outage. Use a reconciliation loop over every timer "
+        "shipped in infrastructure/systemd/ instead."
+    )


### PR DESCRIPTION
## Summary

Adds an idempotent reconciliation pass to \`infrastructure/boot-pull.sh\` that \`systemctl enable --now\`'s every \`*.timer\` shipped in \`infrastructure/systemd/\`. Replaces the prior "enable only on first install" path with self-healing behavior on every boot.

## Why

Root cause of the 2026-04-21 SNDK EOD incident. \`alpha-engine-eod.timer\` was disabled on ae-trading for an unknown reason. The prior boot-pull logic only enabled timers inside the \`[ ! -f "$target" ]\` branch (new install), so a disabled-but-present timer had no recovery path. EOD emails silently stopped firing for two boots until manual SSM intervention re-enabled the timer.

Failure modes the reconciliation pass now covers:

1. **Manual \`systemctl disable\`** (intentional debugging, accidental).
2. **EBS volume state** where unit files exist but \`timers.target.wants/\` is empty (volume replacement, cloned AMI).
3. **Setup-script updates** that add new timers after the one-shot \`setup-trading-ec2.sh\` already ran — the prior logic only enabled them if the target file did not exist, so post-setup additions could silently stay disabled.

\`systemctl enable\` is idempotent on already-enabled timers; on disabled-but-present timers it recreates the \`timers.target.wants/\` symlink.

## Change

\`\`\`bash
# OLD: enable only in the NEW-install branch
for unit in "$SYSTEMD_SRC"/*.service "$SYSTEMD_SRC"/*.timer; do
    if [ ! -f "$target" ]; then
        sudo cp ...
        [[ "$name" == *.timer ]] && NEW_TIMERS+=("$name")  # only these get enabled
    elif ! diff ...; then
        sudo cp ...  # updated, but NOT enabled
    fi
done
if \$CHANGED; then
    for timer in "\${NEW_TIMERS[@]}"; do
        sudo systemctl enable --now "\$timer"
    done
fi

# NEW: separate install pass + reconciliation pass
for unit in "\$SYSTEMD_SRC"/*.service "\$SYSTEMD_SRC"/*.timer; do
    # ... install / update if needed ...
done
if \$CHANGED; then
    sudo systemctl daemon-reload
fi

# Reconciliation — every shipped timer MUST be enabled every boot.
for unit in "\$SYSTEMD_SRC"/*.timer; do
    sudo systemctl enable --now "\$(basename "\$unit")"
done
\`\`\`

## Test plan

- [x] \`bash -n infrastructure/boot-pull.sh\` — syntax ok
- [x] \`pytest tests/test_boot_pull_timer_reconcile.py -v\` — 3/3 new regression tests pass (loop exists, NEW_TIMERS-only path forbidden, enable call present)
- [x] Full alpha-engine suite: 283/283 pass
- [x] Pre-push executor dry-run: ✅ Dry-run passed (validates the PR #78 fix for SNDK also ships correctly)
- [ ] Verify in production logs after next ae-trading boot: \`tail -40 /var/log/boot-pull.log\` should show \`OK   systemd: enable reconciled alpha-engine-{eod,daemon,daily-data}.timer\` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)