### PR TITLE
fix(executor): simulate-mode propagates positions to sim_client

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -518,6 +518,14 @@ def _plan_entries(
 
         n_entered += 1
         if simulate:
+            # Accumulate position state on the simulated client so the
+            # held-position guard above (line ~392 "SKIP ENTER ... already
+            # in portfolio") fires correctly on subsequent simulate dates.
+            # Without this, sim_client._positions stays empty across every
+            # signal date and the backtester re-ENTERs already-held tickers
+            # — the parity over-shoot pattern observed 2026-04-25 (bt=86 vs
+            # live=55, the extra bt orders were all currently-held names).
+            ibkr.place_market_order(ticker, "BUY", sizing["shares"])
             orders.append({
                 "date": run_date,
                 "ticker": ticker,
@@ -661,6 +669,9 @@ def _plan_exits_and_reduces(
             current_price = ibkr.get_current_price(ticker)
             if current_price is None:
                 current_price = current_positions[ticker].get("avg_cost", 0)
+            # Match ENTER simulate path — propagate state to sim_client so
+            # downstream sim dates see the EXITed position as gone.
+            ibkr.place_market_order(ticker, "SELL", shares_held)
             orders.append({
                 "date": run_date,
                 "ticker": ticker,
@@ -731,6 +742,9 @@ def _plan_exits_and_reduces(
             if current_price is None:
                 current_price = current_positions[ticker].get("avg_cost", 0)
             remaining_value = (shares_held - shares_to_sell) * (current_price or 0)
+            # Match ENTER/EXIT simulate paths — partial sell on sim_client
+            # so the position's reduced shares carry to the next sim date.
+            ibkr.place_market_order(ticker, "SELL", shares_to_sell)
             orders.append({
                 "date": run_date,
                 "ticker": ticker,


### PR DESCRIPTION
## Summary

Three branches in \`executor.main.run\` (ENTER ~line 520, EXIT ~660, REDUCE ~729) appended orders to the return list but never called \`ibkr.place_market_order()\` in simulate mode. Result: \`sim_client._positions\` stayed empty across every simulate date — the held-position guard at line ~392 (\`"SKIP ENTER ... already in portfolio"\`) never fired in simulate mode.

## Symptom

Caught 2026-04-25 Sat SF parity report against post-PR-#98 \`trades.db\`:
- \`n_live_enters_matchable: 55\`
- \`n_backtester_enters: 86\`
- The +1 to +10 over-shoot tickers per signal_trading_day (JHG, LNTH, PFE, CME, NVT, TER, FAST, MA, etc.) are exactly the names **currently held** in the live paper portfolio.

Live executor correctly suppresses re-entry on already-held names; simulate path bypassed the guard because no state ever transitioned through sim_client.

## Fix

In each simulate branch, call \`ibkr.place_market_order()\` with the matching action/shares before appending to \`orders\`. The existing \`SimulatedIBKRClient.place_market_order()\` already correctly mutates \`_positions\` for BUY/SELL — we just needed to actually call it.

| Branch | Call added |
|---|---|
| ENTER | \`ibkr.place_market_order(ticker, "BUY", sizing["shares"])\` |
| EXIT | \`ibkr.place_market_order(ticker, "SELL", shares_held)\` |
| REDUCE | \`ibkr.place_market_order(ticker, "SELL", shares_to_sell)\` |

## Side effect

Param-sweep simulation results will change. Yesterday's Sharpe numbers came from the broken sim that re-ENTERed every signal date from a fresh portfolio. New numbers reflect realistic mark-to-market state — **correctness improvement, not regression.**

## Test plan

- [x] 341/341 existing tests pass — no test had asserted the broken behavior
- [ ] Live: parity-only spot run via SSM after merge; expect bt-enters drops from 86 → ~55 (matching live count, give or take)

🤖 Generated with [Claude Code](https://claude.com/claude-code)