### PR TITLE
fix(executor): prevent short-sell from retry duplicates + auto-cover unintended shorts

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -164,11 +164,18 @@ def _validate_sell_shares(
     shares: int,
     action: str,
     context: str,
+    pending_sell_shares: int = 0,
 ) -> int | None:
-    """Validate and cap sell shares against held position.
+    """Validate and cap sell shares against held position minus in-flight sells.
 
     Returns adjusted share count, or None if the sell should be skipped
-    (no position held — selling would go short).
+    (no capacity to sell — selling would go short).
+
+    ``pending_sell_shares`` is the total un-filled SELL quantity already working
+    at the broker for this ticker. Passing it in lets us cap against
+    held - in-flight so a retry/duplicate can't cumulatively blow past the
+    position. (PFE incident 2026-04-22: three duplicate SELL 77s each passed
+    this check individually against held=155, summing to 231 → short 76.)
 
     When ``_allow_shorts`` is True (set via ``allow_shorts: true`` in
     risk.yaml), the guard is bypassed and sells are allowed to create
@@ -177,18 +184,19 @@ def _validate_sell_shares(
     if _allow_shorts:
         return shares
     held = int(positions.get(ticker, {}).get("shares", 0))
-    if held <= 0:
+    available = held - int(pending_sell_shares)
+    if available <= 0:
         logger.warning(
-            "SKIP %s %s %s: hold %d shares — selling would go short",
-            context, action, ticker, held,
+            "SKIP %s %s %s: hold %d shares, in-flight SELL %d — no capacity",
+            context, action, ticker, held, pending_sell_shares,
         )
         return None
-    if shares > held:
+    if shares > available:
         logger.warning(
-            "CAPPING %s %s %s: requested %d but hold %d — capping to avoid short",
-            context, action, ticker, shares, held,
+            "CAPPING %s %s %s: requested %d but available %d (held %d minus in-flight SELL %d)",
+            context, action, ticker, shares, available, held, pending_sell_shares,
         )
-        return held
+        return available
     return shares
 
 
@@ -204,10 +212,27 @@ def _place_order_with_retry(
     """Place a market order with retry on Rejected/Timeout.
 
     Returns the order result dict. Logs retries and final failure.
+
+    Retry rules:
+      * Rejected → real failure (Cancelled/Inactive/ApiCancelled). Retry.
+      * Timeout  → no answer from IB Gateway at all. Cancel prior orderId
+                   (best-effort) to prevent a stale duplicate, then retry.
+      * Working  → IB accepted the order and is holding it (PreSubmitted at
+                   pre-open, Submitted routing, etc.). Do NOT retry — it will
+                   fill when the hold releases. Retrying duplicates the order
+                   (PFE incident 2026-04-22).
+      * Filled / PartialFill → done.
     """
     order_result = None
     for attempt in range(MAX_ORDER_RETRIES):
         if attempt > 0:
+            prior_id = order_result.get("ib_order_id") if order_result else None
+            prior_status = order_result.get("status") if order_result else None
+            if prior_status == "Timeout" and prior_id is not None:
+                try:
+                    ibkr.cancel_order(prior_id)
+                except Exception as exc:
+                    logger.warning("cancel_order(%s) raised: %s", prior_id, exc)
             _time.sleep(ORDER_RETRY_DELAYS[attempt])
             logger.info("Retry %d/%d: %s %s", attempt + 1, MAX_ORDER_RETRIES, label, ticker)
         if use_bracket and bracket_kwargs:
@@ -218,6 +243,48 @@ def _place_order_with_retry(
         if order_result["status"] not in ("Rejected", "Timeout"):
             break
     return order_result
+
+
+def _enqueue_cover_for_unintended_shorts(
+    positions: dict,
+    order_book: "OrderBook",
+    run_date: str,
+) -> list[str]:
+    """Scan IB positions; enqueue an URGENT COVER for any short.
+
+    Runs at the top of Phase 0 when ``allow_shorts=False`` (the default).
+    Any negative position is treated as unintended — we did not knowingly
+    open it — and must be flattened immediately at market open.
+
+    Mirror of urgent_exit: emits a COVER urgent into the order book so the
+    existing Phase 0 BUY path executes it. Dedupe is handled by
+    ``OrderBook.add_urgent_exit`` (ticker+signal), so calling this twice in
+    a session is safe.
+
+    Returns the list of tickers that had an auto-cover enqueued.
+    """
+    if _allow_shorts:
+        return []
+    covered = []
+    for ticker, pos in positions.items():
+        shares = int(pos.get("shares", 0))
+        if shares >= 0:
+            continue
+        qty = abs(shares)
+        logger.error(
+            "AUTO-COVER %s: detected short position %d — enqueuing URGENT COVER %d",
+            ticker, shares, qty,
+        )
+        order_book.add_urgent_exit({
+            "ticker": ticker,
+            "signal": "COVER",
+            "shares": qty,
+            "reason": "auto_cover_unintended_short",
+            "detail": f"position={shares} at Phase 0 open; allow_shorts=False",
+            "date": run_date,
+        })
+        covered.append(ticker)
+    return covered
 
 
 def load_config() -> dict:
@@ -419,6 +486,22 @@ def run_daemon(dry_run: bool = False) -> None:
         # Fetch current positions once for short-sell prevention checks
         _phase0_positions = ibkr.get_positions() if not dry_run else {}
 
+        # Auto-cover: any short position at Phase 0 open is unintended
+        # (allow_shorts=False is the configured invariant). Enqueue URGENT
+        # COVERs into the order book before the normal loop so the existing
+        # BUY path flattens them. Covers the residue from bugs like the PFE
+        # retry-duplicate incident 2026-04-22.
+        if not dry_run:
+            auto_covered = _enqueue_cover_for_unintended_shorts(
+                _phase0_positions, order_book, run_date,
+            )
+            if auto_covered:
+                send_daemon_status(
+                    f"⚠️ *AUTO-COVER enqueued for unintended shorts*\n"
+                    f"Tickers: {', '.join(auto_covered)}"
+                )
+                order_book.save()
+
         for urgent in order_book.pending_urgent_exits():
             ticker = urgent["ticker"]
             action = urgent["signal"]  # "EXIT", "REDUCE", or "COVER"
@@ -430,8 +513,20 @@ def run_daemon(dry_run: bool = False) -> None:
                 side = "BUY"
             else:
                 side = "SELL"
-                # Short-sell prevention: cap sell shares at current held position
-                validated = _validate_sell_shares(_phase0_positions, ticker, shares, action, "URGENT")
+                # Short-sell prevention: cap sell shares at held minus in-flight.
+                # In-flight check defends against the PFE incident 2026-04-22
+                # where a retry loop issued three duplicate SELL 77s that each
+                # individually passed held=155, summing to 231 → short 76.
+                pending = 0
+                if not dry_run:
+                    try:
+                        pending = ibkr.get_open_sell_shares(ticker)
+                    except Exception as exc:
+                        logger.warning("get_open_sell_shares(%s) failed: %s — treating as 0", ticker, exc)
+                validated = _validate_sell_shares(
+                    _phase0_positions, ticker, shares, action, "URGENT",
+                    pending_sell_shares=pending,
+                )
                 if validated is None:
                     order_book.mark_urgent_executed(ticker, action)
                     continue
@@ -764,10 +859,18 @@ def _execute_exit(
     sell_action = "SELL"
     current_price = price_state.get("last", 0)
 
-    # Short-sell prevention: verify we hold enough shares before selling
+    # Short-sell prevention: verify we hold enough shares net of in-flight sells.
     if not dry_run:
         positions = ibkr.get_positions()
-        validated = _validate_sell_shares(positions, ticker, shares, action, "intraday")
+        pending = 0
+        try:
+            pending = ibkr.get_open_sell_shares(ticker)
+        except Exception as exc:
+            logger.warning("get_open_sell_shares(%s) failed: %s — treating as 0", ticker, exc)
+        validated = _validate_sell_shares(
+            positions, ticker, shares, action, "intraday",
+            pending_sell_shares=pending,
+        )
         if validated is None:
             order_book.remove_stop(ticker)
             order_book.save()

--- a/executor/ibkr.py
+++ b/executor/ibkr.py
@@ -209,6 +209,11 @@ class IBKRClient:
 
         # Poll for fill confirmation
         terminal_states = {"Filled", "Cancelled", "Inactive", "ApiCancelled"}
+        # PreSubmitted = IBKR accepted the order but is holding it (pre-open,
+        # outside-RTH with outsideRth=False, regulatory hold). Orders in this
+        # state WILL fill when the hold releases (e.g. market open), so the
+        # retry layer must not re-place; treat as "Working".
+        working_states = {"PendingSubmit", "PreSubmitted", "Submitted"}
         elapsed = 0.0
         poll_interval = 0.5
         while elapsed < timeout_seconds:
@@ -237,6 +242,8 @@ class IBKRClient:
             result_status = "Rejected"
         elif filled_shares and filled_shares < shares:
             result_status = "PartialFill"
+        elif status in working_states:
+            result_status = "Working"
         elif status not in terminal_states:
             result_status = "Timeout"
         else:
@@ -244,8 +251,8 @@ class IBKRClient:
 
         logger.info(
             f"Order {result_status}: {action} {shares} {ticker} "
-            f"| orderId={trade.order.orderId} fill_price={fill_price} "
-            f"filled_shares={filled_shares}"
+            f"| orderId={trade.order.orderId} ibStatus={status} "
+            f"fill_price={fill_price} filled_shares={filled_shares}"
         )
         return {
             "ib_order_id": trade.order.orderId,
@@ -329,10 +336,48 @@ class IBKRClient:
         self.ib.sleep(2)  # Allow cancellations to propagate
         logger.info("Global cancel sent — all open orders cancelled")
 
+    def cancel_order(self, ib_order_id: int) -> bool:
+        """Cancel a single open order by its IB orderId. Best-effort.
+
+        Returns True if we found the trade and issued cancelOrder, False if
+        the orderId was not among openTrades. Safe to call on already-terminal
+        orders (IBKR simply ignores unknown/done IDs).
+        """
+        if ib_order_id is None:
+            return False
+        self.ensure_connected()
+        for trade in self.ib.openTrades():
+            if trade.order.orderId == ib_order_id:
+                self.ib.cancelOrder(trade.order)
+                logger.info("Cancel requested for orderId=%s", ib_order_id)
+                return True
+        logger.debug("cancel_order: orderId=%s not in openTrades", ib_order_id)
+        return False
+
     def get_open_orders(self) -> list:
         """Return list of open orders."""
         self.ensure_connected()
         return self.ib.openOrders()
+
+    def get_open_sell_shares(self, ticker: str) -> int:
+        """Return total un-filled SELL shares currently working at IB for ticker.
+
+        Used by the short-sell guardrail so a new SELL can be capped against
+        already-in-flight sells in addition to current position. Scans
+        ``openTrades()`` for SELL orders matching ticker and sums
+        ``totalQuantity - filled``.
+        """
+        self.ensure_connected()
+        pending = 0
+        for trade in self.ib.openTrades():
+            if trade.contract.symbol != ticker:
+                continue
+            if trade.order.action != "SELL":
+                continue
+            remaining = int(trade.order.totalQuantity) - int(trade.orderStatus.filled or 0)
+            if remaining > 0:
+                pending += remaining
+        return pending
 
     def disconnect(self):
         self.ib.disconnect()

--- a/tests/test_daemon_phase0.py
+++ b/tests/test_daemon_phase0.py
@@ -5,10 +5,12 @@ from unittest.mock import MagicMock, patch
 from executor.daemon import (
     _validate_sell_shares,
     _cleanup_connections,
+    _enqueue_cover_for_unintended_shorts,
     _place_order_with_retry,
     MAX_ORDER_RETRIES,
     ORDER_RETRY_DELAYS,
 )
+from executor.order_book import OrderBook, _default_book
 
 
 # ── _validate_sell_shares ────────────────────────────────────────────────────
@@ -34,6 +36,71 @@ class TestValidateSellShares:
         positions = {"AAPL": {"shares": -5}}
         result = _validate_sell_shares(positions, "AAPL", 10, "SELL", "exit")
         assert result is None
+
+    def test_caps_against_in_flight_pending_sells(self):
+        # PFE incident 2026-04-22: retry loop issued three duplicate SELL 77s
+        # that each individually passed held=155, summing to 231 → short 76.
+        # With in-flight tracking, the second + third retries see the first
+        # order's 77 remaining and refuse.
+        positions = {"PFE": {"shares": 155}}
+        result = _validate_sell_shares(
+            positions, "PFE", 77, "REDUCE", "URGENT",
+            pending_sell_shares=77,
+        )
+        assert result == 77  # 155 - 77 = 78 available; requested 77 fits
+        result = _validate_sell_shares(
+            positions, "PFE", 77, "REDUCE", "URGENT",
+            pending_sell_shares=154,
+        )
+        assert result == 1  # 155 - 154 = 1 available; cap to 1
+        result = _validate_sell_shares(
+            positions, "PFE", 77, "REDUCE", "URGENT",
+            pending_sell_shares=155,
+        )
+        assert result is None  # no capacity — refuse
+
+
+# ── _enqueue_cover_for_unintended_shorts ─────────────────────────────────────
+
+
+class TestEnqueueCoverForUnintendedShorts:
+    def _fresh_book(self, tmp_path):
+        return OrderBook(_default_book("2026-04-22"), path=tmp_path / "ob.json")
+
+    def test_enqueues_cover_for_negative_position(self, tmp_path):
+        book = self._fresh_book(tmp_path)
+        positions = {"PFE": {"shares": -76}, "AAPL": {"shares": 100}}
+        covered = _enqueue_cover_for_unintended_shorts(positions, book, "2026-04-22")
+        assert covered == ["PFE"]
+        pending = book.pending_urgent_exits()
+        assert len(pending) == 1
+        assert pending[0]["ticker"] == "PFE"
+        assert pending[0]["signal"] == "COVER"
+        assert pending[0]["shares"] == 76
+        assert pending[0]["reason"] == "auto_cover_unintended_short"
+
+    def test_skips_long_and_flat_positions(self, tmp_path):
+        book = self._fresh_book(tmp_path)
+        positions = {"AAPL": {"shares": 100}, "MSFT": {"shares": 0}}
+        covered = _enqueue_cover_for_unintended_shorts(positions, book, "2026-04-22")
+        assert covered == []
+        assert book.pending_urgent_exits() == []
+
+    def test_bypasses_when_allow_shorts_true(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("executor.daemon._allow_shorts", True)
+        book = self._fresh_book(tmp_path)
+        positions = {"PFE": {"shares": -76}}
+        covered = _enqueue_cover_for_unintended_shorts(positions, book, "2026-04-22")
+        assert covered == []
+        assert book.pending_urgent_exits() == []
+
+    def test_dedup_safe_on_repeat_call(self, tmp_path):
+        book = self._fresh_book(tmp_path)
+        positions = {"PFE": {"shares": -76}}
+        _enqueue_cover_for_unintended_shorts(positions, book, "2026-04-22")
+        _enqueue_cover_for_unintended_shorts(positions, book, "2026-04-22")
+        # OrderBook.add_urgent_exit dedupes by ticker+signal
+        assert len(book.pending_urgent_exits()) == 1
 
 
 # ── _place_order_with_retry ──────────────────────────────────────────────────
@@ -96,6 +163,58 @@ class TestPlaceOrderWithRetry:
         assert mock_sleep.call_count == MAX_ORDER_RETRIES - 1
         for i in range(1, MAX_ORDER_RETRIES):
             mock_sleep.assert_any_call(ORDER_RETRY_DELAYS[i])
+
+    @patch("executor.daemon._time.sleep")
+    def test_working_status_does_not_retry(self, mock_sleep):
+        # PreSubmitted/Submitted → "Working" from place_market_order. The
+        # order is live at the broker; retrying would duplicate it (PFE
+        # incident 2026-04-22).
+        ibkr = MagicMock()
+        ibkr.place_market_order.return_value = {"status": "Working", "ib_order_id": 287}
+        result = _place_order_with_retry(ibkr, "PFE", "SELL", 77, "urgent")
+        assert result["status"] == "Working"
+        assert ibkr.place_market_order.call_count == 1
+        ibkr.cancel_order.assert_not_called()
+        mock_sleep.assert_not_called()
+
+    @patch("executor.daemon._time.sleep")
+    def test_timeout_cancels_prior_order_before_retry(self, mock_sleep):
+        ibkr = MagicMock()
+        ibkr.place_market_order.side_effect = [
+            {"status": "Timeout", "ib_order_id": 287},
+            {"status": "Filled", "ib_order_id": 289},
+        ]
+        result = _place_order_with_retry(ibkr, "PFE", "SELL", 77, "urgent")
+        assert result["status"] == "Filled"
+        assert ibkr.place_market_order.call_count == 2
+        ibkr.cancel_order.assert_called_once_with(287)
+
+    @patch("executor.daemon._time.sleep")
+    def test_rejected_does_not_cancel(self, mock_sleep):
+        # Rejected means IB already terminated the order (Cancelled / Inactive
+        # / ApiCancelled); cancelling again is a no-op. Skip the call to keep
+        # retry fast and avoid log noise.
+        ibkr = MagicMock()
+        ibkr.place_market_order.side_effect = [
+            {"status": "Rejected", "ib_order_id": 287},
+            {"status": "Filled", "ib_order_id": 289},
+        ]
+        _place_order_with_retry(ibkr, "AAPL", "SELL", 10, "urgent")
+        ibkr.cancel_order.assert_not_called()
+
+    @patch("executor.daemon._time.sleep")
+    def test_cancel_order_failure_does_not_abort_retry(self, mock_sleep):
+        # If cancel_order raises, we still want to proceed with the retry —
+        # the prior order may have already terminated at IB side.
+        ibkr = MagicMock()
+        ibkr.cancel_order.side_effect = RuntimeError("ib unreachable")
+        ibkr.place_market_order.side_effect = [
+            {"status": "Timeout", "ib_order_id": 287},
+            {"status": "Filled", "ib_order_id": 289},
+        ]
+        result = _place_order_with_retry(ibkr, "PFE", "SELL", 77, "urgent")
+        assert result["status"] == "Filled"
+        assert ibkr.place_market_order.call_count == 2
 
 
 # ── _cleanup_connections ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three-layer fix for the PFE short-position incident on 2026-04-22, when a pre-open retry loop flipped a long 155 PFE position into short 76. Adds a hard guardrail against accidental shorts, fixes the retry bug that caused them, and adds an automatic cover resolver for any short that still slips through.

## Incident

`URGENT REDUCE PFE: SELL 77 shares` fired at 13:30:24 UTC (daemon just booted, market was seconds from opening). IBKR accepted the MarketOrder into `PreSubmitted` pending the 13:30 open. After 30s `place_market_order` normalised the still-`PreSubmitted` state to `Timeout`; `_place_order_with_retry` placed a fresh SELL 77. This happened twice more. At 13:33:31 UTC all three orders filled at the open — 231 shares sold vs. the 77 intended. Position went 155 long → -76 short.

Each individual order passed `_validate_sell_shares` (77 ≤ 155 held), but the cumulative in-flight working-order sum did not.

## Fixes

1. **`executor/ibkr.py:place_market_order`** — distinguishes `Working` (`PendingSubmit` / `PreSubmitted` / `Submitted`) from `Timeout`. `Working` orders are live at IBKR and will fill when the hold releases; they must not be retried.
2. **`executor/daemon.py:_place_order_with_retry`** — only retries on `Rejected` / `Timeout`. Before retrying on `Timeout`, best-effort cancels the prior `ib_order_id` via new `ibkr.cancel_order()` so a stray can't fill later.
3. **`executor/daemon.py:_validate_sell_shares`** — now accepts `pending_sell_shares` and caps against `held - in-flight`. Phase 0 urgent exits and intraday exits both query `ibkr.get_open_sell_shares(ticker)` before validating. Defence-in-depth: even if the retry path races again, cumulative working SELL qty can't exceed the position.
4. **`executor/daemon.py:_enqueue_cover_for_unintended_shorts`** — new Phase 0 pre-step when `allow_shorts=False` (the configured invariant). Any negative position gets an URGENT COVER enqueued into the order book, executed via the existing COVER → BUY path, and announced via a flow-doctor alert. Mirror of urgent_exit.

## Test plan

- [x] `pytest tests/test_daemon_phase0.py -v` — 23 tests pass (9 new, including PFE incident reproduction)
- [x] `pytest` full suite — 292 tests pass
- [x] pre-push executor dry-run hook passed
- [ ] Monitor next market open on ae-trading after merge + deploy: confirm no duplicate orders logged, confirm auto-cover flattens today's PFE short
- [ ] Manual test: leave the paper account with a synthetic short overnight, start the daemon at open, verify auto-cover fires

## Follow-ups (not in this PR)

- Clean up today's -76 PFE short. The auto-cover resolver *would* handle it automatically on the next daemon start, but that is tomorrow. Recommend a manual BUY 76 before EOD reconcile (1:20 PM PT) rather than carrying the short through a second trading day.
- Consider a 2-phase order-recon loop in `daemon.py` that re-inspects `openTrades()` every N seconds during Phase 0 to surface any stuck Working orders mid-session, not just at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)