### PR TITLE
fix(eod_reconcile): hard-block historical-date reruns to prevent live…

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -29,6 +29,7 @@ from executor.trade_logger import (
     init_db, log_eod, backup_to_s3, get_entry_trade, get_todays_trades,
 )
 
+from alpha_engine_lib.dates import now_dual
 from alpha_engine_lib.logging import setup_logging
 # See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
@@ -336,9 +337,29 @@ def _apply_dividend_delta(
 
 
 def run(run_date: str | None = None) -> None:
-    run_date = run_date or str(date.today())
+    today_trading_day = now_dual().trading_day
+    if run_date is None:
+        run_date = today_trading_day
+        logger.info(
+            "EOD reconciliation | date=%s (resolved from now_dual().trading_day)",
+            run_date,
+        )
+    else:
+        if run_date != today_trading_day:
+            raise RuntimeError(
+                f"EOD reconciliation refusing run_date={run_date!r} "
+                f"!= today's trading_day {today_trading_day!r}. "
+                f"Historical reruns are unsafe: get_account_snapshot() returns "
+                f"current live IB state which would be written against the "
+                f"historical row, corrupting the prior_nav chain. "
+                f"For SPY-only corrections use infrastructure/backfill_eod_pnl_spy.py; "
+                f"a --from-snapshot mode for full historical reconstruction is owed."
+            )
+        logger.info(
+            "EOD reconciliation | date=%s (explicit; matches today's trading_day)",
+            run_date,
+        )
     _health_start = _time.time()
-    logger.info(f"EOD reconciliation | date={run_date}")
 
     config = load_config()
 
@@ -879,4 +900,20 @@ def run(run_date: str | None = None) -> None:
 
 
 if __name__ == "__main__":
-    run()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "EOD reconciliation. Defaults to today's trading_day "
+            "(via alpha_engine_lib.dates.now_dual). Hard-fails on any "
+            "explicit --date that isn't today: live IB state would corrupt "
+            "the historical row's NAV/positions."
+        )
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="YYYY-MM-DD; must equal today's trading_day or the run aborts.",
+    )
+    args = parser.parse_args()
+    run(run_date=args.date)

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -1,5 +1,7 @@
 """Unit tests for executor.eod_reconcile — P&L math and data helpers."""
 import json
+import sys
+from types import SimpleNamespace
 import pytest
 from unittest.mock import patch, MagicMock
 from io import BytesIO
@@ -9,6 +11,7 @@ from executor.eod_reconcile import (
     _load_signals_from_s3,
     _load_predictions_from_s3,
     _build_position_contexts,
+    run,
 )
 
 
@@ -371,3 +374,93 @@ class TestPnLMath:
         spy_prior_close = 445.0
         spy_return = (spy_price / spy_prior_close - 1) * 100
         assert spy_return == pytest.approx(1.1235955, rel=1e-4)
+
+
+# ── run_date gating ──────────────────────────────────────────────────────────
+# Historical reruns are unsafe: get_account_snapshot() always returns current
+# live IB state, which would be written against the historical row and
+# corrupt the prior_nav chain. The gate hard-fails before any IBKR call.
+
+
+class TestRunDateGating:
+    def test_explicit_past_date_raises(self):
+        """run(run_date=<yesterday>) must raise before any IB connection."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            with pytest.raises(RuntimeError, match="Historical reruns are unsafe"):
+                run(run_date="2026-04-27")
+
+    def test_explicit_future_date_raises(self):
+        """A future-dated rerun is also a mismatch and must raise."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            with pytest.raises(RuntimeError, match="refusing run_date"):
+                run(run_date="2026-04-29")
+
+    def test_error_message_names_both_dates(self):
+        """Error message must include both the requested and resolved dates
+        so the operator can immediately see what was rejected."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            with pytest.raises(RuntimeError) as exc:
+                run(run_date="2026-04-25")
+            msg = str(exc.value)
+            assert "2026-04-25" in msg
+            assert "2026-04-28" in msg
+            assert "backfill_eod_pnl_spy.py" in msg  # points operator to safe path
+
+    def test_default_resolves_to_now_dual_trading_day(self, monkeypatch, tmp_path):
+        """run() with no run_date resolves via now_dual().trading_day, not
+        date.today() (which would be UTC on ae-trading and could drift past
+        midnight Pacific)."""
+        # Patch now_dual + bail out at the first IO boundary (load_config) so
+        # we don't need to mock the full IB/S3/SQLite plumbing — the gate
+        # check fires before any of that.
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
+             patch("executor.eod_reconcile.load_config") as mock_cfg:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            mock_cfg.side_effect = RuntimeError("expected_test_sentinel")
+            # The fact that it reaches load_config (and not the historical
+            # gate) confirms run_date resolved to today.
+            with pytest.raises(RuntimeError, match="expected_test_sentinel"):
+                run(run_date=None)
+
+    def test_explicit_today_succeeds_past_gate(self):
+        """Explicit --date matching today's trading_day is permitted."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
+             patch("executor.eod_reconcile.load_config") as mock_cfg:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            mock_cfg.side_effect = RuntimeError("expected_test_sentinel")
+            # Same as above: reaches load_config means gate accepted today.
+            with pytest.raises(RuntimeError, match="expected_test_sentinel"):
+                run(run_date="2026-04-28")
+
+    def test_cli_date_flag_forwards_to_run(self):
+        """`python eod_reconcile.py --date YYYY-MM-DD` invokes run(run_date=...)."""
+        argv = ["eod_reconcile.py", "--date", "2026-04-25"]
+        with patch.object(sys, "argv", argv):
+            import argparse
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--date", default=None)
+            args = parser.parse_args(argv[1:])
+            assert args.date == "2026-04-25"
+
+    def test_cli_no_args_passes_none(self):
+        """No --date passes None, which run() resolves via now_dual."""
+        import argparse
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--date", default=None)
+        args = parser.parse_args([])
+        assert args.date is None


### PR DESCRIPTION
…-IB corruption

run(run_date='YYYY-MM-DD') against a past date silently corrupts the prior_nav chain — get_account_snapshot() always returns current live IB state, which gets written against the historical row. Today's automatic EOD then computes daily_return against the corrupted prior_nav, hiding most of the day's actual P&L. Surfaced 2026-04-28 morning while trying to recover the missed 4/27 EOD; worked around with manual SQL INSERT.

Fix: resolve default run_date via alpha_engine_lib.dates.now_dual (NYSE- aware Pacific-time "last completed trading day"), and hard-fail when an explicit run_date doesn't match. Error message names both dates and points the operator at infrastructure/backfill_eod_pnl_spy.py for SPY-only corrections; a --from-snapshot mode for full historical reconstruction is owed but not in scope here. Added argparse to the CLI entrypoint so the surface is explicit (systemd timer's no-arg invocation is unchanged).

7 new tests cover: explicit past-date raise, explicit future-date raise, error message format, default resolution via now_dual (not date.today), explicit-today success, CLI --date forwarding, CLI no-args defaulting. 388 passes (existing executor suite green, no regressions).

Closes ROADMAP P1 "executor/eod_reconcile.py — historical-date reruns corrupt today's data via live IB read".