### PR TITLE
fix(executor): constituents fallback for EOD sector enrichment

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -96,6 +96,41 @@ def _load_signals_from_s3(bucket: str, run_date: str, max_lookback: int = 5) -> 
     return {}, f"Signals unavailable from S3 for {run_date} (checked {max_lookback} days back)"
 
 
+def _load_constituents_sector_map(bucket: str) -> dict[str, str]:
+    """Return the latest S&P 500+400 ticker→GICS sector map from S3.
+
+    Reads ``market_data/weekly/{YYYY-MM-DD}/constituents.json`` written by
+    the alpha-engine-data weekly collector. Used as the final sector
+    lookup fallback in EOD reconcile — catches legacy/fractional-share
+    positions whose ticker isn't in today's research universe or whose
+    entry_trade row predates reliable sector population.
+
+    Returns an empty dict on miss so the caller can fall through to the
+    "Unknown" sentinel without raising.
+    """
+    s3 = boto3.client("s3")
+    try:
+        resp = s3.list_objects_v2(Bucket=bucket, Prefix="market_data/weekly/")
+        keys = [
+            obj["Key"] for obj in resp.get("Contents", [])
+            if obj["Key"].endswith("/constituents.json")
+        ]
+        if not keys:
+            logger.warning("No constituents.json under market_data/weekly/ in %s", bucket)
+            return {}
+        latest = max(keys)
+        obj = s3.get_object(Bucket=bucket, Key=latest)
+        data = json.loads(obj["Body"].read())
+        sector_map = data.get("sector_map", {}) or {}
+        logger.info(
+            "Loaded sector_map from %s (%d tickers)", latest, len(sector_map),
+        )
+        return sector_map
+    except Exception as e:
+        logger.error("Failed to load constituents sector_map: %s", e)
+        return {}
+
+
 def _load_predictions_from_s3(bucket: str) -> tuple[dict, str | None]:
     """Load latest predictions from S3. Returns ({ticker: pred_dict}, warning_msg) on failure."""
     s3 = boto3.client("s3")
@@ -368,9 +403,15 @@ def run(run_date: str | None = None) -> None:
             )
             _time.sleep(wait)
 
-    # Enrich positions with sector — signals.json first, entry-trade fallback.
+    # Enrich positions with sector. Lookup chain:
+    #   1. signals.json today (universe + buy_candidates)
+    #   2. trades.db entry_trade.sector
+    #   3. S&P 500+400 constituents.json (latest weekly snapshot) — catches
+    #      legacy/fractional-share positions whose ticker has fallen out of
+    #      today's research universe (e.g. dividend-reinvestment remnants).
     # A missing sector is an observability failure (blank rows in sector
-    # attribution), not a hard error — log loudly and continue with "Unknown".
+    # attribution), not a hard error — log loudly and continue with "Unknown"
+    # only when all three sources miss.
     signals_bucket = config.get("signals_bucket", "alpha-engine-research")
     try:
         sig_data, _ = _load_signals_from_s3(signals_bucket, run_date)
@@ -379,6 +420,7 @@ def run(run_date: str | None = None) -> None:
             t = s.get("ticker")
             if t and s.get("sector"):
                 sector_lookup[t] = s["sector"]
+        constituents_lookup: dict[str, str] | None = None
         for ticker in positions:
             if positions[ticker].get("sector"):
                 continue
@@ -389,9 +431,15 @@ def run(run_date: str | None = None) -> None:
             if entry and entry.get("sector"):
                 positions[ticker]["sector"] = entry["sector"]
                 continue
+            if constituents_lookup is None:
+                constituents_lookup = _load_constituents_sector_map(signals_bucket)
+            if ticker in constituents_lookup:
+                positions[ticker]["sector"] = constituents_lookup[ticker]
+                continue
             logger.error(
-                "Sector unknown for %s — missing from signals.json and entry trade. "
-                "Sector attribution will be incomplete.", ticker,
+                "Sector unknown for %s — missing from signals.json, entry trade, "
+                "and S&P 500+400 constituents. Sector attribution will be incomplete.",
+                ticker,
             )
             positions[ticker]["sector"] = "Unknown"
     except Exception as e:

--- a/tests/test_eod_reconcile_logic.py
+++ b/tests/test_eod_reconcile_logic.py
@@ -1,11 +1,14 @@
 """Tests for executor/eod_reconcile.py — testable logic without IB Gateway."""
 
-from unittest.mock import patch
+import io
+import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from executor.eod_reconcile import (
     _apply_dividend_delta,
+    _load_constituents_sector_map,
     _resolve_prior_price,
     _synthesize_rationales,
 )
@@ -152,3 +155,64 @@ class TestSynthesizeRationales:
         assert len(result) == 2
         assert "AAPL" in result
         assert "MSFT" in result
+
+
+class TestLoadConstituentsSectorMap:
+    """Sector enrichment fallback reads latest weekly constituents.json."""
+
+    def _mock_s3(self, keys: list[str], sector_map: dict | None):
+        s3 = MagicMock()
+        s3.list_objects_v2.return_value = {
+            "Contents": [{"Key": k} for k in keys],
+        }
+        body = {"sector_map": sector_map} if sector_map is not None else {}
+        s3.get_object.return_value = {
+            "Body": io.BytesIO(json.dumps(body).encode()),
+        }
+        return s3
+
+    @patch("executor.eod_reconcile.boto3")
+    def test_picks_latest_weekly_snapshot(self, mock_boto3):
+        # Lexicographic max of ISO dates == chronological latest
+        s3 = self._mock_s3(
+            keys=[
+                "market_data/weekly/2026-04-04/constituents.json",
+                "market_data/weekly/2026-04-18/constituents.json",
+                "market_data/weekly/2026-04-11/constituents.json",
+            ],
+            sector_map={"VRTX": "Health Care", "MSFT": "Information Technology"},
+        )
+        mock_boto3.client.return_value = s3
+
+        result = _load_constituents_sector_map("alpha-engine-research")
+
+        assert result == {"VRTX": "Health Care", "MSFT": "Information Technology"}
+        # Confirms the most recent key was the one fetched
+        s3.get_object.assert_called_once_with(
+            Bucket="alpha-engine-research",
+            Key="market_data/weekly/2026-04-18/constituents.json",
+        )
+
+    @patch("executor.eod_reconcile.boto3")
+    def test_empty_when_no_snapshots_listed(self, mock_boto3):
+        s3 = MagicMock()
+        s3.list_objects_v2.return_value = {"Contents": []}
+        mock_boto3.client.return_value = s3
+        assert _load_constituents_sector_map("bucket") == {}
+        s3.get_object.assert_not_called()
+
+    @patch("executor.eod_reconcile.boto3")
+    def test_empty_on_s3_exception(self, mock_boto3):
+        s3 = MagicMock()
+        s3.list_objects_v2.side_effect = RuntimeError("boom")
+        mock_boto3.client.return_value = s3
+        assert _load_constituents_sector_map("bucket") == {}
+
+    @patch("executor.eod_reconcile.boto3")
+    def test_empty_when_sector_map_missing_from_payload(self, mock_boto3):
+        s3 = self._mock_s3(
+            keys=["market_data/weekly/2026-04-18/constituents.json"],
+            sector_map=None,  # body has no sector_map key
+        )
+        mock_boto3.client.return_value = s3
+        assert _load_constituents_sector_map("bucket") == {}


### PR DESCRIPTION
## Summary
- Extend EOD sector enrichment with a third lookup step before the "Unknown" sentinel: the S&P 500+400 constituents snapshot written weekly by `alpha-engine-data` (`market_data/weekly/{date}/constituents.json`).
- Order of resolution: (1) today's `signals.json`, (2) `trades.db` entry_trade row, (3) latest weekly `constituents.json` `sector_map`, (4) log ERROR + "Unknown".
- Helper `_load_constituents_sector_map` is lazy (only called when steps 1–2 both miss) and tolerant (returns `{}` on S3 error or missing payload).

## 2026-04-22 incident
Six IB positions tripped the "Sector unknown" path and fired flow-doctor alerts:

| Ticker | Shares | Resolved GICS sector (from constituents) |
|---|---|---|
| ABBV | 1 | Health Care |
| CASY | 5 | Consumer Staples |
| MSFT | 1 | Information Technology |
| NVDA | 1 | Information Technology |
| V | 1 | Financials |
| VRTX | 312 | Health Care |

Five are 1–5 share dividend-reinvestment / fractional remnants whose tickers have rotated out of the tracked research universe. The sixth (VRTX, 312 shares) has an entry-trade row predating reliable sector population. All six resolve cleanly via the latest `market_data/weekly/2026-04-18/constituents.json` (503 tickers, complete coverage).

## Test plan
- [x] `pytest tests/` — 326 passed (4 new tests covering the helper: latest-snapshot selection, empty listing, S3 exception, missing `sector_map` key).
- [ ] Next weekday EOD: confirm zero flow-doctor sector-unknown alerts and populated sector attribution for all open positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)