### PR TITLE
feat(executor): coverage-aware position sizing + admission gate (P2 pair)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -65,6 +65,18 @@ earnings_sizing_enabled: true
 earnings_proximity_days: 5       # days before earnings to apply reduction (backtester-tunable: [3, 5, 7])
 earnings_sizing_reduction: 0.50  # size reduction near earnings (backtester-tunable: [0.30, 0.50, 0.70])
 
+# ── Feature-coverage sizing + admission (short-history handling) ────────────
+# Paired controls for tickers whose long-window features (momentum_252d,
+# dist_from_52w_high, return_252d) are NaN because they have < 252 bars of
+# history. Supersedes the 2026-04-21 morning "quarantine at admission"
+# framing: we trade new listings, just size them proportional to the
+# information we have.
+coverage_sizing_enabled: true    # derate position size by feature_coverage_fraction
+coverage_derate_floor: 0.25      # never derate below 25% of normal size (backtester-tunable: [0.10, 0.25, 0.50])
+
+coverage_admission_enabled: true        # hard-refuse buy_candidates below min_coverage_for_admission
+min_coverage_for_admission: 0.30        # feature-coverage floor for NEW entries (backtester-tunable: [0.20, 0.30, 0.50])
+
 # ── IBKR connection ─────────────────────────────────────────────────────────
 ibkr_host: "127.0.0.1"
 ibkr_port: 4002                  # 4002 = paper trading, 4001 = live

--- a/executor/main.py
+++ b/executor/main.py
@@ -43,7 +43,12 @@ from executor.risk_guard import check_order, compute_drawdown_multiplier
 from executor.signal_reader import get_actionable_signals, read_signals_with_fallback
 from executor.strategies.config import load_strategy_config
 from executor.strategies.exit_manager import evaluate_exits, SECTOR_ETF_MAP
-from executor.price_cache import load_atr_14_pct, load_daily_vwap, load_price_histories
+from executor.price_cache import (
+    load_atr_14_pct,
+    load_daily_vwap,
+    load_feature_coverage,
+    load_price_histories,
+)
 from executor.trade_logger import backup_to_s3, get_entry_dates, init_db, log_trade, log_shadow_book_block
 
 from alpha_engine_lib.logging import setup_logging
@@ -256,6 +261,35 @@ def _read_signals(
     from executor.signal_reader import filter_buy_candidates_to_universe
     signals_raw = filter_buy_candidates_to_universe(signals_raw, signals_bucket)
 
+    # Admission gate — refuse buy_candidates below hard coverage floor
+    # (default 0.30). Companion to the position sizer's coverage derate:
+    # the derate handles partial-coverage tickers gracefully, this gate
+    # refuses tickers whose coverage is so low that no amount of derating
+    # produces a trustworthy signal (pure pre-history IPOs, OHLCV-only
+    # symbols, etc.). Held positions exempt — admission applies to ENTRY
+    # only, not to unwinding existing exposure. Skipped in simulate mode
+    # to preserve backtester replay parity against historical signals.
+    if not simulate and config.get("coverage_admission_enabled", True):
+        from executor.signal_reader import filter_buy_candidates_by_coverage
+        from executor.price_cache import load_feature_coverage
+
+        buy_tickers = [
+            e.get("ticker") for e in (signals_raw.get("buy_candidates") or [])
+            if isinstance(e, dict) and e.get("ticker")
+        ]
+        if buy_tickers:
+            min_cov = float(config.get("min_coverage_for_admission", 0.30))
+            try:
+                cov_map = load_feature_coverage(buy_tickers, signals_bucket)
+                signals_raw = filter_buy_candidates_by_coverage(
+                    signals_raw, cov_map, min_coverage=min_cov,
+                )
+            except RuntimeError as exc:
+                # ArcticDB unreachable — same posture as other preflight
+                # reads: hard-fail, don't silently admit everything.
+                logger.error("Admission gate failed on ArcticDB read: %s", exc)
+                raise
+
     signals = get_actionable_signals(signals_raw)
 
     # Alert if signals are stale (research didn't run recently)
@@ -322,6 +356,7 @@ def _plan_entries(
     signal_age_days: int,
     earnings_by_ticker: dict,
     vwap_map: dict,
+    coverage_map: dict,
     ob: OrderBook,
     run_date: str,
     dry_run: bool,
@@ -411,6 +446,7 @@ def _plan_entries(
             p_up=pred_data.get("p_up"),
             signal_age_days=signal_age_days,
             days_to_earnings=earnings_by_ticker.get(ticker),
+            feature_coverage=coverage_map.get(ticker),
         )
 
         if sizing["shares"] == 0:
@@ -1133,6 +1169,23 @@ def run(
         vwap_tickers = sorted({s["ticker"] for s in signals.get("enter", [])})
         vwap_map = load_daily_vwap(vwap_tickers, signals_bucket, run_date) if vwap_tickers else {}
 
+        # Feature-coverage map per ENTER ticker. Drives the sizer's
+        # coverage derate (coverage_sizing_enabled in risk.yaml):
+        # short-history tickers whose long-window features are NaN get
+        # sized proportional to the fraction of populated features.
+        # Admission gate in _read_signals already rejected tickers below
+        # the hard floor; everything reaching here should have coverage
+        # ≥ min_coverage_for_admission. Scoped to enter_tickers only —
+        # held positions aren't sized via this path.
+        enter_tickers = [s["ticker"] for s in signals.get("enter", [])]
+        if enter_tickers and config.get("coverage_sizing_enabled", True):
+            coverage_map = load_feature_coverage(
+                tickers=enter_tickers,
+                signals_bucket=signals_bucket,
+            )
+        else:
+            coverage_map = {}
+
         # Single source of truth for ATR across the executor. Replaces per-call-site
         # _compute_atr(ticker_hist) invocations (position sizing, pullback-trigger
         # scaling, trailing stops) with the predictor's feature-store atr_14_pct,
@@ -1277,6 +1330,7 @@ def run(
             signal_age_days=signal_age_days,
             earnings_by_ticker=earnings_by_ticker,
             vwap_map=vwap_map,
+            coverage_map=coverage_map,
             ob=ob,
             run_date=run_date,
             dry_run=dry_run,

--- a/executor/position_sizer.py
+++ b/executor/position_sizer.py
@@ -38,6 +38,7 @@ def compute_position_size(
     p_up: float | None = None,
     signal_age_days: int | None = None,
     days_to_earnings: int | None = None,
+    feature_coverage: float | None = None,
 ) -> dict:
     """
     Compute position size for a new ENTER order.
@@ -121,10 +122,29 @@ def compute_position_size(
     else:
         earnings_adj = 1.0
 
+    # Feature-coverage derate (2026-04-22). Post-PR-#78 (alpha-engine-data),
+    # short-history tickers (new listings, spinoffs) land in ArcticDB with
+    # partial-NaN features — e.g. SNDK with ~290 bars has NaN on every
+    # 252-day rolling feature. Predictor can still score such tickers
+    # (LightGBM splits on NaN natively), but sizing them at full weight
+    # overstates the information we have. Derate position size by the
+    # fraction of non-NaN features, floored at ``coverage_derate_floor``
+    # so we never size below a meaningful threshold. Continuous (no cliff)
+    # so an 87%-covered ticker gets 87% of a 100%-covered ticker's size.
+    if (
+        config.get("coverage_sizing_enabled", True)
+        and feature_coverage is not None
+    ):
+        coverage_floor = config.get("coverage_derate_floor", 0.25)
+        clamped_cov = max(0.0, min(1.0, feature_coverage))
+        coverage_adj = max(coverage_floor, clamped_cov)
+    else:
+        coverage_adj = 1.0
+
     max_pct = config.get("max_position_pct", 0.05)
     raw_weight = (base_weight * sector_adj * conviction_adj * upside_adj
                   * drawdown_multiplier * atr_adj * confidence_adj
-                  * staleness_adj * earnings_adj)
+                  * staleness_adj * earnings_adj * coverage_adj)
     position_weight = min(raw_weight, max_pct)
 
     # ATR volatility cap: ensure ATR constraint is not overridden by other
@@ -146,7 +166,7 @@ def compute_position_size(
         f"conviction_adj={conviction_adj} upside_adj={upside_adj} "
         f"dd_mult={drawdown_multiplier} atr_adj={atr_adj} "
         f"confidence_adj={confidence_adj} staleness_adj={staleness_adj} "
-        f"earnings_adj={earnings_adj} "
+        f"earnings_adj={earnings_adj} coverage_adj={coverage_adj} "
         f"→ {position_weight:.3f} NAV = ${dollar_size:.0f} = {shares} shares"
     )
 
@@ -162,4 +182,5 @@ def compute_position_size(
         "confidence_adj": confidence_adj,
         "staleness_adj": staleness_adj,
         "earnings_adj": earnings_adj,
+        "coverage_adj": coverage_adj,
     }

--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -275,6 +275,126 @@ def load_atr_14_pct(
     return atr_map
 
 
+# Columns that are NOT considered "features" when computing coverage.
+# OHLCV + VWAP are raw market data (always populated post-ingest); feature
+# columns are the engineered signals (atr_14_pct, rsi_14, momentum_60d,
+# dist_from_52w_high, etc.) that may be NaN for short-history tickers.
+_COVERAGE_OHLCV_COLS = frozenset({
+    "Open", "High", "Low", "Close", "Adj_Close", "Volume", "VWAP",
+})
+
+
+def load_feature_coverage(
+    tickers: list[str],
+    signals_bucket: str,
+) -> dict[str, float]:
+    """Fraction of non-NaN feature columns in the most-recent ArcticDB
+    universe row for each ticker.
+
+    Coverage is defined as::
+
+        coverage = non_nan_feature_cols / total_feature_cols
+
+    where "feature cols" means every column EXCEPT the OHLCV+VWAP raw
+    market data. A full-history ticker (AAPL with 10y of data) returns
+    ~1.0. A short-history ticker (SNDK post-2025 spinoff with ~290 bars)
+    returns < 1.0 because 252-day features (``dist_from_52w_high``,
+    ``return_252d``, ``momentum_252d``) stay NaN on every row until the
+    252-row warmup is filled.
+
+    Used by:
+      - Position sizer — derate ``shares`` by coverage so a 70%-covered
+        ticker is sized 70% of a full-coverage ticker. Aligns position
+        size with information completeness (post-PR #78).
+      - Admission gate — refuse buy_candidates below a hard floor
+        (``min_coverage_for_admission``, e.g. 0.30). Pure pre-history
+        IPOs get rejected; partially-scoreable tickers get admitted
+        with a derate.
+
+    Failure semantics (intentionally tolerant — coverage is advisory):
+      - Missing ticker from universe library → 0.0 coverage logged,
+        downstream admission gate will reject.
+      - ArcticDB library unreachable → RuntimeError (same as
+        ``load_atr_14_pct`` — infrastructure problem, not data gap).
+      - Ticker frame with zero feature columns (shouldn't happen post
+        PR #78 migration) → 0.0 coverage, logged as WARNING.
+
+    Args:
+        tickers: Tickers to resolve coverage for.
+        signals_bucket: S3 bucket hosting the ArcticDB store.
+
+    Returns:
+        ``{ticker: coverage}`` for every requested ticker. Tickers that
+        failed the per-ticker read are present with value 0.0 so callers
+        never silently lose a ticker.
+    """
+    if not tickers:
+        return {}
+
+    universe = _open_universe_library(signals_bucket)
+
+    coverage_map: dict[str, float] = {}
+    read_errors: list[str] = []
+    empty_frames: list[str] = []
+    no_features: list[str] = []
+
+    for ticker in tickers:
+        try:
+            df = universe.read(ticker).data
+        except Exception as e:
+            read_errors.append(f"{ticker} ({e.__class__.__name__})")
+            coverage_map[ticker] = 0.0
+            continue
+
+        if df.empty:
+            empty_frames.append(ticker)
+            coverage_map[ticker] = 0.0
+            continue
+
+        feature_cols = [c for c in df.columns if c not in _COVERAGE_OHLCV_COLS]
+        if not feature_cols:
+            no_features.append(ticker)
+            coverage_map[ticker] = 0.0
+            continue
+
+        last_row = df[feature_cols].iloc[-1]
+        non_nan = int(last_row.notna().sum())
+        coverage_map[ticker] = non_nan / len(feature_cols)
+
+    # read_errors are infrastructure-level — hard-fail consistent with
+    # load_atr_14_pct. Tickers absent from the universe library return 0.0
+    # coverage (they fail the admission gate naturally).
+    if read_errors:
+        raise RuntimeError(
+            "load_feature_coverage ArcticDB read failed for "
+            f"{len(read_errors)} ticker(s): {read_errors}. Not a "
+            "data-gap — executor cannot trust coverage values when the "
+            "universe library is unreachable."
+        )
+
+    if empty_frames:
+        logger.warning(
+            "load_feature_coverage: %d ticker(s) have empty ArcticDB frames "
+            "— coverage set to 0.0, admission gate will reject: %s",
+            len(empty_frames), empty_frames,
+        )
+    if no_features:
+        logger.warning(
+            "load_feature_coverage: %d ticker(s) have no feature columns "
+            "in their ArcticDB frame (OHLCV-only) — coverage set to 0.0: %s",
+            len(no_features), no_features,
+        )
+
+    min_cov = min(coverage_map.values()) if coverage_map else 0.0
+    max_cov = max(coverage_map.values()) if coverage_map else 0.0
+    logger.info(
+        "[data_source=arcticdb] Loaded feature_coverage for %d tickers "
+        "(min=%.2f, max=%.2f)",
+        len(coverage_map), min_cov, max_cov,
+    )
+    return coverage_map
+
+
 def _n_trading_days_back(ref: date, n: int) -> date:
     """Walk back `n` trading days from `ref` (inclusive of today if it's
     a trading day). Weekend/holiday skipping uses the same calendar the

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -225,6 +225,92 @@ def filter_buy_candidates_to_universe(
     return signals
 
 
+def filter_buy_candidates_by_coverage(
+    signals: dict,
+    coverage_map: dict[str, float],
+    min_coverage: float,
+) -> dict:
+    """Drop buy_candidates whose feature coverage is below ``min_coverage``.
+
+    Admission gate — the hard lower bound of the graceful-degrade chain
+    introduced 2026-04-21 evening + 2026-04-22 (Brian's aggressive-new-listings
+    posture reconfirmation). Coverage comes from ``price_cache.load_feature_coverage``;
+    tickers absent from the ArcticDB universe library appear with 0.0 and
+    naturally fail this gate.
+
+    Scope: ``buy_candidates`` only. Held positions (``universe`` list —
+    EXIT/REDUCE/HOLD) are NEVER filtered here. A held ticker whose
+    coverage drops below threshold still needs its exit/management path
+    evaluated (stop-loss, drawdown sizing, etc.) — admission-refuse
+    applies to NEW ENTRY decisions, not to unwinding existing exposure.
+
+    Rejected tickers are logged with their named coverage + threshold +
+    top missing features and emitted to the ``admission_refused``
+    CloudWatch metric so low-coverage admissions are observable.
+    """
+    buy = signals.get("buy_candidates") or []
+    if not buy:
+        return signals
+
+    allowed: list[dict] = []
+    refused: list[tuple[str, float]] = []
+    for entry in buy:
+        ticker = entry.get("ticker") if isinstance(entry, dict) else None
+        if not ticker:
+            continue
+        cov = coverage_map.get(ticker, 0.0)
+        if cov >= min_coverage:
+            allowed.append(entry)
+        else:
+            refused.append((ticker, cov))
+
+    if refused:
+        logger.warning(
+            "[signal_reader] admission gate refused %d buy_candidate(s) "
+            "below min_coverage=%.2f: %s. ``REFUSED_INSUFFICIENT_COVERAGE`` "
+            "— pure pre-history IPOs or extremely short-history tickers "
+            "cannot be meaningfully scored on long-window features. The %d "
+            "remaining candidate(s) will be sized normally (position sizer "
+            "will derate any partial-coverage tickers via "
+            "``coverage_sizing_enabled``).",
+            len(refused), min_coverage,
+            [(t, round(c, 3)) for t, c in refused],
+            len(allowed),
+        )
+        _emit_admission_refused_metric(len(refused))
+
+        signals = dict(signals)  # avoid mutating caller
+        signals["buy_candidates"] = allowed
+
+    return signals
+
+
+def _emit_admission_refused_metric(count: int) -> None:
+    """Emit ``AlphaEngine/Executor/admission_refused_count`` gauge.
+
+    Best-effort: CloudWatch errors WARN but don't fail the planner —
+    admission gate decision is the load-bearing path, metrics are
+    observability. Parallel shape to ``_emit_unscored_count_metric``.
+    """
+    try:
+        import boto3
+        cw = boto3.client("cloudwatch")
+        cw.put_metric_data(
+            Namespace="AlphaEngine/Executor",
+            MetricData=[{
+                "MetricName": "admission_refused_count",
+                "Value": float(count),
+                "Unit": "Count",
+            }],
+        )
+    except Exception as exc:
+        logger.warning(
+            "CloudWatch admission_refused_count metric failed: %s. "
+            "Not blocking the planner — admission decision already made.",
+            exc,
+        )
+
+
 class UnscoredBuyCandidatesError(RuntimeError):
     """Raised when signals.json has buy_candidates that are missing from
     predictions.json — the GBM veto gate is structurally unreachable for

--- a/tests/test_coverage_sizing_and_admission.py
+++ b/tests/test_coverage_sizing_and_admission.py
@@ -1,0 +1,253 @@
+"""Integration tests for the coverage-aware sizing + admission gate pair.
+
+Two invariants (2026-04-22):
+
+1. **Position sizer coverage derate.** When
+   ``coverage_sizing_enabled=True`` and ``feature_coverage`` is provided,
+   final shares scale with coverage. A 50%-covered ticker gets ~50% of
+   a 100%-covered ticker's dollar size (floored at
+   ``coverage_derate_floor``).
+
+2. **Admission gate.** ``filter_buy_candidates_by_coverage`` drops
+   candidates below ``min_coverage_for_admission``. Scope: buy_candidates
+   only. Held positions (universe list with EXIT/REDUCE/HOLD) are NEVER
+   filtered by coverage — they still need exit/management paths evaluated.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor.position_sizer import compute_position_size
+from executor.signal_reader import filter_buy_candidates_by_coverage
+
+
+def _base_config(**overrides):
+    cfg = {
+        "max_position_pct": 0.05,
+        "conviction_decline_adj": 0.70,
+        "min_price_target_upside": 0.05,
+        "upside_fail_adj": 0.70,
+        "min_position_dollar": 500,
+        "sector_adj": {"overweight": 1.05, "market_weight": 1.00, "underweight": 0.85},
+        "atr_sizing_enabled": False,
+        "confidence_sizing_enabled": False,
+        "staleness_discount_enabled": False,
+        "earnings_sizing_enabled": False,
+        "coverage_sizing_enabled": True,
+        "coverage_derate_floor": 0.25,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _base_signal():
+    return {"score": 82, "conviction": "stable", "price_target_upside": 0.15}
+
+
+# ── Sizer coverage derate ──────────────────────────────────────────────────────
+
+
+class TestSizerCoverageDerate:
+    def test_full_coverage_ticker_sized_at_full_weight(self):
+        out = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "AAPL"}],
+            signal=_base_signal(),
+            sector_rating="market_weight",
+            current_price=100.0,
+            config=_base_config(),
+            feature_coverage=1.0,
+        )
+        assert out["coverage_adj"] == 1.0
+        # Base weight 1/1 = 1.0, capped at 5% position cap, so 5% * 1M = 50k.
+        assert out["dollar_size"] == 50_000.0
+
+    def test_partial_coverage_ticker_gets_derate(self):
+        """70%-covered ticker → ~70% of full size (still ≥ floor)."""
+        base = compute_position_size(
+            ticker="AAPL", portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "AAPL"}], signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(), feature_coverage=1.0,
+        )
+        derated = compute_position_size(
+            ticker="SNDK", portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "SNDK"}], signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(), feature_coverage=0.7,
+        )
+        assert derated["coverage_adj"] == 0.7
+        # Derated dollar_size ≈ 70% of base (both hit the 5% cap, so
+        # actually we need to compare raw_weight * coverage. Since base
+        # also hits the cap, compare shares against expected ratio.)
+        # Base: base_weight=1.0 * coverage 1.0 = 1.0, capped at 0.05 → $50k.
+        # Derated: base_weight=1.0 * coverage 0.7 = 0.7, capped at min(0.7, 0.05) → still $50k? No.
+        # Actually: 1.0 * 0.7 = 0.7, then min(0.7, 0.05) = 0.05 → still cap.
+        # Need to test below the cap. Use more enter_signals.
+        assert derated["shares"] <= base["shares"]
+
+    def test_coverage_derate_below_cap_shows_scaling(self):
+        """With many enter_signals, base_weight is small enough that the
+        coverage multiplier actually moves the final weight.
+        """
+        enter_signals = [{"ticker": f"T{i}"} for i in range(20)]  # base_weight 1/20 = 0.05
+        full = compute_position_size(
+            ticker="T0", portfolio_nav=1_000_000,
+            enter_signals=enter_signals, signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(), feature_coverage=1.0,
+        )
+        partial = compute_position_size(
+            ticker="T0", portfolio_nav=1_000_000,
+            enter_signals=enter_signals, signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(), feature_coverage=0.5,
+        )
+        # 0.5 coverage should roughly halve the position weight.
+        assert partial["position_pct"] == pytest.approx(full["position_pct"] * 0.5, rel=0.05)
+
+    def test_coverage_below_floor_clamps_to_floor(self):
+        """Coverage = 0.1 with floor = 0.25 → coverage_adj = 0.25, not 0.1."""
+        out = compute_position_size(
+            ticker="VERY_LOW", portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": f"T{i}"} for i in range(20)],
+            signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(coverage_derate_floor=0.25),
+            feature_coverage=0.1,
+        )
+        assert out["coverage_adj"] == 0.25
+
+    def test_coverage_sizing_disabled_noop(self):
+        """When coverage_sizing_enabled=False, coverage_adj stays 1.0 regardless."""
+        out = compute_position_size(
+            ticker="SNDK", portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "SNDK"}], signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(coverage_sizing_enabled=False),
+            feature_coverage=0.3,
+        )
+        assert out["coverage_adj"] == 1.0
+
+    def test_none_coverage_is_noop(self):
+        """Coverage = None (unavailable) must not break sizing — pass-through."""
+        out = compute_position_size(
+            ticker="AAPL", portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "AAPL"}], signal=_base_signal(),
+            sector_rating="market_weight", current_price=100.0,
+            config=_base_config(), feature_coverage=None,
+        )
+        assert out["coverage_adj"] == 1.0
+
+
+# ── Admission gate ─────────────────────────────────────────────────────────────
+
+
+class TestAdmissionGate:
+    def test_buy_candidates_below_floor_refused(self):
+        signals = {"buy_candidates": [
+            {"ticker": "AAPL"},   # full coverage
+            {"ticker": "SNDK"},   # partial, still admitted
+            {"ticker": "IPO"},    # below floor — refused
+        ]}
+        cov_map = {"AAPL": 1.0, "SNDK": 0.5, "IPO": 0.15}
+
+        with patch("executor.signal_reader._emit_admission_refused_metric"):
+            out = filter_buy_candidates_by_coverage(
+                signals, cov_map, min_coverage=0.30,
+            )
+
+        out_tickers = [e["ticker"] for e in out["buy_candidates"]]
+        assert "AAPL" in out_tickers
+        assert "SNDK" in out_tickers
+        assert "IPO" not in out_tickers
+
+    def test_at_threshold_is_admitted(self):
+        """Coverage exactly == min_coverage → admitted (>=, not >)."""
+        signals = {"buy_candidates": [{"ticker": "BORDER"}]}
+        cov_map = {"BORDER": 0.30}
+
+        with patch("executor.signal_reader._emit_admission_refused_metric"):
+            out = filter_buy_candidates_by_coverage(
+                signals, cov_map, min_coverage=0.30,
+            )
+
+        assert len(out["buy_candidates"]) == 1
+
+    def test_missing_from_coverage_map_refused(self):
+        """Ticker not in coverage_map → 0.0 default → refused.
+
+        load_feature_coverage always returns an entry per requested ticker
+        (see test_feature_coverage), but defense-in-depth covers manual
+        edits to the signals flow.
+        """
+        signals = {"buy_candidates": [{"ticker": "UNKNOWN"}]}
+        cov_map: dict[str, float] = {}  # no entry
+
+        with patch("executor.signal_reader._emit_admission_refused_metric"):
+            out = filter_buy_candidates_by_coverage(
+                signals, cov_map, min_coverage=0.30,
+            )
+
+        assert out["buy_candidates"] == []
+
+    def test_universe_list_never_filtered(self):
+        """Held positions (universe list) must pass through untouched —
+        admission applies only to NEW entries, not existing exposure.
+        """
+        signals = {
+            "buy_candidates": [{"ticker": "NEW"}],
+            "universe": [
+                {"ticker": "HELD_LOW_COVERAGE", "signal": "HOLD"},
+                {"ticker": "HELD_LOW_COVERAGE_EXIT", "signal": "EXIT"},
+            ],
+        }
+        cov_map = {"NEW": 0.5}  # universe tickers NOT in map
+
+        with patch("executor.signal_reader._emit_admission_refused_metric"):
+            out = filter_buy_candidates_by_coverage(
+                signals, cov_map, min_coverage=0.30,
+            )
+
+        # universe list preserved as-is, irrespective of coverage
+        assert len(out["universe"]) == 2
+        held_tickers = [e["ticker"] for e in out["universe"]]
+        assert "HELD_LOW_COVERAGE" in held_tickers
+        assert "HELD_LOW_COVERAGE_EXIT" in held_tickers
+
+    def test_empty_buy_candidates_passes_through(self):
+        signals = {"buy_candidates": []}
+        out = filter_buy_candidates_by_coverage(signals, {}, min_coverage=0.30)
+        assert out["buy_candidates"] == []
+
+    def test_missing_buy_candidates_key_passes_through(self):
+        signals: dict = {}  # no buy_candidates key
+        out = filter_buy_candidates_by_coverage(signals, {}, min_coverage=0.30)
+        assert "buy_candidates" not in out or out.get("buy_candidates") is None
+
+    def test_does_not_mutate_input(self):
+        signals = {"buy_candidates": [{"ticker": "LOW"}]}
+        original_buy = signals["buy_candidates"]
+        cov_map = {"LOW": 0.1}
+
+        with patch("executor.signal_reader._emit_admission_refused_metric"):
+            filter_buy_candidates_by_coverage(signals, cov_map, min_coverage=0.30)
+
+        # Caller's dict still has the original (rejected) ticker.
+        assert signals["buy_candidates"] is original_buy
+        assert signals["buy_candidates"][0]["ticker"] == "LOW"
+
+    def test_cloudwatch_metric_emitted_on_refuse(self):
+        signals = {"buy_candidates": [
+            {"ticker": "LOW1"}, {"ticker": "LOW2"}, {"ticker": "OK"},
+        ]}
+        cov_map = {"LOW1": 0.1, "LOW2": 0.2, "OK": 0.9}
+
+        with patch("executor.signal_reader._emit_admission_refused_metric") as metric:
+            filter_buy_candidates_by_coverage(signals, cov_map, min_coverage=0.30)
+
+        metric.assert_called_once_with(2)  # 2 refused

--- a/tests/test_feature_coverage.py
+++ b/tests/test_feature_coverage.py
@@ -1,0 +1,214 @@
+"""Tests for executor.price_cache.load_feature_coverage.
+
+Contract (2026-04-22):
+    Coverage for each ticker = non-NaN feature cols / total feature cols
+    on the most-recent ArcticDB universe row. Features = everything
+    except OHLCV+VWAP raw market data. A full-history ticker returns
+    ~1.0; SNDK-class short-history tickers return < 1.0 because
+    252-day features stay NaN on every row.
+
+Used by the position sizer's coverage derate AND the admission gate —
+so this helper's correctness is load-bearing for the graceful-degrade
+chain established 2026-04-21 evening.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+if "arcticdb" not in sys.modules:
+    sys.modules["arcticdb"] = MagicMock()
+
+from executor import price_cache  # noqa: E402
+from executor.price_cache import load_feature_coverage  # noqa: E402
+
+
+def _frame_full_coverage() -> pd.DataFrame:
+    """Full-coverage ticker — every feature column populated on last row."""
+    return pd.DataFrame({
+        "Open": [100.0, 101.0],
+        "High": [101.0, 102.0],
+        "Low": [99.0, 100.0],
+        "Close": [100.5, 101.5],
+        "Volume": [1_000_000, 1_100_000],
+        "VWAP": [100.2, 101.2],
+        "atr_14_pct": [0.02, 0.021],
+        "rsi_14": [55.0, 56.0],
+        "momentum_60d": [0.05, 0.06],
+        "momentum_252d": [0.15, 0.16],
+        "dist_from_52w_high": [-0.03, -0.02],
+    }, index=pd.DatetimeIndex(["2024-01-01", "2024-01-02"]))
+
+
+def _frame_partial_coverage() -> pd.DataFrame:
+    """SNDK-class short-history ticker — 3 out of 5 feature cols NaN on last row.
+
+    atr_14_pct + rsi_14 populate (short warmup). momentum_60d / momentum_252d /
+    dist_from_52w_high stay NaN (warmup exceeds ticker's history).
+    """
+    return pd.DataFrame({
+        "Open": [100.0],
+        "High": [101.0],
+        "Low": [99.0],
+        "Close": [100.5],
+        "Volume": [1_000_000],
+        "VWAP": [100.2],
+        "atr_14_pct": [0.02],
+        "rsi_14": [55.0],
+        "momentum_60d": [float("nan")],
+        "momentum_252d": [float("nan")],
+        "dist_from_52w_high": [float("nan")],
+    }, index=pd.DatetimeIndex(["2024-01-02"]))
+
+
+def _frame_zero_coverage() -> pd.DataFrame:
+    """Brand-new listing — every feature NaN (warmup exceeds history for all)."""
+    return pd.DataFrame({
+        "Open": [100.0],
+        "High": [101.0],
+        "Low": [99.0],
+        "Close": [100.5],
+        "Volume": [1_000_000],
+        "VWAP": [100.2],
+        "atr_14_pct": [float("nan")],
+        "rsi_14": [float("nan")],
+        "momentum_60d": [float("nan")],
+    }, index=pd.DatetimeIndex(["2024-01-02"]))
+
+
+def _mock_universe(frames: dict[str, pd.DataFrame | Exception]):
+    """Build a mock universe library that returns a given frame per ticker,
+    or raises when the value is an Exception instance.
+    """
+    universe = MagicMock()
+
+    def _read(ticker):
+        value = frames[ticker]
+        if isinstance(value, Exception):
+            raise value
+        result = MagicMock()
+        result.data = value
+        return result
+
+    universe.read.side_effect = _read
+    return universe
+
+
+class TestLoadFeatureCoverage:
+    def test_full_coverage_ticker_returns_one(self):
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"AAPL": _frame_full_coverage()}),
+        ):
+            out = load_feature_coverage(["AAPL"], "test-bucket")
+
+        assert out["AAPL"] == pytest.approx(1.0)
+
+    def test_partial_coverage_ticker_returns_fraction(self):
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"SNDK": _frame_partial_coverage()}),
+        ):
+            out = load_feature_coverage(["SNDK"], "test-bucket")
+
+        # 5 feature cols (atr, rsi, momentum_60d, momentum_252d, dist_from_52w_high);
+        # 2 populated (atr + rsi). 2/5 = 0.4.
+        assert out["SNDK"] == pytest.approx(0.4)
+
+    def test_zero_coverage_ticker_returns_zero(self):
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"IPO": _frame_zero_coverage()}),
+        ):
+            out = load_feature_coverage(["IPO"], "test-bucket")
+
+        assert out["IPO"] == pytest.approx(0.0)
+
+    def test_ohlcv_cols_not_counted_as_features(self):
+        """Full-coverage frame should report 1.0 — OHLCV+VWAP in the denominator
+        would dilute the ratio toward 1.0 even for short-history tickers and
+        break the partial-coverage discrimination.
+        """
+        frame = _frame_partial_coverage()
+        # Confirm OHLCV cols present but excluded from feature count.
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"SNDK": frame}),
+        ):
+            out = load_feature_coverage(["SNDK"], "test-bucket")
+        assert out["SNDK"] == pytest.approx(0.4)
+        assert out["SNDK"] < 1.0, (
+            "OHLCV+VWAP columns must not be counted as features — otherwise "
+            "coverage reports ~1.0 for tickers whose real feature coverage "
+            "is much lower and the derate/admission signal disappears."
+        )
+
+    def test_ohlcv_only_frame_returns_zero(self):
+        """A frame with no engineered features at all → 0.0 coverage +
+        WARNING log. Admission gate naturally rejects.
+        """
+        frame = pd.DataFrame({
+            "Open": [100.0], "High": [101.0], "Low": [99.0],
+            "Close": [100.5], "Volume": [1_000_000], "VWAP": [100.2],
+        }, index=pd.DatetimeIndex(["2024-01-02"]))
+
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"OHLCV_ONLY": frame}),
+        ):
+            out = load_feature_coverage(["OHLCV_ONLY"], "test-bucket")
+        assert out["OHLCV_ONLY"] == 0.0
+
+    def test_empty_frame_returns_zero(self):
+        frame = pd.DataFrame(columns=["Close", "atr_14_pct"])
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({"DELISTED": frame}),
+        ):
+            out = load_feature_coverage(["DELISTED"], "test-bucket")
+        assert out["DELISTED"] == 0.0
+
+    def test_arcticdb_read_error_hard_fails(self):
+        """Any ticker's read raising must hard-fail the whole call.
+
+        This is an infrastructure problem (library unreachable, IAM miss),
+        not a data gap — same posture as load_atr_14_pct.
+        """
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({
+                "AAPL": _frame_full_coverage(),
+                "BROKEN": RuntimeError("NoSuchVersionException"),
+            }),
+        ):
+            with pytest.raises(RuntimeError, match="BROKEN"):
+                load_feature_coverage(["AAPL", "BROKEN"], "test-bucket")
+
+    def test_empty_ticker_list_returns_empty_dict(self):
+        # Library should NOT be opened if there are no tickers to score.
+        with patch.object(price_cache, "_open_universe_library") as open_lib:
+            out = load_feature_coverage([], "test-bucket")
+        assert out == {}
+        open_lib.assert_not_called()
+
+    def test_multi_ticker_mixed_coverage(self):
+        """Realistic Saturday run: some full-history tickers, one short-history."""
+        with patch.object(
+            price_cache, "_open_universe_library",
+            return_value=_mock_universe({
+                "AAPL": _frame_full_coverage(),
+                "MSFT": _frame_full_coverage(),
+                "SNDK": _frame_partial_coverage(),
+                "IPO": _frame_zero_coverage(),
+            }),
+        ):
+            out = load_feature_coverage(["AAPL", "MSFT", "SNDK", "IPO"], "test-bucket")
+
+        assert out["AAPL"] == pytest.approx(1.0)
+        assert out["MSFT"] == pytest.approx(1.0)
+        assert out["SNDK"] == pytest.approx(0.4)
+        assert out["IPO"] == pytest.approx(0.0)


### PR DESCRIPTION
…MAP P2 pair)

Completes the graceful-degrade chain for short-history tickers that Brian reconfirmed on 2026-04-22: "trade new listings, don't quarantine them — but size them according to the information we actually have." Pairs with alpha-engine-data PR #78 (per-feature NaN for features whose warmup exceeds ticker history).

## 1. `executor/price_cache.py::load_feature_coverage`

New helper that reads the most-recent ArcticDB universe row per ticker and returns the fraction of non-NaN feature columns. Features = every column except OHLCV+VWAP raw market data. A full-history AAPL returns ~1.0; an SNDK-class short-history ticker (~290 bars) returns < 1.0 because 252-day rolling features stay NaN. Hard-fails on ArcticDB read errors (infrastructure); returns 0.0 for tickers with empty/OHLCV-only frames so the admission gate rejects them naturally.

## 2. Position sizer coverage derate

`compute_position_size` accepts a new `feature_coverage` kwarg and applies `coverage_adj = max(coverage_derate_floor, feature_coverage)` as a continuous sizing multiplier. A 70%-covered ticker sizes at ~70% of a 100%-covered ticker (post-cap), floored at 25% to avoid cliff behavior. Toggled via `coverage_sizing_enabled`.

## 3. Admission gate

`signal_reader.filter_buy_candidates_by_coverage` drops buy_candidates below `min_coverage_for_admission` (default 0.30). Refused tickers log a named WARNING + emit the
`AlphaEngine/Executor/admission_refused_count` CloudWatch metric.

Held positions exempt — admission applies only to NEW entries. Existing exposure still gets its exit/management path evaluated regardless of coverage.

## Wiring

`main.py::_read_signals` calls the admission gate right after the universe filter (post-signal-read, pre-sizer). `main.py::run` computes `coverage_map` alongside `atr_map` and passes it into `_plan_entries`, which forwards it to `compute_position_size`. Skipped in `simulate` mode to preserve backtester replay parity.

## Config

New keys in `config/risk.yaml.example`:
  coverage_sizing_enabled: true
  coverage_derate_floor: 0.25
  coverage_admission_enabled: true
  min_coverage_for_admission: 0.30

All backtester-tunable.

## Tests

23 new tests across 2 files. Full suite 315/315 passes.