### PR TITLE
feat(trades): dual-track calendar_date + trading_day per DATE_CONVENTIONS (PR 2)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -1020,6 +1020,12 @@ def _execute_entry(
         "trigger_type": trigger_reason,
         "spy_price_at_order": _spy_now,
         "slippage_vs_signal": _slippage,
+        # Date-convention dual-tracking. trading_day is the last completed
+        # NYSE session at fill time (populated by log_trade fallback if
+        # omitted); signal_trading_day links back to the signals.json that
+        # originated this entry — threaded through OrderBook from main.py's
+        # _read_signals(). See alpha-engine-docs/private/DATE_CONVENTIONS.md.
+        "signal_trading_day": entry.get("signal_date"),
     })
 
     # Mark entry as executed in order book

--- a/executor/main.py
+++ b/executor/main.py
@@ -560,6 +560,13 @@ def _plan_entries(
             ob.add_entry({
                 "ticker": ticker,
                 "signal": "ENTER",
+                # signal_date links each pending entry back to the signals.json
+                # file it originated from. Threaded to log_trade() at fill time
+                # as `signal_trading_day` so backtester ↔ live parity can match
+                # by signal cohort (DATE_CONVENTIONS.md). `run_date` here is
+                # the date returned by _read_signals — already the signal's
+                # trading_day per research's stamping convention.
+                "signal_date": run_date,
                 "shares": sizing["shares"],
                 "current_price": current_price,
                 "dollar_size": sizing["dollar_size"],

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -64,6 +64,16 @@ _TRADES_MIGRATIONS = [
     "ALTER TABLE trades ADD COLUMN realized_alpha_pct REAL",
     "ALTER TABLE trades ADD COLUMN days_held INTEGER",
     "ALTER TABLE trades ADD COLUMN slippage_vs_signal REAL",
+    # ── Date-convention dual-tracking (2026-04-24) ──
+    # See alpha-engine-docs/private/DATE_CONVENTIONS.md. Every trade-related
+    # artifact pairs calendar_date (existing `date`/`created_at` audit columns)
+    # with a trading_day (NYSE last-completed-session attribution) and, where
+    # applicable, the signal_trading_day that originated the trade. Both new
+    # columns are nullable so backfill on existing rows is a separate one-shot
+    # script (scripts/backfill_trading_day.py) and old log_trade() callers
+    # without the new context keep working as NULLs.
+    "ALTER TABLE trades ADD COLUMN trading_day TEXT",
+    "ALTER TABLE trades ADD COLUMN signal_trading_day TEXT",
 ]
 
 _EOD_MIGRATIONS = [
@@ -149,6 +159,22 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
     All other keys are optional.
     """
     trade_id = str(uuid.uuid4())
+    # If trading_day not provided by the caller, derive it from the
+    # date-convention helper so legacy call sites that haven't been migrated
+    # yet still get a populated trading_day rather than NULL. See
+    # alpha-engine-docs/private/DATE_CONVENTIONS.md for the rule
+    # (trading_day = last_closed_trading_day(now), strictly backward-looking).
+    # signal_trading_day stays NULL by default — only entry trades originating
+    # from a known signals.json populate it.
+    trading_day = trade.get("trading_day")
+    if trading_day is None:
+        try:
+            from alpha_engine_lib.dates import now_dual
+            trading_day = now_dual().trading_day
+        except Exception:
+            # Lib not yet bumped on this deploy — leave NULL. Backfill script
+            # closes the gap. Don't hard-fail on a missing optional dep.
+            trading_day = None
     conn.execute(
         """
         INSERT INTO trades (
@@ -162,8 +188,8 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             entry_trade_id, signal_price, trigger_price, trigger_type,
             spy_price_at_order, realized_pnl, realized_return_pct,
             spy_return_during_hold, realized_alpha_pct, days_held,
-            slippage_vs_signal, created_at
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            slippage_vs_signal, trading_day, signal_trading_day, created_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             trade_id,
@@ -203,6 +229,8 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             trade.get("realized_alpha_pct"),
             trade.get("days_held"),
             trade.get("slippage_vs_signal"),
+            trading_day,
+            trade.get("signal_trading_day"),
             datetime.now(timezone.utc).isoformat(),
         ),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ requests~=2.32
 #   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
 #   EC2: ~/.netrc covers github.com with a PAT that has Contents:read
 #        on alpha-engine-lib (confirm via git ls-remote before deploy).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.1.4
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.0

--- a/scripts/backfill_trading_day.py
+++ b/scripts/backfill_trading_day.py
@@ -1,0 +1,354 @@
+"""
+backfill_trading_day.py — one-shot backfill for the trading_day +
+signal_trading_day columns added to trades.db on 2026-04-24.
+
+Per alpha-engine-docs/private/DATE_CONVENTIONS.md:
+  - trading_day = last completed NYSE trading session at the moment of the
+    trade's fill_time (or created_at as fallback). Backward-looking.
+  - signal_trading_day = the trading_day of the signals.json that
+    originated this trade. For ENTER actions, back-resolved by walking
+    signals/{date}/signals.json files in S3 looking for the ticker. For
+    EXIT/REDUCE/manual-tool actions, NULL is acceptable.
+
+Idempotent: running this script multiple times produces the same result.
+A trade row is updated only if the target column is currently NULL — so
+forward-write call sites (the new daemon entry path) keep authoritative
+values and the backfill never overwrites them.
+
+Usage:
+    # Dry run — print what would be updated, no writes.
+    python scripts/backfill_trading_day.py --db-path /path/to/trades.db --dry-run
+
+    # Live backfill on ae-trading.
+    python scripts/backfill_trading_day.py --db-path /path/to/trades.db
+
+    # Limit signal-date back-resolution window (default 30 calendar days).
+    python scripts/backfill_trading_day.py --db-path ... --signal-lookback-days 60
+
+The signal-date back-resolution walks S3 from the trade's date backward.
+For each candidate date in [trade_date - lookback, trade_date], if
+signals/{date}/signals.json exists and contains the trade's ticker as
+ENTER (or any signal action — we match liberally because exits and
+reduces also originate from signal events), that date is the
+signal_trading_day. The first match wins (most recent signal that
+referenced the ticker).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sqlite3
+import sys
+from datetime import date, datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Lib helpers ─────────────────────────────────────────────────────────────
+
+
+def _import_lib_dates():
+    """Import alpha_engine_lib.dates with a clear error if the pin is stale."""
+    try:
+        from alpha_engine_lib.dates import session_for_timestamp
+        return session_for_timestamp
+    except ImportError as exc:
+        sys.stderr.write(
+            "ERROR: alpha_engine_lib.dates not importable. "
+            "This script requires alpha-engine-lib v0.2.0+. "
+            "Update requirements.txt and reinstall before running.\n"
+            f"Underlying ImportError: {exc}\n"
+        )
+        sys.exit(2)
+
+
+# ── Column-presence guard ───────────────────────────────────────────────────
+
+
+def _ensure_columns_exist(conn: sqlite3.Connection) -> None:
+    """Verify trading_day and signal_trading_day columns are present.
+    The init_db migration in trade_logger.py adds them; this script must
+    run AFTER trade_logger has touched the DB at least once on this deploy.
+    Hard-fail with a clear pointer if missing."""
+    cur = conn.execute("PRAGMA table_info(trades)")
+    cols = {row[1] for row in cur.fetchall()}
+    missing = {"trading_day", "signal_trading_day"} - cols
+    if missing:
+        sys.stderr.write(
+            f"ERROR: trades table is missing columns {missing}. "
+            f"Run trade_logger.init_db() against this DB first to apply "
+            f"the schema migration, then re-run the backfill.\n"
+        )
+        sys.exit(2)
+
+
+# ── trading_day backfill (from fill_time / created_at) ──────────────────────
+
+
+def _trading_day_for_row(row: dict, session_for_timestamp) -> Optional[str]:
+    """Compute trading_day for a row from its existing timestamp columns.
+
+    Prefers fill_time (when the IB fill landed) and falls back to
+    created_at (when log_trade inserted the row). Returns None only if
+    neither column has a parseable timestamp — indicates malformed
+    historical data, logged as a warning.
+    """
+    for col in ("fill_time", "created_at"):
+        val = row.get(col)
+        if not val:
+            continue
+        try:
+            ts = datetime.fromisoformat(val.replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            return session_for_timestamp(ts)
+        except (ValueError, TypeError) as exc:
+            logger.warning(
+                "Could not parse %s=%r for trade_id=%s: %s",
+                col, val, row.get("trade_id"), exc,
+            )
+            continue
+    return None
+
+
+# ── signal_trading_day back-resolution (S3 signals.json walk) ───────────────
+
+
+class _SignalIndex:
+    """Lazy ticker→signal_trading_day cache.
+
+    Walks signals/{date}/signals.json in S3 once per backfill run, building
+    a map of (ticker, set-of-signal-dates) so per-trade lookups are O(1).
+    Avoids repeated S3 GETs when many trades share the same originating
+    signal week.
+    """
+
+    def __init__(self, bucket: str, lookback_days: int):
+        self._bucket = bucket
+        self._lookback_days = lookback_days
+        self._ticker_to_signal_dates: dict[str, list[str]] = {}
+        self._loaded = False
+
+    def _load(self, earliest: date) -> None:
+        if self._loaded:
+            return
+        try:
+            import boto3
+        except ImportError as exc:
+            sys.stderr.write(f"ERROR: boto3 required for signal back-resolve: {exc}\n")
+            sys.exit(2)
+        s3 = boto3.client("s3")
+        # List signals/ keys under the bucket. The prefix is intentionally
+        # broad — we filter to ones >= earliest after listing.
+        paginator = s3.get_paginator("list_objects_v2")
+        n_files = 0
+        for page in paginator.paginate(Bucket=self._bucket, Prefix="signals/"):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if not key.endswith("/signals.json"):
+                    continue
+                # signals/{date}/signals.json — extract date.
+                parts = key.split("/")
+                if len(parts) < 3:
+                    continue
+                signal_date = parts[1]
+                try:
+                    dt = date.fromisoformat(signal_date)
+                except ValueError:
+                    continue
+                if dt < earliest:
+                    continue
+                try:
+                    body = s3.get_object(Bucket=self._bucket, Key=key)["Body"].read()
+                    payload = json.loads(body)
+                except Exception as exc:
+                    logger.warning("Could not read s3://%s/%s: %s", self._bucket, key, exc)
+                    continue
+                # Walk universe + buy_candidates + any other ticker-bearing
+                # arrays. Liberal match: any ticker that appears in this
+                # signals.json is considered a candidate originator.
+                tickers = self._extract_tickers(payload)
+                for t in tickers:
+                    self._ticker_to_signal_dates.setdefault(t, []).append(signal_date)
+                n_files += 1
+        # Each ticker's date list sorted descending so most-recent is first.
+        for t in self._ticker_to_signal_dates:
+            self._ticker_to_signal_dates[t].sort(reverse=True)
+        self._loaded = True
+        logger.info(
+            "Signal index built: %d signals.json files, %d unique tickers",
+            n_files, len(self._ticker_to_signal_dates),
+        )
+
+    @staticmethod
+    def _extract_tickers(payload: dict) -> set[str]:
+        tickers: set[str] = set()
+        # Common locations in the signals.json schema. Match liberally —
+        # back-resolution is best-effort and a missing match yields NULL,
+        # which is the documented soft-fail outcome.
+        for key in ("universe", "buy_candidates", "watchlist", "exits"):
+            arr = payload.get(key) or []
+            if isinstance(arr, list):
+                for item in arr:
+                    if isinstance(item, dict):
+                        t = item.get("ticker")
+                        if t:
+                            tickers.add(t)
+                    elif isinstance(item, str):
+                        tickers.add(item)
+            elif isinstance(arr, dict):
+                # universe sometimes keyed by ticker.
+                for t in arr.keys():
+                    tickers.add(t)
+        return tickers
+
+    def lookup(self, ticker: str, trade_date: str) -> Optional[str]:
+        """Return the most recent signal_trading_day ≤ trade_date for ticker."""
+        if not self._loaded:
+            try:
+                earliest = date.fromisoformat(trade_date) - _timedelta_days(self._lookback_days)
+            except ValueError:
+                earliest = date.fromisoformat("2026-01-01")
+            self._load(earliest)
+        candidates = self._ticker_to_signal_dates.get(ticker, [])
+        for sd in candidates:
+            if sd <= trade_date:
+                return sd
+        return None
+
+
+def _timedelta_days(n: int):
+    from datetime import timedelta
+    return timedelta(days=n)
+
+
+# ── Main loop ───────────────────────────────────────────────────────────────
+
+
+def backfill(
+    db_path: str,
+    bucket: str,
+    *,
+    dry_run: bool = False,
+    signal_lookback_days: int = 30,
+) -> dict:
+    """Run the backfill. Returns a stats dict for operator visibility."""
+    session_for_timestamp = _import_lib_dates()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    _ensure_columns_exist(conn)
+
+    rows = conn.execute(
+        """
+        SELECT trade_id, ticker, action, date, fill_time, created_at,
+               trading_day, signal_trading_day
+        FROM trades
+        ORDER BY created_at
+        """
+    ).fetchall()
+
+    signal_index = _SignalIndex(bucket=bucket, lookback_days=signal_lookback_days)
+
+    stats = {
+        "total_rows": len(rows),
+        "trading_day_filled": 0,
+        "trading_day_already_set": 0,
+        "trading_day_unresolved": 0,
+        "signal_trading_day_filled": 0,
+        "signal_trading_day_already_set": 0,
+        "signal_trading_day_unresolved_enter": 0,
+        "non_enter_skipped": 0,
+        "writes_committed": 0,
+    }
+
+    for row in rows:
+        row_d = dict(row)
+        updates: dict[str, str] = {}
+
+        # trading_day backfill
+        if row_d.get("trading_day"):
+            stats["trading_day_already_set"] += 1
+        else:
+            td = _trading_day_for_row(row_d, session_for_timestamp)
+            if td:
+                updates["trading_day"] = td
+                stats["trading_day_filled"] += 1
+            else:
+                stats["trading_day_unresolved"] += 1
+
+        # signal_trading_day backfill (ENTER actions only — others stay NULL)
+        if row_d.get("signal_trading_day"):
+            stats["signal_trading_day_already_set"] += 1
+        elif row_d.get("action") == "ENTER" and row_d.get("ticker") and row_d.get("date"):
+            std = signal_index.lookup(row_d["ticker"], row_d["date"])
+            if std:
+                updates["signal_trading_day"] = std
+                stats["signal_trading_day_filled"] += 1
+            else:
+                stats["signal_trading_day_unresolved_enter"] += 1
+        else:
+            stats["non_enter_skipped"] += 1
+
+        if updates and not dry_run:
+            set_clause = ", ".join(f"{k} = ?" for k in updates.keys())
+            params = list(updates.values()) + [row_d["trade_id"]]
+            conn.execute(
+                f"UPDATE trades SET {set_clause} WHERE trade_id = ?",
+                params,
+            )
+            stats["writes_committed"] += 1
+
+    if not dry_run:
+        conn.commit()
+
+    return stats
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--db-path", required=True, help="Path to trades.db on disk.")
+    p.add_argument(
+        "--bucket",
+        default="alpha-engine-research",
+        help="S3 bucket for signals.json walk (default: alpha-engine-research).",
+    )
+    p.add_argument(
+        "--signal-lookback-days",
+        type=int,
+        default=30,
+        help="How many calendar days to walk back when listing signals.json (default 30).",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute updates but don't write to the database.",
+    )
+    p.add_argument("--log-level", default="INFO", help="DEBUG | INFO | WARNING | ERROR")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper()),
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
+    stats = backfill(
+        db_path=args.db_path,
+        bucket=args.bucket,
+        dry_run=args.dry_run,
+        signal_lookback_days=args.signal_lookback_days,
+    )
+    print(json.dumps(stats, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_trades_db_dual_tracking.py
+++ b/tests/test_trades_db_dual_tracking.py
@@ -1,0 +1,361 @@
+"""Tests for the trades.db dual-tracking migration (2026-04-24).
+
+Covers:
+  * Schema migration is idempotent — re-running init_db() against a DB that
+    already has the new columns is a no-op.
+  * log_trade() populates trading_day via the alpha_engine_lib.dates fallback
+    when the caller doesn't pass it explicitly.
+  * log_trade() honors an explicit trading_day from the caller (live daemon
+    path will populate this from the OrderBook entry context).
+  * signal_trading_day defaults to NULL and is written when provided.
+  * Backfill script populates NULL columns idempotently and never overwrites
+    existing values.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from executor.trade_logger import init_db, log_trade
+
+
+# ── init_db idempotence + column presence ───────────────────────────────────
+
+
+def _columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute("PRAGMA table_info(trades)")
+    cols = {row[1] for row in cur.fetchall()}
+    conn.close()
+    return cols
+
+
+def test_init_db_creates_dual_tracking_columns(tmp_path):
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    cols = _columns(db_path)
+    assert "trading_day" in cols
+    assert "signal_trading_day" in cols
+
+
+def test_init_db_idempotent(tmp_path):
+    """Running init_db twice on the same path doesn't error."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    # Second invocation hits the duplicate-column branch in the migration loop.
+    conn = init_db(str(db_path))
+    conn.close()
+    cols = _columns(db_path)
+    assert "trading_day" in cols
+    assert "signal_trading_day" in cols
+
+
+def test_init_db_idempotent_after_legacy_db(tmp_path):
+    """Simulate a pre-migration DB by creating only the legacy schema, then
+    init_db should add the new columns without error."""
+    db_path = tmp_path / "trades.db"
+    # Create the legacy schema manually (subset of pre-2026-04-24 columns).
+    legacy_conn = sqlite3.connect(str(db_path))
+    legacy_conn.execute(
+        """
+        CREATE TABLE trades (
+            trade_id TEXT PRIMARY KEY,
+            date TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            action TEXT NOT NULL,
+            shares INTEGER NOT NULL,
+            created_at TEXT NOT NULL
+        )
+        """
+    )
+    legacy_conn.commit()
+    legacy_conn.close()
+    # Now run init_db — should ALTER TABLE for every migration including ours.
+    conn = init_db(str(db_path))
+    conn.close()
+    cols = _columns(db_path)
+    assert "trading_day" in cols
+    assert "signal_trading_day" in cols
+
+
+# ── log_trade column population ─────────────────────────────────────────────
+
+
+def _read_back(db_path: Path, trade_id: str) -> dict:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT * FROM trades WHERE trade_id = ?", (trade_id,)).fetchone()
+    conn.close()
+    assert row is not None, f"trade {trade_id} not found"
+    return dict(row)
+
+
+def _minimal_trade(**overrides) -> dict:
+    base = {
+        "date": "2026-04-27",
+        "ticker": "AAPL",
+        "action": "ENTER",
+        "shares": 100,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_log_trade_populates_trading_day_via_fallback(tmp_path):
+    """No trading_day in trade dict → log_trade derives it via now_dual()."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    trade_id = log_trade(conn, _minimal_trade())
+    conn.close()
+    row = _read_back(db_path, trade_id)
+    # Either lib is installed and trading_day is populated, or lib import
+    # failed and it stays NULL — either is acceptable for backward-compat.
+    # We assert that NO ERROR was raised; the precise value depends on lib
+    # availability at test time.
+    assert row["trade_id"] == trade_id  # row was inserted
+
+
+def test_log_trade_honors_explicit_trading_day(tmp_path):
+    """Caller-provided trading_day takes precedence over the fallback."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    trade_id = log_trade(conn, _minimal_trade(trading_day="2026-04-24"))
+    conn.close()
+    row = _read_back(db_path, trade_id)
+    assert row["trading_day"] == "2026-04-24"
+
+
+def test_log_trade_signal_trading_day_default_null(tmp_path):
+    """signal_trading_day stays NULL when not provided."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    trade_id = log_trade(conn, _minimal_trade())
+    conn.close()
+    row = _read_back(db_path, trade_id)
+    assert row["signal_trading_day"] is None
+
+
+def test_log_trade_signal_trading_day_explicit(tmp_path):
+    """Caller-provided signal_trading_day is stored."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    trade_id = log_trade(
+        conn,
+        _minimal_trade(signal_trading_day="2026-04-24"),
+    )
+    conn.close()
+    row = _read_back(db_path, trade_id)
+    assert row["signal_trading_day"] == "2026-04-24"
+
+
+def test_log_trade_legacy_callers_still_work(tmp_path):
+    """Backward compat: a trade dict with no new fields inserts cleanly.
+    All legacy daemon/exit/manual-tool call sites pass through this path."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    trade_id = log_trade(
+        conn,
+        _minimal_trade(
+            price_at_order=100.0,
+            fill_price=100.5,
+            fill_time="2026-04-27T14:30:00+00:00",
+            ib_order_id=12345,
+        ),
+    )
+    conn.close()
+    row = _read_back(db_path, trade_id)
+    assert row["trade_id"] == trade_id
+    assert row["fill_price"] == 100.5
+
+
+# ── Backfill script ─────────────────────────────────────────────────────────
+
+
+def _seed_trades(db_path: Path, trades: list[dict]) -> None:
+    conn = init_db(str(db_path))
+    for trade in trades:
+        log_trade(conn, trade)
+    conn.close()
+
+
+def _read_all(db_path: Path) -> list[dict]:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = [dict(r) for r in conn.execute("SELECT * FROM trades ORDER BY created_at").fetchall()]
+    conn.close()
+    return rows
+
+
+def _set_columns_null(db_path: Path) -> None:
+    """Force trading_day + signal_trading_day to NULL on every row, simulating
+    a fresh-from-pre-migration state for the backfill to operate on."""
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("UPDATE trades SET trading_day = NULL, signal_trading_day = NULL")
+    conn.commit()
+    conn.close()
+
+
+def test_backfill_dry_run_does_not_write(tmp_path):
+    """--dry-run computes updates but doesn't mutate the DB."""
+    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    from scripts import backfill_trading_day
+
+    db_path = tmp_path / "trades.db"
+    _seed_trades(db_path, [
+        {
+            "date": "2026-04-27",
+            "ticker": "AAPL",
+            "action": "ENTER",
+            "shares": 100,
+            "fill_time": "2026-04-27T14:30:00+00:00",
+        },
+    ])
+    _set_columns_null(db_path)
+
+    # Mock the SignalIndex S3 walk since we don't have a real bucket in tests.
+    with patch.object(backfill_trading_day, "_SignalIndex") as mock_index_cls:
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "2026-04-24"
+        mock_index_cls.return_value = mock_index
+
+        stats = backfill_trading_day.backfill(
+            db_path=str(db_path),
+            bucket="test-bucket",
+            dry_run=True,
+        )
+
+    assert stats["trading_day_filled"] >= 1
+    # No writes committed despite computed updates.
+    assert stats["writes_committed"] == 0
+    rows = _read_all(db_path)
+    assert all(r["trading_day"] is None for r in rows)
+
+
+def test_backfill_idempotent(tmp_path):
+    """Running backfill twice produces the same end state — already-set
+    columns are skipped on the second pass."""
+    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    from scripts import backfill_trading_day
+
+    db_path = tmp_path / "trades.db"
+    _seed_trades(db_path, [
+        {
+            "date": "2026-04-27",
+            "ticker": "AAPL",
+            "action": "ENTER",
+            "shares": 100,
+            "fill_time": "2026-04-27T14:30:00+00:00",
+        },
+        {
+            "date": "2026-04-27",
+            "ticker": "MSFT",
+            "action": "EXIT",
+            "shares": 50,
+            "fill_time": "2026-04-27T15:00:00+00:00",
+        },
+    ])
+    _set_columns_null(db_path)
+
+    with patch.object(backfill_trading_day, "_SignalIndex") as mock_index_cls:
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "2026-04-24"
+        mock_index_cls.return_value = mock_index
+
+        stats1 = backfill_trading_day.backfill(
+            db_path=str(db_path), bucket="test-bucket", dry_run=False,
+        )
+        rows_after_first = _read_all(db_path)
+
+        stats2 = backfill_trading_day.backfill(
+            db_path=str(db_path), bucket="test-bucket", dry_run=False,
+        )
+        rows_after_second = _read_all(db_path)
+
+    # First pass writes both rows (trading_day for each + signal_trading_day for ENTER).
+    assert stats1["writes_committed"] >= 1
+    # Second pass writes nothing — every row's columns are already populated.
+    assert stats2["writes_committed"] == 0
+    # State is stable across the two runs.
+    assert rows_after_first == rows_after_second
+
+
+def test_backfill_does_not_overwrite_existing_values(tmp_path):
+    """If trading_day is already set (e.g., from a forward-write call site),
+    the backfill must not overwrite it."""
+    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    from scripts import backfill_trading_day
+
+    db_path = tmp_path / "trades.db"
+    _seed_trades(db_path, [
+        {
+            "date": "2026-04-27",
+            "ticker": "AAPL",
+            "action": "ENTER",
+            "shares": 100,
+            "fill_time": "2026-04-27T14:30:00+00:00",
+            "trading_day": "EXPLICIT_VALUE",  # forward-write authoritative
+            "signal_trading_day": "EXPLICIT_SIGNAL",
+        },
+    ])
+    # Don't NULL — leave the explicit values in place.
+
+    with patch.object(backfill_trading_day, "_SignalIndex") as mock_index_cls:
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "BACKFILL_GUESS"
+        mock_index_cls.return_value = mock_index
+
+        stats = backfill_trading_day.backfill(
+            db_path=str(db_path), bucket="test-bucket", dry_run=False,
+        )
+
+    assert stats["writes_committed"] == 0
+    assert stats["trading_day_already_set"] == 1
+    assert stats["signal_trading_day_already_set"] == 1
+    rows = _read_all(db_path)
+    assert rows[0]["trading_day"] == "EXPLICIT_VALUE"
+    assert rows[0]["signal_trading_day"] == "EXPLICIT_SIGNAL"
+
+
+def test_backfill_skips_signal_trading_day_for_non_enter(tmp_path):
+    """EXIT and REDUCE actions don't have a signal_trading_day backfill —
+    they stay NULL by design (they're outcomes of held positions, not new
+    signal-driven entries)."""
+    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    from scripts import backfill_trading_day
+
+    db_path = tmp_path / "trades.db"
+    _seed_trades(db_path, [
+        {
+            "date": "2026-04-27",
+            "ticker": "AAPL",
+            "action": "EXIT",
+            "shares": 100,
+            "fill_time": "2026-04-27T14:30:00+00:00",
+        },
+    ])
+    _set_columns_null(db_path)
+
+    with patch.object(backfill_trading_day, "_SignalIndex") as mock_index_cls:
+        mock_index = MagicMock()
+        mock_index.lookup.return_value = "2026-04-24"
+        mock_index_cls.return_value = mock_index
+
+        stats = backfill_trading_day.backfill(
+            db_path=str(db_path), bucket="test-bucket", dry_run=False,
+        )
+
+    assert stats["non_enter_skipped"] == 1
+    rows = _read_all(db_path)
+    assert rows[0]["signal_trading_day"] is None
+    # trading_day still gets backfilled — that's based on fill_time, not action.
+    assert rows[0]["trading_day"] is not None


### PR DESCRIPTION
## Summary
PR 2 of the system-wide date-convention rollout. Adds `trading_day` + `signal_trading_day` columns to `trades.db`; threads `signal_date` from `_read_signals` through the OrderBook to the daemon's entry-fill log; ships a backfill script for the 165 historical rows.

This is the **actual parity-divergence unblock**. Once this lands + backfill runs + alpha-engine-backtester PR 3 (parity-test alignment) ships, the parity test compares cohorts by `signal_trading_day` and the 80%+ noise floor from the 2026-04-24 dry-run drops out.

## Spec
[`DATE_CONVENTIONS.md`](https://github.com/cipher813/alpha-engine-docs/blob/main/private/DATE_CONVENTIONS.md) — the policy. The rule: `trading_day = last_completed_trading_day(now)`, strictly backward-looking. `signal_trading_day` = the trading_day of the signals.json that originated this trade.

## Foundation
- alpha-engine-lib v0.2.0 (lib PR #7, merged): adds `alpha_engine_lib.dates.now_dual()` + `session_for_timestamp()`.
- `requirements.txt` bumped from `@v0.1.4` → `@v0.2.0`.

## Changes

**`executor/trade_logger.py`**
- Two new ALTER TABLE migrations appended to `_TRADES_MIGRATIONS` (idempotent — duplicate-column branch already handles re-runs).
- `log_trade()` pulls `trading_day` from the trade dict, falls back to `now_dual()` if missing, never raises if the lib is unavailable. `signal_trading_day` is written iff present.

**`executor/main.py`**
- `ob.add_entry({...})` (line 560) now embeds `signal_date=run_date`. `run_date` is the date returned by `_read_signals()` — already the signal's trading_day per research's stamping convention.

**`executor/daemon.py`**
- Entry-execution `log_trade` call (line 988) extracts `entry.get("signal_date")` and passes it as `signal_trading_day`.
- Exit paths (lines 566, 865) leave `signal_trading_day` NULL — exits aren't signal-cohort-driven.
- Manual tools (`liquidate_all`, `emergency_shutdown`) leave both NULL — log_trade fallback covers trading_day.

**`scripts/backfill_trading_day.py`** (new)
- Backfills `trading_day` via `session_for_timestamp(fill_time or created_at)` on every row where it's currently NULL.
- For ENTER actions, back-resolves `signal_trading_day` by walking `signals/{date}/signals.json` files in S3, building a ticker → most-recent-signal-date index.
- `--dry-run` mode; idempotent; never overwrites existing values.

**`tests/test_trades_db_dual_tracking.py`** (new)
- 12 tests covering schema migration idempotence, log_trade fallback + explicit paths, backfill dry-run no-write, idempotency, no-overwrite-existing, non-ENTER skip.
- All 12 pass locally; full executor suite 341/341 pass (no regressions).

## Deploy plan (paper-soak window before Monday market open)

```bash
# 1. Merge this PR

# 2. On ae-trading: pull + reinstall (picks up lib v0.2.0)
ae-trading "cd ~/alpha-engine && git pull && source .venv/bin/activate && pip install -r requirements.txt"

# 3. Verify schema migration applied (init_db runs on next executor start, but
#    you can also force it by importing trade_logger):
ae-trading "cd ~/alpha-engine && source .venv/bin/activate && python -c 'from executor.trade_logger import init_db; conn = init_db(\"~/alpha-engine/trades.db\"); print(conn.execute(\"PRAGMA table_info(trades)\").fetchall()[-2:])'"

# 4. Run backfill in dry-run first
ae-trading "cd ~/alpha-engine && source .venv/bin/activate && python scripts/backfill_trading_day.py --db-path ~/alpha-engine/trades.db --dry-run"

# 5. Review stats output, then run live
ae-trading "cd ~/alpha-engine && source .venv/bin/activate && python scripts/backfill_trading_day.py --db-path ~/alpha-engine/trades.db"

# 6. Restart daemon (so new code path is live for Monday)
ae-trading "sudo systemctl restart alpha-engine-daemon.service"

# 7. Verify
ae-trading "cd ~/alpha-engine && source .venv/bin/activate && python -c 'import sqlite3; c=sqlite3.connect(\"~/alpha-engine/trades.db\"); rows=c.execute(\"SELECT trade_id, trading_day, signal_trading_day FROM trades ORDER BY created_at DESC LIMIT 5\").fetchall(); print(rows)'"
```

## Sequencing for re-enabling Saturday SF
The Sat SF EventBridge rule was disabled tonight (2026-04-24) to skip the noisy parity run. Re-enable after this PR + alpha-engine-backtester PR 3 (parity test alignment):

```bash
aws events enable-rule --name alpha-engine-saturday
```

Manual SF execution is also an option once the backfill + daemon restart land — exercises the new path end-to-end.

## Sequence in the broader migration
- PR 1 (lib v0.2.0): merged, tagged
- **PR 2 (this PR)**: trades.db dual-tracking + backfill
- PR 3 (alpha-engine-backtester): parity test matches by `signal_trading_day` instead of `(date, ticker, action)`
- PR 4 (alpha-engine-predictor): predictions.json dual-track + holiday gate
- PR 5 (alpha-engine-research): signals.json adds `calendar_date` audit field
- PR 6 (alpha-engine-data): weekly artifacts add `trading_day_as_of`

🤖 Generated with [Claude Code](https://claude.com/claude-code)