### PR TITLE
chore(iam): codify alpha-engine-executor-role inline policies

### DIFF
--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -1,0 +1,86 @@
+# IAM policies (alpha-engine executor)
+
+Source-of-truth for the inline IAM policies on the executor's IAM roles.
+Mirrors the `alpha-engine-data` codification pattern (one JSON file per
+inline policy + an `apply.sh` runner) with a directory-per-role layout
+since the executor role has multiple inline policies.
+
+## Layout
+
+```
+infrastructure/iam/
+├── apply.sh
+├── README.md
+└── <role-name>/
+    ├── <policy-1>.json
+    ├── <policy-2>.json
+    └── ...
+```
+
+The directory name is the IAM role name; each JSON filename (minus `.json`)
+is the inline policy name on that role.
+
+## Roles managed here
+
+- **`alpha-engine-executor-role`** — assumed by the trading EC2 instance
+  (`ae-trading`) and any executor processes assuming it. 9 inline policies
+  as of 2026-04-27. Trust policy + role creation are NOT managed here
+  (out of scope for the flat-file approach).
+
+## Out of scope (not codified here)
+
+- Trust policies (`AssumeRolePolicyDocument`) — those are role creation,
+  managed manually
+- Managed policies (e.g. `AmazonSSMManagedInstanceCore` is attached to
+  `alpha-engine-executor-role`) — managed manually via attach commands
+- Role creation itself — pre-existing, managed manually
+
+## Usage
+
+```bash
+# Apply every policy in this directory tree
+./infrastructure/iam/apply.sh
+
+# Apply every policy on one role
+./infrastructure/iam/apply.sh --role alpha-engine-executor-role
+
+# Apply one specific policy
+./infrastructure/iam/apply.sh --role alpha-engine-executor-role --policy alpha-engine-cloudwatch-metrics
+
+# Print planned commands without executing
+./infrastructure/iam/apply.sh --dry-run
+```
+
+`apply.sh` calls `aws iam put-role-policy`, which is idempotent — re-running
+overwrites the existing inline policy on the role. To remove a policy you
+codified here, delete the file AND run `aws iam delete-role-policy` manually
+(removal is not yet automated to avoid an `apply.sh` invocation accidentally
+wiping policies whose JSON file was deleted in a stale checkout).
+
+## Drift detection
+
+There is no automated drift detector in this repo today. To check whether
+any role's inline policies have drifted from this directory:
+
+```bash
+aws iam list-role-policies --role-name alpha-engine-executor-role
+```
+
+The set of returned policy names should match the set of `.json` files in
+`alpha-engine-executor-role/`.
+
+## When you add a new inline policy
+
+1. Apply it to AWS first (e.g. via `aws iam put-role-policy ...`)
+2. Save the JSON document to the matching directory
+3. Commit the file with a description of why the grant was needed
+
+## When you remove an inline policy
+
+1. Delete the file from this directory
+2. Run `aws iam delete-role-policy --role-name <role> --policy-name <policy>`
+3. Commit the deletion
+
+The flat-file approach is intentionally low-ceremony — if the blast radius
+grows (cross-account, multiple roles per service, complex trust-policy
+state), migrate to CloudFormation/Terraform.

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PutAlphaEngineMetrics",
+            "Effect": "Allow",
+            "Action": "cloudwatch:PutMetricData",
+            "Resource": "*",
+            "Condition": {
+                "StringLike": {
+                    "cloudwatch:namespace": "AlphaEngine/*"
+                }
+            }
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ec2-spot.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ec2-spot.json
@@ -1,0 +1,23 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SpotInstanceLaunch",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:RunInstances",
+                "ec2:DescribeInstances",
+                "ec2:TerminateInstances",
+                "ec2:CreateTags",
+                "ec2:DescribeInstanceStatus"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "PassRoleToSpot",
+            "Effect": "Allow",
+            "Action": "iam:PassRole",
+            "Resource": "arn:aws:iam::711398986525:role/alpha-engine-executor-role"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-research-bucket-write.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-research-bucket-write.json
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:ListBucket",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::alpha-engine-research",
+                "arn:aws:s3:::alpha-engine-research/*"
+            ]
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
@@ -1,0 +1,91 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListResearchBucket",
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::alpha-engine-research"
+        },
+        {
+            "Sid": "ReadResearchSignals",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::alpha-engine-research/signals/*"
+        },
+        {
+            "Sid": "ReadResearchDb",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::alpha-engine-research/research.db"
+        },
+        {
+            "Sid": "ReadPrices",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::alpha-engine-research/prices/*"
+        },
+        {
+            "Sid": "ReadPopulation",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::alpha-engine-research/population/*"
+        },
+        {
+            "Sid": "ReadWritePredictorData",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::alpha-engine-research/predictor/weights/*",
+                "arn:aws:s3:::alpha-engine-research/predictor/predictions/*",
+                "arn:aws:s3:::alpha-engine-research/predictor/price_cache/*",
+                "arn:aws:s3:::alpha-engine-research/predictor/price_cache_slim/*",
+                "arn:aws:s3:::alpha-engine-research/predictor/daily_closes/*",
+                "arn:aws:s3:::alpha-engine-research/predictor/metrics/*"
+            ]
+        },
+        {
+            "Sid": "ReadWriteBacktestResults",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::alpha-engine-research/backtest/*"
+        },
+        {
+            "Sid": "ReadWriteAutoConfig",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::alpha-engine-research/config/*"
+        },
+        {
+            "Sid": "ReadWriteExecutorBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::alpha-engine-executor",
+                "arn:aws:s3:::alpha-engine-executor/*"
+            ]
+        },
+        {
+            "Sid": "ReadWriteHealth",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::alpha-engine-research/health/*"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ses-send.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ses-send.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "ses:SendEmail",
+            "Resource": "*"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-access.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter"
+            ],
+            "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/*"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-read.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-read.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "SSMParameterStoreRead",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParametersByPath",
+                "ssm:GetParameter"
+            ],
+            "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/alpha-engine/*"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-stepfunctions-eod.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-stepfunctions-eod.json
@@ -1,0 +1,10 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "states:StartExecution",
+            "Resource": "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        }
+    ]
+}

--- a/infrastructure/iam/alpha-engine-executor-role/mnemon-s3-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/mnemon-s3-access.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::mnemon-memory",
+                "arn:aws:s3:::mnemon-memory/*"
+            ]
+        }
+    ]
+}

--- a/infrastructure/iam/apply.sh
+++ b/infrastructure/iam/apply.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# apply.sh — Apply all IAM inline policies in this directory tree to their
+# matching roles.
+#
+# Layout (directory-per-role to support multiple inline policies per role):
+#
+#   infrastructure/iam/<role-name>/<policy-name>.json
+#
+# Each JSON file is a policy document. The directory name is the IAM role
+# name. The filename (minus .json) is the inline policy name. This keeps the
+# 1:1 file→inline-policy mapping that alpha-engine-data established, while
+# accommodating roles that already have multiple inline policies in prod
+# (the executor role has 9 as of 2026-04-27).
+#
+# This is intentionally low-ceremony — no CloudFormation, no Terraform.
+# Trust policies + role creation are NOT managed here (out of scope for a
+# flat-file approach); the script only updates inline policies on roles
+# that already exist.
+#
+# Usage:
+#   ./infrastructure/iam/apply.sh                                # apply every policy
+#   ./infrastructure/iam/apply.sh --role alpha-engine-executor-role
+#                                                                # one role, all policies
+#   ./infrastructure/iam/apply.sh --role <role> --policy <name>  # one specific policy
+#   ./infrastructure/iam/apply.sh --dry-run                      # print planned commands
+#
+# Prerequisites:
+#   - AWS CLI configured with iam:PutRolePolicy on the target roles
+#   - The target IAM roles already exist in AWS
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGION="${AWS_REGION:-us-east-1}"
+
+DRY_RUN=0
+TARGET_ROLE=""
+TARGET_POLICY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --role)
+      TARGET_ROLE="$2"
+      shift 2
+      ;;
+    --policy)
+      TARGET_POLICY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+apply_one() {
+  local file="$1"
+  local role
+  role="$(basename "$(dirname "$file")")"
+  local policy_name
+  policy_name="$(basename "$file" .json)"
+
+  if ! python3 -c "import json; json.load(open('$file'))" 2>/dev/null; then
+    echo "ERROR: $file is not valid JSON — skipping" >&2
+    return 1
+  fi
+
+  echo "Applying $file -> role=$role policy=$policy_name"
+  if [ "$DRY_RUN" = 1 ]; then
+    echo "  [dry-run] aws iam put-role-policy --role-name $role --policy-name $policy_name --policy-document file://$file --region $REGION"
+    return 0
+  fi
+
+  aws iam put-role-policy \
+    --role-name "$role" \
+    --policy-name "$policy_name" \
+    --policy-document "file://$file" \
+    --region "$REGION"
+  echo "  OK"
+}
+
+cd "$SCRIPT_DIR"
+
+shopt -s nullglob
+
+if [[ -n "$TARGET_ROLE" && -n "$TARGET_POLICY" ]]; then
+  file="${TARGET_ROLE}/${TARGET_POLICY}.json"
+  if [[ ! -f "$file" ]]; then
+    echo "ERROR: $file not found" >&2
+    exit 1
+  fi
+  apply_one "$file"
+elif [[ -n "$TARGET_ROLE" ]]; then
+  if [[ ! -d "$TARGET_ROLE" ]]; then
+    echo "ERROR: role directory $TARGET_ROLE not found" >&2
+    exit 1
+  fi
+  files=( "$TARGET_ROLE"/*.json )
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No .json policy files found in $TARGET_ROLE/"
+    exit 0
+  fi
+  for file in "${files[@]}"; do
+    apply_one "$file"
+  done
+else
+  files=( */*.json )
+  if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No .json policy files found under $SCRIPT_DIR"
+    exit 0
+  fi
+  for file in "${files[@]}"; do
+    apply_one "$file"
+  done
+fi


### PR DESCRIPTION
## Summary
- Brings the executor's 9 inline IAM policies under source control, mirroring the alpha-engine-data pattern (one JSON file per inline policy + `apply.sh` runner). Adopted a directory-per-role layout (`infrastructure/iam/<role>/<policy>.json`) so multi-policy roles are first class — alpha-engine-data's flat single-file-per-role layout assumed one policy per role, which doesn't hold here.
- Today's `cloudwatch:PutMetricData` grant (added 2026-04-27 14:24 UTC during the morning incident recovery) was previously memory-only via `reference_iam_executor_cloudwatch_grant`. Now reproducible from source.
- Verified locally: `bash infrastructure/iam/apply.sh` applied all 9 policies cleanly (idempotent put-role-policy). `aws iam list-role-policies --role-name alpha-engine-executor-role` now matches the set of `.json` files exactly.

## Codified policies
- `alpha-engine-cloudwatch-metrics` — new today, scoped to `AlphaEngine/*` namespace
- `alpha-engine-ec2-spot`
- `alpha-engine-research-bucket-write`
- `alpha-engine-s3-access`
- `alpha-engine-ses-send`
- `alpha-engine-ssm-access`
- `alpha-engine-ssm-read`
- `alpha-engine-stepfunctions-eod`
- `mnemon-s3-access`

## Out of scope (intentionally)
- Trust policies (`AssumeRolePolicyDocument`) — role creation only, not inline-policy
- Managed policies (`AmazonSSMManagedInstanceCore` is attached but AWS-provided)
- Role creation itself — pre-existing in AWS

## Test plan
- [x] `bash infrastructure/iam/apply.sh --dry-run` enumerates all 9 policies with correct role + policy names
- [x] `bash infrastructure/iam/apply.sh` applies all 9 cleanly (idempotent)
- [x] `aws iam list-role-policies --role-name alpha-engine-executor-role` set matches codified set 1:1
- [ ] Future PR: automated drift detector in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)