### PR TITLE
fix(eod): restore daemon-triggers-SF as canonical EOD path (revert PR…

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -460,6 +460,13 @@ def run_daemon(dry_run: bool = False) -> None:
     trades_executed = 0
     executed_tickers: set = set()  # tracks tickers already traded today
 
+    # Track whether we reached the live trading window so the finally block
+    # can decide whether it's safe to fire the EOD pipeline. Pre-market exits
+    # (shutdown signal, early crash, etc.) must NOT trigger EOD — market-close
+    # side-effects like stopping the trading EC2 instance would then run
+    # before the market ever opened.
+    market_opened = False
+
     try:
         # ── Wait for market open (daemon may start before 9:30 AM ET) ────
         if not is_market_hours():
@@ -469,6 +476,11 @@ def run_daemon(dry_run: bool = False) -> None:
             if _shutdown_requested:
                 return
             logger.info("Market is open — proceeding")
+
+        # Guard: Phase 0 urgent exits + live IB order placement must only run
+        # once the market is actually open. Reaching this line means the
+        # wait-for-open loop above exited on is_market_hours() == True.
+        market_opened = True
 
         # ── Phase 0: Execute urgent exits/covers immediately (no trigger delay) ──
         # Fetch current positions once for short-sell prevention checks
@@ -783,6 +795,70 @@ def run_daemon(dry_run: bool = False) -> None:
             f"Trades executed: {trades_executed}"
         )
         logger.info("Daemon shutdown complete | trades=%d", trades_executed)
+
+        # Trigger EOD pipeline Step Function only when two conditions hold
+        # at exit time:
+        #   1. market_opened: the daemon actually entered the live trading
+        #      window. Pre-market exits (crash, signal) must not fire EOD.
+        #   2. not is_market_hours(): the market is closed RIGHT NOW. This
+        #      makes SIGTERM-driven mid-session restarts (systemctl restart,
+        #      maintenance) safe — the daemon exits, market is still open,
+        #      no EOD fires, instance stays up.
+        # Checking state at exit (instead of tracking an exit-reason flag)
+        # handles the race where the market closes between the last loop
+        # iteration and the finally block.
+        #
+        # 2026-04-28: this is the canonical EOD trigger after Phase 1 of the
+        # EOD-SF cutover. Replaced systemd timer + EventBridge cron with a
+        # single daemon-driven path per "no redundant paths." Removed by
+        # PR #94 on 2026-04-22 (which kept the systemd timer instead) —
+        # restored here because the timer was retired in PR #117 and the
+        # SF is the architecturally correct caller.
+        if not dry_run and market_opened and not is_market_hours():
+            _trigger_eod_pipeline(config, run_date)
+        elif not dry_run:
+            logger.warning(
+                "Skipping EOD pipeline trigger: market_opened=%s market_open_now=%s",
+                market_opened, is_market_hours(),
+            )
+
+
+def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
+    """Start the EOD Step Function pipeline after daemon shutdown.
+
+    Input shape matches the SF's expectations: trading_instance_id (array
+    for SSM sendCommand) + sns_topic_arn for HandleFailure publish.
+    Extra fields (run_date, triggered_by) are harmless — the SF ignores
+    them but they're useful for audit / debugging in execution history.
+
+    Failures are non-fatal so a transient SF / IAM hiccup doesn't crash
+    the daemon mid-shutdown. SF failure surfaces via the SNS HandleFailure
+    branch when it eventually fires; daemon-side failure to start
+    surfaces via the WARN log + flow-doctor capture.
+    """
+    try:
+        import boto3 as _b3_sf
+        sfn = _b3_sf.client("stepfunctions", region_name="us-east-1")
+        state_machine_arn = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
+        trading_instance_id = "i-018eb3307a21329bf"
+        sns_topic_arn = config.get(
+            "sns_topic_arn",
+            "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
+        )
+        import json as _json_sf
+        sfn.start_execution(
+            stateMachineArn=state_machine_arn,
+            name=f"eod-{run_date}-{int(__import__('time').time())}",
+            input=_json_sf.dumps({
+                "trading_instance_id": [trading_instance_id],
+                "sns_topic_arn": sns_topic_arn,
+                "run_date": run_date,
+                "triggered_by": "daemon_shutdown",
+            }),
+        )
+        logger.info("EOD pipeline triggered: %s", state_machine_arn)
+    except Exception as exc:
+        logger.warning("Failed to trigger EOD pipeline (non-fatal): %s", exc)
 
 
 def _execute_exit(

--- a/tests/test_daemon_phase0.py
+++ b/tests/test_daemon_phase0.py
@@ -247,3 +247,77 @@ class TestCleanupConnections:
         monitor = MagicMock()
         _cleanup_connections(monitor, None)
         monitor.unsubscribe_all.assert_called_once()
+
+
+# ── _trigger_eod_pipeline ────────────────────────────────────────────────────
+# Daemon shutdown is the canonical trigger for the alpha-engine-eod-pipeline
+# Step Function. PR #94 (2026-04-22) removed this trigger and kept the
+# systemd timer; PR #117 (2026-04-28) retired the systemd timer; this test
+# locks the trigger code in place so a future "let's clean this up" doesn't
+# re-introduce the SF-orphaned regression that lasted from 4/22 to 4/28.
+
+
+class TestTriggerEodPipeline:
+    def test_calls_step_functions_start_execution(self):
+        from executor.daemon import _trigger_eod_pipeline
+
+        with patch("boto3.client") as mock_boto:
+            sfn = MagicMock()
+            mock_boto.return_value = sfn
+            _trigger_eod_pipeline(
+                {"sns_topic_arn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"},
+                "2026-04-29",
+            )
+            sfn.start_execution.assert_called_once()
+            kwargs = sfn.start_execution.call_args.kwargs
+            assert "alpha-engine-eod-pipeline" in kwargs["stateMachineArn"]
+            assert kwargs["name"].startswith("eod-2026-04-29-")
+
+    def test_input_payload_shape(self):
+        """Input must include trading_instance_id (array — SF SSM step expects
+        it) + sns_topic_arn (HandleFailure publish target)."""
+        import json
+
+        from executor.daemon import _trigger_eod_pipeline
+
+        with patch("boto3.client") as mock_boto:
+            sfn = MagicMock()
+            mock_boto.return_value = sfn
+            _trigger_eod_pipeline(
+                {"sns_topic_arn": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"},
+                "2026-04-29",
+            )
+            payload = json.loads(sfn.start_execution.call_args.kwargs["input"])
+            assert isinstance(payload["trading_instance_id"], list)
+            assert payload["trading_instance_id"][0].startswith("i-")
+            assert payload["sns_topic_arn"].startswith("arn:aws:sns:")
+            assert payload["run_date"] == "2026-04-29"
+            assert payload["triggered_by"] == "daemon_shutdown"
+
+    def test_failure_is_non_fatal(self):
+        """Daemon's finally block must not crash if SF start fails. The
+        trigger logs a WARN and returns; SF-side failures surface via SNS
+        HandleFailure and flow-doctor when the SF eventually fires."""
+        from executor.daemon import _trigger_eod_pipeline
+
+        with patch("boto3.client") as mock_boto:
+            sfn = MagicMock()
+            sfn.start_execution.side_effect = RuntimeError("transient IAM hiccup")
+            mock_boto.return_value = sfn
+            # Must NOT raise — the daemon shutdown path can't tolerate an
+            # exception out of this trigger.
+            _trigger_eod_pipeline({}, "2026-04-29")
+
+    def test_uses_default_sns_topic_when_config_missing(self):
+        """`_trigger_eod_pipeline({}, ...)` must still produce a valid
+        input — the default SNS topic ARN is hardcoded as fallback."""
+        import json
+
+        from executor.daemon import _trigger_eod_pipeline
+
+        with patch("boto3.client") as mock_boto:
+            sfn = MagicMock()
+            mock_boto.return_value = sfn
+            _trigger_eod_pipeline({}, "2026-04-29")
+            payload = json.loads(sfn.start_execution.call_args.kwargs["input"])
+            assert "alpha-engine-alerts" in payload["sns_topic_arn"]


### PR DESCRIPTION
… #94)

Phase 1 of the EOD-SF cutover (PR #117) retired the systemd timers but mistakenly added an EventBridge cron rule as the SF trigger. The intended architecture — and the one in place pre-PR-#94 — is the daemon itself triggering the SF on shutdown. PR #94 (2026-04-22) removed that trigger to fix the duplicate-EOD-email bug, but kept the systemd timer instead of the SF; that decision was the wrong half. With the timer now retired (PR #117) and the EventBridge rule removed (this session), the daemon-side trigger is restored as the single authoritative caller.

What this restores (mirror of PR #94's diff):
- `market_opened` flag tracking whether the daemon entered the live trading window. Pre-market exits (early crash, shutdown signal during the wait-for-open loop) must NOT fire EOD — market-close side-effects like StopTradingInstance would otherwise run before the market ever opened.
- `_trigger_eod_pipeline(config, run_date)` helper: starts the SF with input `{trading_instance_id, sns_topic_arn, run_date, triggered_by}`. Failures are non-fatal (logged WARN; SF-side failures still surface via the SF's HandleFailure → SNS branch when it fires).
- Trigger call in the finally block, gated on `market_opened AND not is_market_hours()`. Checking state at exit (vs tracking an exit-reason flag) handles the race where the market closes between the last loop iteration and the finally block. Also makes SIGTERM-driven mid-session restarts safe — the daemon exits, market is still open, no EOD fires, instance stays up.

Why daemon-trigger-only (no EventBridge cron backstop):
- Per "no redundant paths around load-bearing scheduled infra" — redundant scheduled paths obscure design intent and host divergence.
- If the daemon doesn't start (boot-pull failure, IB Gateway down, etc.) the morning weekday SF's RunDaemon step fails loud; SNS alarm fires. That's the early-warning signal. No cost-protection cron backstop; the operator notices the alarm and stops the instance manually if needed. Acceptable trade-off given the warning system.

IAM:
- `alpha-engine-executor-role` already has `alpha-engine-stepfunctions-eod` inline policy granting `states:StartExecution` on the EOD SF (codified in `infrastructure/iam/` via PR #105). No IAM changes needed.

Tests:
- New `TestTriggerEodPipeline` class in `tests/test_daemon_phase0.py`: 4 tests cover (a) start_execution called on the right SF ARN, (b) input payload shape (trading_instance_id array + sns_topic_arn + run_date + triggered_by), (c) failure is non-fatal, (d) default SNS topic when config missing.
- Locks the trigger code in place so a future "let's clean this up" doesn't re-introduce the SF-orphaned regression that lasted from 4/22 to 4/28.
- 395 full executor suite pass (391 → 395; +4 new).

Companion AWS state changes (applied via CLI tonight):
- Deleted EventBridge rule `alpha-engine-eod` (mistakenly created earlier this session).
- Reverted `alpha-engine-eventbridge-sfn-role-policy` to 2 ARNs (saturday + weekday only); EOD SF no longer needs to be in the role's resource list since EventBridge is no longer the trigger.

Validation: tomorrow Wed 2026-04-29, 6:11 AM PT boot-pull cleans systemd timers (PR #117), daemon starts via systemd, market opens 6:30 AM PT (`market_opened = True` after the wait-for-open loop), 1:15 PM PT daemon shutdown handler fires `_trigger_eod_pipeline`, SF runs PostMarketData → EODReconcile → StopTradingInstance. Single EOD email lands; instance stops via SF.