### PR TITLE
chore(iam): automated drift detector for codified inline policies

### DIFF
--- a/.github/workflows/iam-drift-check.yml
+++ b/.github/workflows/iam-drift-check.yml
@@ -1,0 +1,42 @@
+name: IAM Drift Check
+
+# Catches drift between codified inline policies under
+# infrastructure/iam/<role>/<policy>.json and the live state on AWS.
+#
+# Triggers:
+#   - Every PR that touches infrastructure/iam/** (so reviewers see drift
+#     before merge if a code change forgot to apply, or an apply forgot
+#     to commit)
+#   - Daily at 09:30 UTC (catches out-of-band manual IAM edits)
+#   - Manual via workflow_dispatch
+#
+# AWS auth: OIDC → github-actions-iam-drift-check role (read-only:
+# iam:ListRolePolicies + iam:GetRolePolicy on the codified roles only).
+
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/iam/**'
+      - '.github/workflows/iam-drift-check.yml'
+  schedule:
+    - cron: '30 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # required for OIDC
+  contents: read
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::711398986525:role/github-actions-iam-drift-check
+          aws-region: us-east-1
+
+      - name: Run IAM drift check
+        run: python3 infrastructure/iam/check-drift.py

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -26,6 +26,11 @@ is the inline policy name on that role.
   (`ae-trading`) and any executor processes assuming it. 9 inline policies
   as of 2026-04-27. Trust policy + role creation are NOT managed here
   (out of scope for the flat-file approach).
+- **`github-actions-iam-drift-check`** — assumed by GitHub Actions via
+  OIDC for the daily IAM-drift-check workflow. Single inline policy
+  granting `iam:ListRolePolicies` + `iam:GetRolePolicy` scoped to the
+  roles this directory manages. Trust policy: `repo:cipher813/alpha-engine`
+  (main + pull_request).
 
 ## Out of scope (not codified here)
 
@@ -59,15 +64,31 @@ wiping policies whose JSON file was deleted in a stale checkout).
 
 ## Drift detection
 
-There is no automated drift detector in this repo today. To check whether
-any role's inline policies have drifted from this directory:
+`check-drift.py` diffs the codified state against AWS for every role
+directory under `infrastructure/iam/`. It checks both:
+
+- **Set drift**: every `.json` file matches an inline policy on the role,
+  and vice versa.
+- **Content drift**: per-policy document equality after JSON normalization.
 
 ```bash
-aws iam list-role-policies --role-name alpha-engine-executor-role
+# Local
+./infrastructure/iam/check-drift.py
+./infrastructure/iam/check-drift.py --role alpha-engine-executor-role
 ```
 
-The set of returned policy names should match the set of `.json` files in
-`alpha-engine-executor-role/`.
+Exit code 0 = clean, 1 = drift detected, 2 = AWS CLI error or invalid
+source JSON.
+
+In CI, `.github/workflows/iam-drift-check.yml` runs the same script:
+
+- On every PR that touches `infrastructure/iam/**` (catches code changes
+  that forgot to apply, or applies that forgot to commit)
+- Daily at 09:30 UTC (catches out-of-band manual IAM edits)
+- Manually via `workflow_dispatch`
+
+Auth uses OIDC via the `github-actions-iam-drift-check` role (read-only:
+`iam:ListRolePolicies` + `iam:GetRolePolicy` on the codified roles only).
 
 ## When you add a new inline policy
 

--- a/infrastructure/iam/check-drift.py
+++ b/infrastructure/iam/check-drift.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""check-drift.py — Diff codified IAM inline policies against live AWS state.
+
+Walks `infrastructure/iam/<role>/<policy>.json` and compares against
+`aws iam list-role-policies` + `aws iam get-role-policy` for each role.
+
+Drift cases (all exit non-zero):
+  * Source has a policy file that AWS doesn't have    (missing-in-aws)
+  * AWS has an inline policy that source doesn't       (extra-in-aws)
+  * Source policy document differs from AWS document   (content-drift)
+
+JSON is compared after normalization (sorted keys, no trailing whitespace),
+so cosmetic-only differences in indentation or key order don't trip the check.
+
+Usage:
+  ./infrastructure/iam/check-drift.py             # check every codified role
+  ./infrastructure/iam/check-drift.py --role X    # check one role
+
+Requires AWS creds with iam:ListRolePolicies + iam:GetRolePolicy on the
+target roles. Locally: any admin profile. In CI: an OIDC role scoped to
+those two read-only actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+
+
+def _aws_iam(*args: str) -> dict | list | str:
+    """Call aws iam ... and return the parsed JSON output."""
+    result = subprocess.run(
+        ["aws", "iam", *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(
+            f"AWS CLI failed: aws iam {' '.join(args)}\n"
+            f"stderr: {result.stderr}\n"
+        )
+        sys.exit(2)
+    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+
+def _canonical_json(doc: dict) -> str:
+    """Canonical JSON for byte-stable comparison: sorted keys, no extra ws."""
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"))
+
+
+def _check_role(role_dir: Path) -> list[str]:
+    """Return list of drift findings for a single role. Empty list means clean."""
+    role_name = role_dir.name
+    findings: list[str] = []
+
+    # ── Set diff ────────────────────────────────────────────────────────────
+    source_policies = {p.stem for p in role_dir.glob("*.json")}
+    if not source_policies:
+        return [f"{role_name}: no .json files in {role_dir} — empty role dir"]
+
+    aws_resp = _aws_iam("list-role-policies", "--role-name", role_name)
+    aws_policies = set(aws_resp.get("PolicyNames", []))
+
+    extra_in_aws = aws_policies - source_policies
+    missing_in_aws = source_policies - aws_policies
+
+    for p in sorted(missing_in_aws):
+        findings.append(
+            f"{role_name}/{p}: codified in source but not on AWS role "
+            f"(run apply.sh to push)"
+        )
+    for p in sorted(extra_in_aws):
+        findings.append(
+            f"{role_name}/{p}: present on AWS role but not codified "
+            f"(add JSON file or delete from AWS)"
+        )
+
+    # ── Content diff for the policies present on both sides ────────────────
+    for policy_name in sorted(source_policies & aws_policies):
+        source_path = role_dir / f"{policy_name}.json"
+        try:
+            source_doc = json.loads(source_path.read_text())
+        except json.JSONDecodeError as exc:
+            findings.append(
+                f"{role_name}/{policy_name}: source JSON invalid ({exc})"
+            )
+            continue
+
+        aws_resp = _aws_iam(
+            "get-role-policy",
+            "--role-name", role_name,
+            "--policy-name", policy_name,
+        )
+        aws_doc = aws_resp.get("PolicyDocument", {})
+
+        if _canonical_json(source_doc) != _canonical_json(aws_doc):
+            findings.append(
+                f"{role_name}/{policy_name}: source document differs from "
+                f"AWS document (content drift)"
+            )
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--role", help="Check one role (default: every codified role)"
+    )
+    args = parser.parse_args()
+
+    if args.role:
+        role_dirs = [SCRIPT_DIR / args.role]
+        if not role_dirs[0].is_dir():
+            sys.stderr.write(f"ERROR: {role_dirs[0]} is not a directory\n")
+            return 2
+    else:
+        role_dirs = sorted(p for p in SCRIPT_DIR.iterdir() if p.is_dir())
+
+    if not role_dirs:
+        print("No codified role directories found under "
+              f"{SCRIPT_DIR} — nothing to check.")
+        return 0
+
+    total_findings: list[str] = []
+    for role_dir in role_dirs:
+        findings = _check_role(role_dir)
+        total_findings.extend(findings)
+
+    if total_findings:
+        print(f"IAM drift detected ({len(total_findings)} finding(s)):")
+        for f in total_findings:
+            print(f"  - {f}")
+        return 1
+
+    role_names = ", ".join(d.name for d in role_dirs)
+    print(f"OK: no IAM drift for {role_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
+++ b/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ReadCodifiedRoles",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListRolePolicies",
+                "iam:GetRolePolicy"
+            ],
+            "Resource": [
+                "arn:aws:iam::711398986525:role/alpha-engine-executor-role",
+                "arn:aws:iam::711398986525:role/github-actions-iam-drift-check"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Adds `infrastructure/iam/check-drift.py` + GitHub Actions workflow that diffs codified IAM state under `infrastructure/iam/<role>/<policy>.json` against the live AWS state. Closes the manual-one-liner gap from PR #105.

## Drift cases detected (all exit non-zero)
- **missing-in-aws**: source has a policy file that AWS doesn't
- **extra-in-aws**: AWS has an inline policy that source doesn't
- **content-drift**: source document differs from AWS document (after JSON normalization)

## CI triggers
- PRs that touch `infrastructure/iam/**` — catches "forgot to apply" or "forgot to commit" on the same change before merge
- Daily at 09:30 UTC — catches out-of-band manual IAM edits
- Manual `workflow_dispatch`

## Auth: new dedicated OIDC role
`github-actions-iam-drift-check` (created in this session). Trust policy scoped to `repo:cipher813/alpha-engine` only; inline policy `iam-readonly` grants `iam:ListRolePolicies` + `iam:GetRolePolicy` on the codified roles. Read-only — intentionally separate from `github-actions-lambda-deploy` which has write IAM perms (different blast radius).

The new role's inline policy is codified at `infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json` so the drift checker checks itself, and `apply.sh` updates it like any other policy. Role creation + trust policy are still manual (per the existing flat-file approach).

## Test plan
- [x] `python3 infrastructure/iam/check-drift.py` → clean
- [x] Induced content drift in a source JSON → script exits 1 with "content drift" finding
- [x] Restored → script exits 0
- [x] Full test suite (341/341) passes
- [ ] Verify CI workflow runs cleanly on this PR (will fire because PR touches `infrastructure/iam/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)