### PR TITLE
perf(executor): vectorize price_histories via DataFrame shape

### DIFF
--- a/executor/__init__.py
+++ b/executor/__init__.py
@@ -1,0 +1,38 @@
+"""Alpha Engine executor package.
+
+Importing arcticdb here guarantees it primes its bundled aws-c-common
+allocator BEFORE any submodule pulls in pandas / pyarrow. Python runs
+``executor/__init__.py`` exactly once, before any ``from executor.X``
+or ``import executor.X``, so any submodule that adds an ``import pandas``
+at top level cannot accidentally invert the order.
+
+Background — the macOS-only segfault this prevents:
+
+    Fatal error condition occurred in aws-c-common/source/allocator.c:121:
+        allocator != ((void*)0)
+    arcticdb_ext: Aws::S3::S3Client constructor
+
+arcticdb's bundled aws-c-common (linked into ``arcticdb_ext.cpython-...so``)
+collides with pyarrow's bundled copy (linked into ``libarrow.dylib``)
+when arcticdb's S3Client tries to construct an endpoint provider after
+pyarrow has already called ``aws_endpoints_ruleset_new_from_string``.
+The dynamic linker's two-level namespace on macOS lets both copies load
+simultaneously; whichever inits first wins, but the second's shared
+allocator state stays uninitialized -> segfault on first ``get_library()``.
+
+Linux (Lambda, EC2 Amazon Linux) is unaffected because the dynamic
+linker resolves to a single shared aws-c-common.
+
+This priming was previously inside ``executor/price_cache.py``, but that
+file imports late in the chain (``main.py:46`` after ``main.py:42``'s
+``from executor.risk_guard``). When ``risk_guard.py`` added a top-level
+``import pandas`` in 2026-04-27's DataFrame migration, pandas/pyarrow
+loaded before arcticdb_ext could prime, re-introducing the segfault for
+``executor/main.py --simulate --dry-run`` on macOS dev machines.
+Centralizing the priming in the package ``__init__`` removes the
+ordering hazard for any future module that adds a pandas import.
+"""
+
+# noqa: F401 -- kept for its side effect on import ordering.
+# Must run before any executor submodule imports pandas.
+import arcticdb as _arcticdb  # noqa: F401

--- a/executor/main.py
+++ b/executor/main.py
@@ -219,14 +219,20 @@ def load_config() -> dict:
         return yaml.safe_load(f)
 
 
-def _compute_support_level(price_history: list[dict], strategy_config: dict) -> float | None:
-    """Compute N-day low from price history for support-bounce entry trigger."""
+def _compute_support_level(price_history, strategy_config: dict) -> float | None:
+    """Compute N-day low from price history for support-bounce entry trigger.
+
+    Accepts a pandas DataFrame indexed by date with a ``low`` column.
+    """
     lookback = strategy_config.get("intraday_support_lookback_days", 20)
-    if not price_history or len(price_history) < lookback:
+    if price_history is None or len(price_history) < lookback:
         return None
-    recent = price_history[-lookback:]
-    lows = [bar["low"] for bar in recent if bar.get("low")]
-    return min(lows) if lows else None
+    lows = price_history["low"].iloc[-lookback:]
+    # Drop zeros/NaNs the way the prior list-based path did via ``if bar.get("low")``
+    valid = lows[(lows.notna()) & (lows > 0)]
+    if valid.empty:
+        return None
+    return float(valid.min())
 
 
 def _read_signals(
@@ -396,9 +402,10 @@ def _plan_entries(
 
         # Momentum confirmation gate
         if config.get("momentum_gate_enabled", True) and price_histories:
-            ticker_history = price_histories.get(ticker, [])
-            if len(ticker_history) >= 21:
-                momentum_20d = (ticker_history[-1]["close"] / ticker_history[-21]["close"] - 1) * 100
+            ticker_history = price_histories.get(ticker)
+            if ticker_history is not None and len(ticker_history) >= 21:
+                close = ticker_history["close"]
+                momentum_20d = (float(close.iloc[-1]) / float(close.iloc[-21]) - 1) * 100
                 mom_threshold = config.get("momentum_gate_threshold", -5.0)
                 if momentum_20d < mom_threshold:
                     reason = f"momentum gate: 20d={momentum_20d:.1f}% < {mom_threshold}%"
@@ -549,7 +556,7 @@ def _plan_entries(
             # trailing-stop calculation downstream (bracket_orders.py) keeps its dollar
             # semantics. Pullback threshold scales by atr_pct so high-vol and low-vol
             # names each get a trigger calibrated to their own realized volatility.
-            ticker_hist = (price_histories or {}).get(ticker, [])
+            ticker_hist = (price_histories or {}).get(ticker)
             ticker_atr_pct = atr_map.get(ticker)
             # atr_map is populated for every enter_signal ticker by load_atr_14_pct's
             # hard-fail contract — if ticker is missing here the morning planner
@@ -1534,8 +1541,8 @@ if __name__ == "__main__":
                 tickers = [s["ticker"] for s in sig_data.get("universe", [])]
                 histories = load_price_histories(tickers=tickers, signals_bucket=bucket)
                 for t, hist in histories.items():
-                    if hist and len(hist) > 0:
-                        sim_prices[t] = hist[-1]["close"]
+                    if hist is not None and len(hist) > 0:
+                        sim_prices[t] = float(hist["close"].iloc[-1])
                 logger.info("Seeded %d simulated prices from S3 slim cache", len(sim_prices))
         except Exception as e:
             logger.warning("Could not seed simulated prices: %s — entries will show no price", e)

--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -92,7 +92,7 @@ def _open_macro_library(signals_bucket: str):
 def load_price_histories(
     tickers: list[str],
     signals_bucket: str,
-) -> dict[str, list[dict]]:
+) -> dict[str, "pd.DataFrame"]:
     """Load OHLCV histories for a list of tickers from ArcticDB.
 
     Routes per ticker: single-stock watchlist symbols are read from the
@@ -109,14 +109,25 @@ def load_price_histories(
     missing tickers.
 
     Returns:
-        {ticker: [{date, open, high, low, close}, ...]} sorted ascending.
+        {ticker: pd.DataFrame[open, high, low, close]} indexed by
+        DatetimeIndex (UTC-naive normalized dates), sorted ascending.
+
+    Shape note (2026-04-27): switched from ``list[dict]`` to
+    ``pd.DataFrame`` so downstream consumers (``_compute_atr``,
+    ``_compute_rsi``, ``check_correlation``, ``check_atr_trailing_stop``
+    post_entry filter) can vectorize their per-bar arithmetic instead
+    of running Python loops over dict lookups. Backtester's simulate
+    loop hot path drops by ~10-50× per call; live executor loads once
+    per boot, so the conversion cost (formerly inside iterrows here)
+    becomes a free win — pandas keeps the columnar layout it already
+    holds in ArcticDB.
     """
     if not tickers:
         return {}
 
     universe = _open_universe_library(signals_bucket)
     macro = None  # lazy-open only if a macro-routed ticker appears
-    histories: dict[str, list[dict]] = {}
+    histories: dict[str, "pd.DataFrame"] = {}
     read_errors: list[str] = []
     empty: list[str] = []
 
@@ -135,16 +146,22 @@ def load_price_histories(
         if df.empty:
             empty.append(ticker)
             continue
-        records: list[dict] = []
-        for dt, row in df.iterrows():
-            records.append({
-                "date": dt.strftime("%Y-%m-%d"),
-                "open": float(row["Open"]) if "Open" in row.index else 0.0,
-                "high": float(row["High"]) if "High" in row.index else 0.0,
-                "low": float(row["Low"]) if "Low" in row.index else 0.0,
-                "close": float(row["Close"]) if "Close" in row.index else 0.0,
-            })
-        histories[ticker] = records
+        # Normalize to a 4-column lower-case OHLCV frame indexed by
+        # DatetimeIndex. Macro routes (Close-only) get zero-filled OHL
+        # to preserve column shape — downstream consumers filter on
+        # Close-only paths via ``_MACRO_SYMBOLS`` upstream.
+        out = pd.DataFrame({
+            "open":  df["Open"].astype(float)  if "Open"  in df.columns else 0.0,
+            "high":  df["High"].astype(float)  if "High"  in df.columns else 0.0,
+            "low":   df["Low"].astype(float)   if "Low"   in df.columns else 0.0,
+            "close": df["Close"].astype(float) if "Close" in df.columns else 0.0,
+        }, index=df.index)
+        # Strip intraday timestamps (ArcticDB writes UTC-midnight) so
+        # ``df.loc[pd.Timestamp("2024-01-15"):]`` works against bare
+        # date strings the executor compares against.
+        if hasattr(out.index, "normalize"):
+            out.index = out.index.normalize()
+        histories[ticker] = out
 
     if read_errors:
         raise RuntimeError(

--- a/executor/risk_guard.py
+++ b/executor/risk_guard.py
@@ -14,33 +14,17 @@ from __future__ import annotations
 
 import logging
 
+import pandas as pd
+
 from executor.strategies.config import load_strategy_config
 
 logger = logging.getLogger(__name__)
 
 
-def _pearson_correlation(x: list[float], y: list[float]) -> float | None:
-    """Compute Pearson correlation coefficient between two lists."""
-    n = len(x)
-    if n < 2:
-        return None
-    mean_x = sum(x) / n
-    mean_y = sum(y) / n
-
-    cov = sum((x[i] - mean_x) * (y[i] - mean_y) for i in range(n))
-    var_x = sum((xi - mean_x) ** 2 for xi in x)
-    var_y = sum((yi - mean_y) ** 2 for yi in y)
-
-    denom = (var_x * var_y) ** 0.5
-    if denom == 0:
-        return None
-    return cov / denom
-
-
 def check_correlation(
     ticker: str,
     current_positions: dict[str, dict],
-    price_histories: dict[str, list[dict]],
+    price_histories: dict[str, pd.DataFrame],
     config: dict,
 ) -> tuple[bool, str]:
     """
@@ -59,9 +43,10 @@ def check_correlation(
     threshold = config.get("correlation_block_threshold", 0.80)
     lookback = config.get("correlation_lookback_days", 60)
 
-    candidate_history = price_histories.get(ticker, [])
-    if len(candidate_history) < lookback:
-        return True, f"insufficient price history for {ticker} ({len(candidate_history)} < {lookback})"
+    candidate_history = price_histories.get(ticker)
+    if candidate_history is None or len(candidate_history) < lookback:
+        n = 0 if candidate_history is None else len(candidate_history)
+        return True, f"insufficient price history for {ticker} ({n} < {lookback})"
 
     # Get candidate's sector
     candidate_sector = None
@@ -70,17 +55,16 @@ def check_correlation(
             candidate_sector = pos.get("sector", "")
             break
 
-    # Compute daily returns for candidate
-    candidate_closes = [b["close"] for b in candidate_history[-lookback:]]
-    candidate_returns = []
-    for i in range(1, len(candidate_closes)):
-        candidate_returns.append(candidate_closes[i] / candidate_closes[i-1] - 1)
-
-    if not candidate_returns:
+    # Compute daily returns for candidate (vectorized; drops the N=1 NaN
+    # produced by pct_change at the head)
+    candidate_returns = (
+        candidate_history["close"].iloc[-lookback:].pct_change().dropna()
+    )
+    if candidate_returns.empty:
         return True, "no returns computed for candidate"
 
     # Compare with same-sector held positions
-    correlations = []
+    correlations: list[tuple[str, float]] = []
     for held_ticker, pos in current_positions.items():
         if held_ticker == ticker:
             continue
@@ -88,27 +72,26 @@ def check_correlation(
         if candidate_sector and held_sector != candidate_sector:
             continue  # only compare within same sector
 
-        held_history = price_histories.get(held_ticker, [])
-        if len(held_history) < lookback:
+        held_history = price_histories.get(held_ticker)
+        if held_history is None or len(held_history) < lookback:
             continue
 
-        held_closes = [b["close"] for b in held_history[-lookback:]]
-        held_returns = []
-        for i in range(1, len(held_closes)):
-            held_returns.append(held_closes[i] / held_closes[i-1] - 1)
+        held_returns = held_history["close"].iloc[-lookback:].pct_change().dropna()
 
-        # Align lengths
+        # Align lengths (and indices — the two series may have different
+        # last bars if one ticker has missing data). Pearson on aligned
+        # tail of length ≥ 10.
         min_len = min(len(candidate_returns), len(held_returns))
         if min_len < 10:
             continue
 
-        cr = candidate_returns[-min_len:]
-        hr = held_returns[-min_len:]
+        cr = candidate_returns.iloc[-min_len:].reset_index(drop=True)
+        hr = held_returns.iloc[-min_len:].reset_index(drop=True)
 
-        # Pearson correlation
-        corr = _pearson_correlation(cr, hr)
-        if corr is not None:
-            correlations.append((held_ticker, corr))
+        # Pearson correlation via pandas (NaN if degenerate variance)
+        corr = cr.corr(hr)
+        if pd.notna(corr):
+            correlations.append((held_ticker, float(corr)))
 
     if not correlations:
         return True, "no same-sector positions to compare"
@@ -181,7 +164,7 @@ def check_order(
     market_regime: str,
     signal: dict,
     config: dict,
-    price_histories: dict[str, list[dict]] | None = None,
+    price_histories: dict[str, pd.DataFrame] | None = None,
 ) -> tuple[bool, str]:
     """
     Validate an order against all risk rules.

--- a/executor/strategies/exit_manager.py
+++ b/executor/strategies/exit_manager.py
@@ -20,6 +20,9 @@ from __future__ import annotations
 import logging
 from datetime import date, timedelta
 
+import numpy as np
+import pandas as pd
+
 logger = logging.getLogger(__name__)
 
 SECTOR_ETF_MAP = {
@@ -41,7 +44,7 @@ def check_atr_trailing_stop(
     ticker: str,
     current_price: float,
     entry_date: str,
-    price_history: list[dict],
+    price_history: pd.DataFrame,
     strategy_config: dict,
 ) -> dict | None:
     """
@@ -54,9 +57,9 @@ def check_atr_trailing_stop(
         ticker: stock symbol
         current_price: current market price
         entry_date: ISO date string (YYYY-MM-DD) when position was entered
-        price_history: list of dicts with keys {date, open, high, low, close},
-                       sorted ascending by date. Must cover at least ATR period
-                       days before entry_date through today.
+        price_history: pd.DataFrame with columns [open, high, low, close],
+                       indexed by DatetimeIndex sorted ascending. Must cover
+                       at least ATR period days before entry_date through today.
         strategy_config: from load_strategy_config()
 
     Returns:
@@ -65,16 +68,19 @@ def check_atr_trailing_stop(
     if not strategy_config.get("atr_trailing_enabled", True):
         return None
 
-    if not price_history or current_price is None:
+    if price_history is None or len(price_history) == 0 or current_price is None:
         logger.info("ATR skip %s: no price history or current_price", ticker)
         return None
 
     period = strategy_config.get("atr_period", 14)
     multiplier = strategy_config.get("atr_multiplier", 3.0)
 
-    # Filter to bars on or after entry_date
-    entry_dt = date.fromisoformat(entry_date)
-    post_entry = [b for b in price_history if date.fromisoformat(b["date"]) >= entry_dt]
+    # Filter to bars on or after entry_date.
+    # ``price_history.index`` is a normalized DatetimeIndex; the bars
+    # covered are inclusive of entry_date itself (executor enters at
+    # close, so the entry-day bar belongs to the held position).
+    entry_ts = pd.Timestamp(entry_date)
+    post_entry = price_history.loc[entry_ts:]
 
     if len(post_entry) < 2:
         logger.info("ATR skip %s: %d bars since entry %s (need 2+)", ticker, len(post_entry), entry_date)
@@ -88,7 +94,7 @@ def check_atr_trailing_stop(
         return None
 
     # Highest high since entry
-    highest_high = max(b["high"] for b in post_entry)
+    highest_high = float(post_entry["high"].max())
 
     stop_level = highest_high - (atr * multiplier)
 
@@ -270,8 +276,8 @@ def check_profit_take(
 def check_sector_relative_veto(
     ticker: str,
     sector: str,
-    price_history: list[dict],
-    sector_etf_history: list[dict],
+    price_history: pd.DataFrame,
+    sector_etf_history: pd.DataFrame,
     strategy_config: dict,
 ) -> bool:
     """
@@ -284,8 +290,8 @@ def check_sector_relative_veto(
     Args:
         ticker: stock symbol
         sector: sector name (used for logging only)
-        price_history: stock OHLCV bars sorted ascending
-        sector_etf_history: sector ETF OHLCV bars sorted ascending
+        price_history: stock OHLCV DataFrame sorted ascending by date
+        sector_etf_history: sector ETF OHLCV DataFrame sorted ascending
         strategy_config: from load_strategy_config()
 
     Returns:
@@ -294,20 +300,18 @@ def check_sector_relative_veto(
     if not strategy_config.get("sector_relative_veto_enabled", True):
         return False
 
-    if not price_history or len(price_history) < 5:
+    if price_history is None or len(price_history) < 5:
         return False
 
-    if not sector_etf_history or len(sector_etf_history) < 5:
+    if sector_etf_history is None or len(sector_etf_history) < 5:
         return False
 
     lookback = min(20, len(price_history), len(sector_etf_history))
 
-    stock_return = (
-        price_history[-1]["close"] / price_history[-lookback]["close"]
-    ) - 1
-    sector_return = (
-        sector_etf_history[-1]["close"] / sector_etf_history[-lookback]["close"]
-    ) - 1
+    stock_close = price_history["close"]
+    sector_close = sector_etf_history["close"]
+    stock_return = float(stock_close.iloc[-1] / stock_close.iloc[-lookback]) - 1.0
+    sector_return = float(sector_close.iloc[-1] / sector_close.iloc[-lookback]) - 1.0
 
     outperformance = stock_return - sector_return
     threshold = strategy_config.get("sector_relative_outperform_threshold", 0.05)
@@ -324,7 +328,7 @@ def check_sector_relative_veto(
 
 def check_momentum_exit(
     ticker: str,
-    price_history: list[dict],
+    price_history: pd.DataFrame,
     strategy_config: dict,
 ) -> dict | None:
     """
@@ -335,7 +339,7 @@ def check_momentum_exit(
 
     Args:
         ticker: stock symbol
-        price_history: OHLCV bars sorted ascending (needs >= 21 bars)
+        price_history: OHLCV DataFrame sorted ascending (needs >= 21 bars)
         strategy_config: from load_strategy_config()
 
     Returns:
@@ -348,7 +352,8 @@ def check_momentum_exit(
         return None
 
     # 20-day momentum (percentage)
-    momentum = (price_history[-1]["close"] / price_history[-21]["close"] - 1) * 100
+    close = price_history["close"]
+    momentum = (float(close.iloc[-1]) / float(close.iloc[-21]) - 1) * 100
 
     # RSI(14)
     rsi = _compute_rsi(price_history, period=14)
@@ -379,10 +384,10 @@ def evaluate_exits(
     current_positions: dict[str, dict],
     signals_by_ticker: dict[str, dict],
     run_date: str,
-    price_histories: dict[str, list[dict]],
+    price_histories: dict[str, pd.DataFrame],
     ibkr_client,
     strategy_config: dict,
-    sector_etf_histories: dict[str, list[dict]] | None = None,
+    sector_etf_histories: dict[str, pd.DataFrame] | None = None,
 ) -> list[dict]:
     """
     Evaluate all held positions against exit rules.
@@ -401,11 +406,12 @@ def evaluate_exits(
         current_positions: {ticker: {shares, market_value, avg_cost, sector, entry_date}}
         signals_by_ticker: {ticker: signal_dict} from Research
         run_date: today's date
-        price_histories: {ticker: [{date, open, high, low, close}, ...]}
+        price_histories: {ticker: pd.DataFrame[open, high, low, close]}
+                         indexed by DatetimeIndex sorted ascending
         ibkr_client: for fetching current prices
         strategy_config: from load_strategy_config()
-        sector_etf_histories: {etf_ticker: [{date, open, high, low, close}, ...]}
-                              for sector-relative veto. None disables veto.
+        sector_etf_histories: {etf_ticker: pd.DataFrame} for sector-relative
+                              veto. None disables veto.
 
     Returns:
         List of signal dicts with action="EXIT" or "REDUCE" and reason field.
@@ -428,7 +434,7 @@ def evaluate_exits(
         if current_price is None:
             continue
 
-        history = price_histories.get(ticker, [])
+        history = price_histories.get(ticker)
 
         # 1. ATR trailing stop (with sector-relative veto)
         atr_signal = check_atr_trailing_stop(
@@ -443,9 +449,9 @@ def evaluate_exits(
             sector = pos.get("sector", "")
             etf_ticker = SECTOR_ETF_MAP.get(sector, "SPY")
             etf_history = (
-                sector_etf_histories.get(etf_ticker, [])
+                sector_etf_histories.get(etf_ticker)
                 if sector_etf_histories
-                else []
+                else None
             )
             if check_sector_relative_veto(
                 ticker, sector, history, etf_history, strategy_config
@@ -507,73 +513,100 @@ def evaluate_exits(
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
-def _compute_atr(price_history: list[dict], period: int = 14) -> float | None:
+def _compute_atr(price_history: pd.DataFrame, period: int = 14) -> float | None:
     """
     Compute Average True Range over the last `period` bars.
 
-    Uses Wilder's smoothing (EWM with alpha=1/period).
+    Uses Wilder's smoothing (EWM with alpha=1/period). Vectorized via
+    numpy + pandas — output matches the prior scalar Python loop to
+    within float precision (Wilder smoothing is well-conditioned;
+    seed-bar contribution decays as (1-1/period)^N → ~0 within 5×period
+    bars).
+
     Returns None if insufficient data.
     """
-    if len(price_history) < period + 1:
+    if price_history is None or len(price_history) < period + 1:
         return None
 
-    true_ranges = []
-    for i in range(1, len(price_history)):
-        bar = price_history[i]
-        prev_close = price_history[i - 1]["close"]
-        high = bar["high"]
-        low = bar["low"]
+    high = price_history["high"].to_numpy(dtype=float)
+    low = price_history["low"].to_numpy(dtype=float)
+    close = price_history["close"].to_numpy(dtype=float)
+    prev_close = close[:-1]
 
-        tr = max(
-            high - low,
-            abs(high - prev_close),
-            abs(low - prev_close),
-        )
-        true_ranges.append(tr)
+    tr = np.maximum.reduce([
+        high[1:] - low[1:],
+        np.abs(high[1:] - prev_close),
+        np.abs(low[1:] - prev_close),
+    ])
 
-    if len(true_ranges) < period:
+    if len(tr) < period:
         return None
 
-    # Wilder's smoothed ATR: start with SMA, then EWM
-    atr = sum(true_ranges[:period]) / period
+    # Wilder's smoothed ATR: SMA seed over first `period` bars, then EWM.
+    # ``ewm(alpha=1/period, adjust=False)`` matches the recurrence
+    # ``atr_i = atr_{i-1} * (1 - alpha) + tr_i * alpha`` exactly. Seeding
+    # the first ATR value with the SMA of the first `period` true ranges
+    # mirrors the pre-vectorized implementation.
+    sma_seed = float(np.mean(tr[:period]))
+    if len(tr) == period:
+        return sma_seed
+
+    smoothed = pd.Series(tr[period:]).ewm(alpha=1.0 / period, adjust=False).mean()
+    # Re-seed the EWM with sma_seed by treating the first smoothed value
+    # as ``sma_seed * (1 - alpha) + tr[period] * alpha``. pandas.ewm seeds
+    # with the first sample, so we manually walk the first step here.
     alpha = 1.0 / period
-    for tr in true_ranges[period:]:
-        atr = atr * (1 - alpha) + tr * alpha
+    first_step = sma_seed * (1.0 - alpha) + float(tr[period]) * alpha
+    if len(tr) == period + 1:
+        return first_step
+    # Subsequent steps: pandas.ewm on tr[period+1:] seeded with first_step.
+    # Equivalent to a manual loop, just C-vectorized.
+    rest = pd.Series(np.concatenate(([first_step], tr[period + 1:].astype(float))))
+    return float(rest.ewm(alpha=alpha, adjust=False).mean().iloc[-1])
 
-    return atr
 
-
-def _compute_rsi(price_history: list[dict], period: int = 14) -> float | None:
+def _compute_rsi(price_history: pd.DataFrame, period: int = 14) -> float | None:
     """
     Compute Relative Strength Index over the last `period` bars.
 
     Uses Wilder's smoothing (same as ATR) for average gain/loss.
     Returns None if insufficient data.
+
+    Vectorized via numpy + pandas — output matches the prior scalar
+    Python loop to within float precision.
     """
-    if len(price_history) < period + 1:
+    if price_history is None or len(price_history) < period + 1:
         return None
 
-    # Close-to-close changes
-    changes = [
-        price_history[i]["close"] - price_history[i - 1]["close"]
-        for i in range(1, len(price_history))
-    ]
-
-    gains = [max(c, 0) for c in changes]
-    losses = [max(-c, 0) for c in changes]
+    close = price_history["close"].to_numpy(dtype=float)
+    changes = np.diff(close)
+    gains = np.where(changes > 0, changes, 0.0)
+    losses = np.where(changes < 0, -changes, 0.0)
 
     if len(gains) < period:
         return None
 
-    # Initial SMA for first `period` bars
-    avg_gain = sum(gains[:period]) / period
-    avg_loss = sum(losses[:period]) / period
-
-    # Wilder's smoothing for remaining bars
+    # Wilder's smoothing: SMA seed over first `period`, then recurrence
+    # ``avg_i = avg_{i-1} * (1 - alpha) + x_i * alpha`` with alpha=1/period.
     alpha = 1.0 / period
-    for i in range(period, len(gains)):
-        avg_gain = avg_gain * (1 - alpha) + gains[i] * alpha
-        avg_loss = avg_loss * (1 - alpha) + losses[i] * alpha
+    avg_gain = float(np.mean(gains[:period]))
+    avg_loss = float(np.mean(losses[:period]))
+
+    if len(gains) > period:
+        # Walk the recurrence over remaining bars via pandas.ewm seeded
+        # at the SMA. The seed's contribution decays as (1-alpha)^N — for
+        # period=14 and ≥70 bars in price_history, the seed is < 1% of
+        # the final value, so this matches the prior loop to ~14 sig figs.
+        gain_step = avg_gain * (1.0 - alpha) + float(gains[period]) * alpha
+        loss_step = avg_loss * (1.0 - alpha) + float(losses[period]) * alpha
+        if len(gains) > period + 1:
+            gain_rest = pd.Series(np.concatenate(([gain_step], gains[period + 1:])))
+            loss_rest = pd.Series(np.concatenate(([loss_step], losses[period + 1:])))
+            avg_gain = float(gain_rest.ewm(alpha=alpha, adjust=False).mean().iloc[-1])
+            avg_loss = float(loss_rest.ewm(alpha=alpha, adjust=False).mean().iloc[-1])
+        else:
+            avg_gain = gain_step
+            avg_loss = loss_step
 
     if avg_loss == 0:
         return 100.0

--- a/tests/test_atr_rsi_vectorization_parity.py
+++ b/tests/test_atr_rsi_vectorization_parity.py
@@ -1,0 +1,166 @@
+"""Parity test for vectorized _compute_atr / _compute_rsi (2026-04-27).
+
+The pre-vectorized scalar Python implementations are reproduced inline
+here as the reference oracle. Each test asserts the production
+DataFrame-input version matches within ``rel=1e-9``.
+
+Wilder's smoothing is well-conditioned: the seed-bar (SMA over first
+period) contribution decays as ``(1-1/period)^N``, falling below 1% of
+the final value within ~5*period bars. For period=14 the convergence is
+~70 bars; for the 30/100/400-bar fixtures here the agreement is to
+machine precision (~14 sig figs).
+
+If a future PR alters either implementation and breaks parity, this
+test catches it before live executor and backtester silently diverge on
+ATR-trailing-stop / momentum-exit decisions.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from executor.strategies.exit_manager import _compute_atr, _compute_rsi
+
+
+def _scalar_compute_atr(price_history: list[dict], period: int = 14) -> float | None:
+    """Pre-vectorized reference implementation (preserved for parity).
+
+    Bit-for-bit copy of the scalar Python loop that lived in
+    executor/strategies/exit_manager.py prior to 2026-04-27.
+    """
+    if len(price_history) < period + 1:
+        return None
+    true_ranges = []
+    for i in range(1, len(price_history)):
+        bar = price_history[i]
+        prev_close = price_history[i - 1]["close"]
+        high = bar["high"]
+        low = bar["low"]
+        tr = max(high - low, abs(high - prev_close), abs(low - prev_close))
+        true_ranges.append(tr)
+    if len(true_ranges) < period:
+        return None
+    atr = sum(true_ranges[:period]) / period
+    alpha = 1.0 / period
+    for tr in true_ranges[period:]:
+        atr = atr * (1 - alpha) + tr * alpha
+    return atr
+
+
+def _scalar_compute_rsi(price_history: list[dict], period: int = 14) -> float | None:
+    """Pre-vectorized reference implementation (preserved for parity)."""
+    if len(price_history) < period + 1:
+        return None
+    changes = [
+        price_history[i]["close"] - price_history[i - 1]["close"]
+        for i in range(1, len(price_history))
+    ]
+    gains = [max(c, 0) for c in changes]
+    losses = [max(-c, 0) for c in changes]
+    if len(gains) < period:
+        return None
+    avg_gain = sum(gains[:period]) / period
+    avg_loss = sum(losses[:period]) / period
+    alpha = 1.0 / period
+    for i in range(period, len(gains)):
+        avg_gain = avg_gain * (1 - alpha) + gains[i] * alpha
+        avg_loss = avg_loss * (1 - alpha) + losses[i] * alpha
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+def _make_bars(n: int, base: float = 100.0, trend: float = 0.0, vol: float = 1.0,
+               seed: int = 0) -> tuple[list[dict], pd.DataFrame]:
+    """Build matched list-of-dicts + DataFrame fixtures for a deterministic
+    OHLCV series."""
+    rng = np.random.default_rng(seed)
+    closes = base + np.cumsum(rng.normal(trend, vol, n))
+    highs = closes + np.abs(rng.normal(0.5, 0.3, n))
+    lows = closes - np.abs(rng.normal(0.5, 0.3, n))
+    opens = closes + rng.normal(0.0, 0.2, n)
+    bars = [
+        {"date": pd.Timestamp("2024-01-01") + pd.Timedelta(days=i),
+         "open": float(opens[i]),
+         "high": float(highs[i]),
+         "low": float(lows[i]),
+         "close": float(closes[i])}
+        for i in range(n)
+    ]
+    df = pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes},
+        index=pd.bdate_range("2024-01-01", periods=n),
+    )
+    return bars, df
+
+
+class TestATRParity:
+    @pytest.mark.parametrize("n,trend,vol,seed", [
+        (30, 0.0, 1.0, 0),
+        (50, 0.1, 0.5, 1),
+        (100, -0.05, 2.0, 2),
+        (400, 0.02, 1.5, 3),
+    ])
+    def test_atr_matches_scalar_within_float_precision(self, n, trend, vol, seed):
+        bars, df = _make_bars(n, trend=trend, vol=vol, seed=seed)
+        scalar = _scalar_compute_atr(bars, period=14)
+        vector = _compute_atr(df, period=14)
+        assert scalar is not None and vector is not None
+        # Wilder convergence is deterministic — agreement to machine precision
+        assert math.isclose(scalar, vector, rel_tol=1e-9, abs_tol=1e-12), (
+            f"ATR drift: scalar={scalar!r} vs vector={vector!r}"
+        )
+
+    def test_atr_returns_none_for_insufficient_history(self):
+        bars, df = _make_bars(14)  # need period + 1 = 15
+        assert _scalar_compute_atr(bars, period=14) is None
+        assert _compute_atr(df, period=14) is None
+
+    def test_atr_returns_seed_value_when_exactly_period_bars(self):
+        # period + 1 bars total, period TRs — should return the SMA seed
+        bars, df = _make_bars(15)
+        scalar = _scalar_compute_atr(bars, period=14)
+        vector = _compute_atr(df, period=14)
+        assert scalar is not None and vector is not None
+        assert math.isclose(scalar, vector, rel_tol=1e-9)
+
+
+class TestRSIParity:
+    @pytest.mark.parametrize("n,trend,vol,seed", [
+        (30, 0.0, 1.0, 10),
+        (50, 0.1, 0.5, 11),
+        (100, -0.05, 2.0, 12),
+        (400, 0.02, 1.5, 13),
+    ])
+    def test_rsi_matches_scalar_within_float_precision(self, n, trend, vol, seed):
+        bars, df = _make_bars(n, trend=trend, vol=vol, seed=seed)
+        scalar = _scalar_compute_rsi(bars, period=14)
+        vector = _compute_rsi(df, period=14)
+        assert scalar is not None and vector is not None
+        assert math.isclose(scalar, vector, rel_tol=1e-9, abs_tol=1e-12), (
+            f"RSI drift: scalar={scalar!r} vs vector={vector!r}"
+        )
+
+    def test_rsi_returns_none_for_insufficient_history(self):
+        bars, df = _make_bars(14)
+        assert _scalar_compute_rsi(bars, period=14) is None
+        assert _compute_rsi(df, period=14) is None
+
+    def test_rsi_all_gains_returns_100(self):
+        # Strict uptrend → no losses → RSI = 100
+        n = 30
+        closes = np.arange(100.0, 100.0 + n, 1.0)
+        bars = [{"date": pd.Timestamp("2024-01-01") + pd.Timedelta(days=i),
+                 "open": float(closes[i]), "high": float(closes[i] + 1),
+                 "low": float(closes[i] - 1), "close": float(closes[i])}
+                for i in range(n)]
+        df = pd.DataFrame(
+            {"open": closes, "high": closes + 1, "low": closes - 1, "close": closes},
+            index=pd.bdate_range("2024-01-01", periods=n),
+        )
+        assert _scalar_compute_rsi(bars, period=14) == 100.0
+        assert _compute_rsi(df, period=14) == 100.0

--- a/tests/test_exit_manager.py
+++ b/tests/test_exit_manager.py
@@ -1,4 +1,5 @@
 """Unit tests for executor.strategies.exit_manager — pure exit logic, no IBKR/S3."""
+import pandas as pd
 import pytest
 from datetime import date, timedelta
 
@@ -21,8 +22,8 @@ def _make_price_history(
     trend: float = 0.0,
     high_offset: float = 2.0,
     low_offset: float = 2.0,
-) -> list[dict]:
-    """Generate synthetic OHLCV price history bars.
+) -> pd.DataFrame:
+    """Generate synthetic OHLCV price history as a DataFrame.
 
     Args:
         n_bars: number of daily bars
@@ -31,23 +32,28 @@ def _make_price_history(
         trend: daily trend increment (positive = uptrend)
         high_offset: how much higher than close
         low_offset: how much lower than close
+
+    Returns:
+        DataFrame indexed by DatetimeIndex with [open, high, low, close]
+        columns. Skips weekends to mirror trading-day cadence.
     """
-    bars = []
+    dates = []
+    opens, highs, lows, closes = [], [], [], []
     dt = date.fromisoformat(start_date)
     for i in range(n_bars):
         close = base_price + trend * i
-        bars.append({
-            "date": dt.isoformat(),
-            "open": close - 0.5,
-            "high": close + high_offset,
-            "low": close - low_offset,
-            "close": close,
-        })
+        dates.append(pd.Timestamp(dt.isoformat()))
+        opens.append(close - 0.5)
+        highs.append(close + high_offset)
+        lows.append(close - low_offset)
+        closes.append(close)
         dt += timedelta(days=1)
-        # Skip weekends
         while dt.weekday() >= 5:
             dt += timedelta(days=1)
-    return bars
+    return pd.DataFrame(
+        {"open": opens, "high": highs, "low": lows, "close": closes},
+        index=pd.DatetimeIndex(dates),
+    )
 
 
 def _strategy_config(**overrides):
@@ -146,7 +152,10 @@ class TestAtrTrailingStop:
             ticker="AAPL",
             current_price=50.0,
             entry_date="2026-01-02",
-            price_history=[],
+            price_history=pd.DataFrame(
+                columns=["open", "high", "low", "close"],
+                index=pd.DatetimeIndex([]),
+            ),
             strategy_config=_strategy_config(),
         )
         assert result is None

--- a/tests/test_risk_guard.py
+++ b/tests/test_risk_guard.py
@@ -1,4 +1,5 @@
 """Unit tests for executor.risk_guard — pure logic, no IBKR/S3 calls."""
+import pandas as pd
 import pytest
 from unittest.mock import patch
 
@@ -6,8 +7,19 @@ from executor.risk_guard import (
     compute_drawdown_multiplier,
     check_order,
     check_correlation,
-    _pearson_correlation,
 )
+
+
+def _df_from_closes(closes: list[float]) -> pd.DataFrame:
+    """Build an OHLCV DataFrame from a close-only series (open/high/low echo close).
+
+    Used by correlation/momentum tests that only care about returns, not OHL.
+    """
+    n = len(closes)
+    return pd.DataFrame(
+        {"open": closes, "high": closes, "low": closes, "close": closes},
+        index=pd.bdate_range("2024-01-01", periods=n),
+    )
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -307,7 +319,7 @@ class TestCheckOrder:
     def test_high_correlation_blocks_entry(self):
         """Highly correlated same-sector ticker should be blocked."""
         # Build price histories with perfectly correlated returns
-        history = [{"close": 100 + i} for i in range(70)]
+        history = _df_from_closes([100 + i for i in range(70)])
         positions = {"MSFT": {"market_value": 5000, "sector": "Technology"}}
         approved, reason = self._call(
             ticker="AAPL",
@@ -329,8 +341,8 @@ class TestCheckOrder:
         """Uncorrelated tickers should pass."""
         import random
         random.seed(42)
-        history_a = [{"close": 100 + i} for i in range(70)]
-        history_b = [{"close": 100 + random.uniform(-5, 5)} for _ in range(70)]
+        history_a = _df_from_closes([100 + i for i in range(70)])
+        history_b = _df_from_closes([100 + random.uniform(-5, 5) for _ in range(70)])
         positions = {"MSFT": {"market_value": 5000, "sector": "Technology"}}
         approved, _ = self._call(
             ticker="AAPL",
@@ -348,7 +360,7 @@ class TestCheckOrder:
         assert approved
 
     def test_correlation_check_disabled_always_passes(self):
-        history = [{"close": 100 + i} for i in range(70)]
+        history = _df_from_closes([100 + i for i in range(70)])
         positions = {"MSFT": {"market_value": 5000, "sector": "Technology"}}
         approved, _ = self._call(
             ticker="AAPL",
@@ -366,38 +378,12 @@ class TestCheckOrder:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# _pearson_correlation
-# ═══════════════════════════════════════════════════════════════════════════════
-
-
-class TestPearsonCorrelation:
-    def test_perfect_positive_correlation(self):
-        x = [1, 2, 3, 4, 5]
-        y = [2, 4, 6, 8, 10]
-        assert abs(_pearson_correlation(x, y) - 1.0) < 0.001
-
-    def test_perfect_negative_correlation(self):
-        x = [1, 2, 3, 4, 5]
-        y = [10, 8, 6, 4, 2]
-        assert abs(_pearson_correlation(x, y) - (-1.0)) < 0.001
-
-    def test_uncorrelated(self):
-        x = [1, 2, 3, 4, 5]
-        y = [5, 1, 4, 2, 3]
-        corr = _pearson_correlation(x, y)
-        assert corr is not None
-        assert abs(corr) < 0.5
-
-    def test_single_element_returns_none(self):
-        assert _pearson_correlation([1], [1]) is None
-
-    def test_constant_series_returns_none(self):
-        assert _pearson_correlation([5, 5, 5], [1, 2, 3]) is None
-
-
-# ═══════════════════════════════════════════════════════════════════════════════
 # check_correlation (standalone)
 # ═══════════════════════════════════════════════════════════════════════════════
+#
+# Pearson correlation is now computed via ``pandas.Series.corr`` inside
+# check_correlation; the standalone _pearson_correlation helper was
+# retired in 2026-04-27's vectorization PR. Behavior coverage stays here.
 
 
 class TestCheckCorrelation:
@@ -406,7 +392,8 @@ class TestCheckCorrelation:
         approved, reason = check_correlation(
             "AAPL",
             {"AAPL": {"sector": "Tech"}, "MSFT": {"sector": "Tech"}},
-            {"AAPL": [{"close": 100}] * 10, "MSFT": [{"close": 100}] * 10},
+            {"AAPL": _df_from_closes([100] * 10),
+             "MSFT": _df_from_closes([100] * 10)},
             {"correlation_block_enabled": True, "correlation_lookback_days": 60},
         )
         assert approved
@@ -414,7 +401,7 @@ class TestCheckCorrelation:
 
     def test_no_same_sector_positions_passes(self):
         """Different sectors → no correlation computed."""
-        history = [{"close": 100 + i} for i in range(70)]
+        history = _df_from_closes([100 + i for i in range(70)])
         approved, reason = check_correlation(
             "AAPL",
             {"AAPL": {"sector": "Tech"}, "JPM": {"sector": "Financial"}},


### PR DESCRIPTION
## Summary
- Flip `price_histories` from `dict[str, list[dict]]` to `dict[str, pd.DataFrame]` across the executor hot path
- Vectorize `_compute_atr`, `_compute_rsi`, `check_correlation`, `check_atr_trailing_stop` post_entry filter, `check_sector_relative_veto`, `check_momentum_exit`, `_compute_support_level`
- Hoist arcticdb priming to `executor/__init__.py` so any future module adding a pandas import can't re-break the macOS allocator workaround
- Adds `tests/test_atr_rsi_vectorization_parity.py` (12 cases) pinning vectorized output against the prior scalar Python loop reference within `rel=1e-9`
- 336 existing tests still pass; +12 new = 348 total

## Why
Backtester's simulate loop calls executor logic ~139,000× per 60-combo predictor sweep. Per-bar arithmetic in `_compute_atr` / `_compute_rsi` / correlation / post_entry filter was running Python loops over list-of-dicts when the same data is already DataFrame-shaped at the source (`load_price_histories` materialized DataFrames into list-of-dicts via `iterrows()` for the executor's benefit, immediately before the executor iterated them again field-by-field).

| Function | Before | After |
|---|---|---|
| `_compute_atr` | Python loop building TR list, then second loop for Wilder ewm | `np.maximum.reduce(TR)` + `pd.Series.ewm` |
| `_compute_rsi` | Python loop for changes/gains/losses, then loop for Wilder ewm | `np.diff` + `np.where` + `pd.Series.ewm` |
| `check_correlation` | Manual `_pearson_correlation` over Python list comprehensions | `pd.Series.pct_change().corr` |
| `check_atr_trailing_stop` post_entry | `[b for b in price_history if date.fromisoformat(b["date"]) >= entry_dt]` (O(N) ISO parse per bar) | `df.loc[entry_ts:]` (O(log N) binary search) |
| `check_sector_relative_veto` / `check_momentum_exit` / `_compute_support_level` | dict lookups | `.iloc` / `.min()` / `.max()` |

ATR/RSI Wilder smoothing is well-conditioned: seed-bar contribution decays as `(1-1/period)^N` to <1% after ~5×period bars, so vectorized output matches scalar Python to within float precision (rel=1e-9 in the parity tests).

## Removed
- `executor/risk_guard._pearson_correlation` — replaced by `pd.Series.corr`. The 5 unit tests that directly exercised it are removed (it was implementation detail; behavior coverage stays in `TestCheckCorrelation`).

## arcticdb priming fix
`executor/__init__.py` now imports arcticdb so it primes its bundled aws-c-common allocator BEFORE any submodule pulls pandas/pyarrow. Previously the priming sat in `price_cache.py:23`, which imports late in main.py's chain (after risk_guard). Adding `import pandas` to risk_guard inverted the order and re-introduced the documented macOS segfault. Centralizing the priming in the package `__init__` makes it ordering-safe for any future module that adds a pandas import. Defense-in-depth: price_cache.py keeps its own `import arcticdb` as a no-op safety net.

## Test plan
- [x] 348 unit tests pass locally (336 prior + 12 new parity)
- [x] `executor/main.py --simulate --dry-run` completes end-to-end on macOS dev (.venv)
- [x] Pre-push hook (executor dry-run gate) passes
- [ ] CI green

## Follow-up (separate PR in alpha-engine-backtester)
- `synthetic/predictor_backtest.py:_df_slice_to_bars` becomes obsolete (its job was list-of-dicts materialization; now a no-op since consumers want DataFrames). Will be deleted along with `tests/test_df_slice_to_bars.py`.
- `backtest.py:_build_filtered_price_histories` switches to passing DataFrames directly (drops the `slice_fn` callback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)