### PR TITLE
perf(deciders): Tier 3 Part A — enrich_positions accepts optional universe_sectors override

### DIFF
--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -70,6 +70,7 @@ def enrich_positions(
     current_positions: dict[str, dict],
     signals_raw: dict,
     entry_dates_lookup: dict[str, str | None] | None = None,
+    universe_sectors: dict[str, str] | None = None,
 ) -> dict[str, dict]:
     """Return a NEW positions dict with each position's ``sector`` and
     ``entry_date`` populated from signals + entry_dates lookup.
@@ -80,15 +81,23 @@ def enrich_positions(
     ``trade_logger.get_entry_dates`` (live) or from the simulated
     client's per-position state (backtester). Pass ``None`` to leave
     ``entry_date`` unset on every position.
+
+    ``universe_sectors``: optional precomputed ``{ticker: sector}`` map.
+    When provided, the per-call dict comprehension over ``signals_raw``'s
+    universe + buy_candidates is skipped — caller has already built the
+    lookup. Live executor passes ``None`` (rebuilt per call); backtester
+    passes a precomputed map shared across all 60 combos in a
+    ``predictor_param_sweep`` (Tier 3 Part A amortization, 2026-04-27).
     """
-    universe_sectors: dict[str, str] = {
-        s["ticker"]: s.get("sector", "")
-        for s in (
-            signals_raw.get("universe", [])
-            + signals_raw.get("buy_candidates", [])
-        )
-        if s.get("ticker")
-    }
+    if universe_sectors is None:
+        universe_sectors = {
+            s["ticker"]: s.get("sector", "")
+            for s in (
+                signals_raw.get("universe", [])
+                + signals_raw.get("buy_candidates", [])
+            )
+            if s.get("ticker")
+        }
     out: dict[str, dict] = {}
     for ticker, pos in current_positions.items():
         new_pos = dict(pos)  # shallow copy

--- a/tests/test_decider_parity.py
+++ b/tests/test_decider_parity.py
@@ -255,6 +255,78 @@ class TestDecideEntriesParity:
         assert held_ticker not in [o["ticker"] for o in plan.orders]
 
 
+class TestEnrichPositionsUniverseSectorsOverride:
+    """Tier 3 Part A (2026-04-27): backtester precomputes
+    ``universe_sectors`` once per signal date, shared across 60 combos
+    in a ``predictor_param_sweep``. Verify the optional override
+    produces byte-equal output to the per-call rebuild path.
+    """
+
+    def test_universe_sectors_override_matches_internal_rebuild(self):
+        from executor.deciders import enrich_positions
+
+        signals_raw = {
+            "universe": [
+                {"ticker": "AAPL", "sector": "Technology"},
+                {"ticker": "JPM", "sector": "Financial"},
+                {"ticker": "JNJ", "sector": "Healthcare"},
+            ],
+            "buy_candidates": [
+                {"ticker": "MSFT", "sector": "Technology"},
+            ],
+        }
+        positions = {
+            "AAPL": {"shares": 100, "avg_cost": 150.0},
+            "MSFT": {"shares": 50, "avg_cost": 300.0},
+        }
+        entry_dates = {"AAPL": "2026-04-20", "MSFT": "2026-04-22"}
+
+        # Path A — internal rebuild (live behavior, override=None)
+        result_a = enrich_positions(positions, signals_raw, entry_dates)
+
+        # Path B — explicit override (backtester behavior)
+        precomputed = {
+            "AAPL": "Technology",
+            "JPM": "Financial",
+            "JNJ": "Healthcare",
+            "MSFT": "Technology",
+        }
+        result_b = enrich_positions(
+            positions, signals_raw, entry_dates,
+            universe_sectors=precomputed,
+        )
+
+        assert result_a == result_b, (
+            "enrich_positions output drift between internal-rebuild "
+            "(override=None) and explicit override paths"
+        )
+
+    def test_override_takes_precedence_over_signals_raw(self):
+        """If caller passes override, signals_raw's sectors are ignored
+        — caller has authoritative pre-built mapping. (Backtester filters
+        signals against universe at simulation-loop bootstrap; the
+        precomputed map reflects that filter.)"""
+        from executor.deciders import enrich_positions
+
+        # signals_raw says AAPL is Technology
+        signals_raw = {
+            "universe": [{"ticker": "AAPL", "sector": "Technology"}],
+            "buy_candidates": [],
+        }
+        # Override says AAPL is Financial (intentionally divergent for the test)
+        override = {"AAPL": "Financial"}
+        positions = {"AAPL": {"shares": 100, "avg_cost": 150.0}}
+
+        result = enrich_positions(
+            positions, signals_raw, entry_dates_lookup=None,
+            universe_sectors=override,
+        )
+
+        assert result["AAPL"]["sector"] == "Financial", (
+            "Override map must take precedence over signals_raw's sectors"
+        )
+
+
 class TestDecideExitsAndReducesParity:
     """Direct decide_exits_and_reduces vs _plan_exits_and_reduces wrapper.
 


### PR DESCRIPTION
## Summary
Adds optional ``universe_sectors`` kwarg to ``executor.deciders.enrich_positions``. When provided, the per-call rebuild from ``signals_raw`` is skipped. Live behavior unchanged (kwarg defaults to ``None`` → rebuild). Unblocks the alpha-engine-backtester sister PR that precomputes this dict ONCE per simulation loop and shares it across all 60 combos in a ``predictor_param_sweep``.

## Motivation
``enrich_positions`` rebuilds ``{ticker: sector}`` from ~900 universe + buy_candidates entries on every call (~5 ms). For ``predictor_param_sweep`` (60 combos × 2316 dates), that's ~700 sec of wasted compute rebuilding the SAME dict from the SAME signals_raw — across combos with different per-sim state but identical cross-sectional signals.

This PR alone is a no-op for live; the win materializes when the alpha-engine-backtester sister PR lands and starts passing the precomputed map.

## Tier 3 context
Part A of a 4-part refactor (~2 weeks, ~25× per-date speedup target). See ``~/Development/alpha-engine-docs/private/alpha-engine-plan-backtest-predictor-tier3-260427.md`` for the full architecture.

## Test plan
- [x] 359 tests pass locally (357 prior + 2 new parity tests)
- [x] ``executor/main.py --simulate --dry-run`` end-to-end passes (pre-push hook)
- [ ] CI green
- [ ] alpha-engine-backtester sister PR consumes the new arg

## New parity tests
- ``test_universe_sectors_override_matches_internal_rebuild`` — byte equality between rebuild path and override path for a fixed fixture
- ``test_override_takes_precedence_over_signals_raw`` — explicit contract: override is authoritative when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)