### PR TITLE
feat(eod): Phase 2 — snapshot capture decouples reconcile from live IB

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -24,7 +24,6 @@ from ssm_secrets import load_secrets
 load_secrets()
 
 from executor.eod_emailer import send_eod_email
-from executor.ibkr import IBKRClient
 from executor.trade_logger import (
     init_db, log_eod, backup_to_s3, get_entry_trade, get_todays_trades,
 )
@@ -337,28 +336,14 @@ def _apply_dividend_delta(
 
 
 def run(run_date: str | None = None) -> None:
-    today_trading_day = now_dual().trading_day
     if run_date is None:
-        run_date = today_trading_day
+        run_date = now_dual().trading_day
         logger.info(
             "EOD reconciliation | date=%s (resolved from now_dual().trading_day)",
             run_date,
         )
     else:
-        if run_date != today_trading_day:
-            raise RuntimeError(
-                f"EOD reconciliation refusing run_date={run_date!r} "
-                f"!= today's trading_day {today_trading_day!r}. "
-                f"Historical reruns are unsafe: get_account_snapshot() returns "
-                f"current live IB state which would be written against the "
-                f"historical row, corrupting the prior_nav chain. "
-                f"For SPY-only corrections use infrastructure/backfill_eod_pnl_spy.py; "
-                f"a --from-snapshot mode for full historical reconstruction is owed."
-            )
-        logger.info(
-            "EOD reconciliation | date=%s (explicit; matches today's trading_day)",
-            run_date,
-        )
+        logger.info("EOD reconciliation | date=%s (explicit)", run_date)
     _health_start = _time.time()
 
     config = load_config()
@@ -366,9 +351,8 @@ def run(run_date: str | None = None) -> None:
     db_path = config["db_path"]
     trades_bucket = config["trades_bucket"]
 
-    # Preflight: AWS_REGION + S3 bucket reachable. Fail fast before the
-    # retry loop so a misconfigured env surfaces immediately instead of
-    # after 3x IBKR reconnect timeouts.
+    # Preflight: AWS_REGION + S3 bucket reachable. Fail fast so a
+    # misconfigured env surfaces immediately instead of deeper down.
     from executor.preflight import ExecutorPreflight
     ExecutorPreflight(bucket=trades_bucket, mode="eod").run()
 
@@ -384,45 +368,58 @@ def run(run_date: str | None = None) -> None:
 
     conn = init_db(db_path)
 
-    # Connect to IB Gateway with retry (transient failures at EOD are common)
-    max_eod_attempts = 3
-    nav = None
-    positions = None
-    for attempt in range(1, max_eod_attempts + 1):
-        try:
-            ibkr = IBKRClient(
-                host=config["ibkr_host"],
-                port=config["ibkr_port"],
-                client_id=config["ibkr_client_id"],
+    # Load EOD state from S3 snapshot keyed by run_date.
+    #
+    # 2026-04-28 (Phase 2 of EOD-SF cutover): replaced the live IB-read
+    # block (`get_account_snapshot` + `get_positions` +
+    # `get_accrued_dividends_by_symbol`) with a snapshot read. The
+    # snapshot is written by `executor/snapshot_capturer.py` running as
+    # the SF's `CaptureSnapshot` step before this step. The snapshot
+    # decouples capture from reconciliation — the row keyed by
+    # `run_date=X` is now built from observations made at time X, not
+    # from now-as-of state at write-time. PR #116's `run_date != today`
+    # hard-block is no longer needed: the snapshot-existence check is
+    # the new contract, and snapshot existence is what makes the run
+    # safe (today, last Tuesday, or any other date with a snapshot).
+    from executor.snapshot_capturer import load_snapshot
+    snapshot = load_snapshot(
+        bucket=trades_bucket,
+        run_date=run_date,
+        region=config.get("aws_region", "us-east-1"),
+    )
+    if snapshot is None:
+        msg = (
+            f"No snapshot at s3://{trades_bucket}/trades/snapshots/{run_date}.json — "
+            f"`executor/snapshot_capturer.py` must run before "
+            f"`executor/eod_reconcile.py` so the row keyed by run_date={run_date!r} "
+            f"sources its inputs from observations made at time {run_date!r} "
+            f"(not from now-as-of IB state). The CaptureSnapshot SF step is the "
+            f"canonical writer; for manual recovery, run "
+            f"`python executor/snapshot_capturer.py --date {run_date}` while IB "
+            f"Gateway is up on ae-trading."
+        )
+        if fd:
+            fd.report(
+                RuntimeError(msg),
+                severity="critical",
+                context={"site": "eod_load_snapshot", "run_date": run_date},
             )
-            account = ibkr.get_account_snapshot()
-            nav = account["net_liquidation"]
-            positions = ibkr.get_positions()
-            # Per-symbol accrued dividends — often {} for paper accounts.
-            # Stored in positions_snapshot to compute day-over-day deltas.
-            dividends_by_symbol = ibkr.get_accrued_dividends_by_symbol()
-            for _tkr, _accrued in dividends_by_symbol.items():
-                if _tkr in positions:
-                    positions[_tkr]["accrued_dividend"] = _accrued
-            ibkr.disconnect()
-            break
-        except Exception as e:
-            if attempt == max_eod_attempts:
-                logger.error(
-                    "EOD: IB Gateway connection failed after %d attempts: %s",
-                    max_eod_attempts, e,
-                )
-                if fd:
-                    fd.report(e, severity="critical", context={
-                        "site": "eod_ibkr_connect", "run_date": run_date,
-                        "attempts": max_eod_attempts})
-                raise
-            wait = 30 * attempt
-            logger.warning(
-                "EOD: IB Gateway attempt %d/%d failed: %s — retrying in %ds",
-                attempt, max_eod_attempts, e, wait,
-            )
-            _time.sleep(wait)
+        raise RuntimeError(msg)
+
+    account = snapshot["account"]
+    nav = account["net_liquidation"]
+    positions = snapshot["positions"]
+    dividends_by_symbol = snapshot.get("accrued_dividends", {})
+    for _tkr, _accrued in dividends_by_symbol.items():
+        if _tkr in positions:
+            positions[_tkr]["accrued_dividend"] = _accrued
+    logger.info(
+        "EOD: snapshot loaded | NAV=$%.2f positions=%d dividends=%d captured_at=%s",
+        nav,
+        len(positions),
+        len(dividends_by_symbol),
+        snapshot.get("captured_at"),
+    )
 
     # Enrich positions with sector. Lookup chain:
     #   1. signals.json today (universe + buy_candidates)

--- a/executor/snapshot_capturer.py
+++ b/executor/snapshot_capturer.py
@@ -1,0 +1,192 @@
+"""
+EOD snapshot capturer — reads live IB state once at end-of-day and
+persists an immutable snapshot to S3 keyed by run_date.
+
+This is Phase 2 of the EOD-SF cutover. Decouples capture from
+reconciliation so `eod_reconcile.py` can read date-locked state from
+S3 instead of reading current live IB state at write-time. The
+architectural invariant: a row keyed by `run_date=X` must source its
+inputs from observations made at time X. Live IB at write-time only
+satisfied this by accident (because the timer happened to fire once
+a day right after close); a snapshot makes it explicit.
+
+Idempotent. Re-running on the same `run_date` overwrites the existing
+snapshot. Hard-fails on IB connection failure or S3 write failure —
+no silent fallback (the reconcile path depends on this snapshot).
+
+SF orchestration: this script runs as the `CaptureSnapshot` step in
+`alpha-engine-eod-pipeline`, between `PostMarketData` and
+`EODReconcile`. Both depend on IB Gateway being up; the SF's
+`StopTradingInstance` step (which kills IB) only fires after
+EODReconcile completes.
+
+S3 path: s3://alpha-engine-research/trades/snapshots/{run_date}.json
+
+Schema (additive-only per CLAUDE.md S3 contract):
+    {
+      "run_date": "YYYY-MM-DD",
+      "captured_at": ISO8601,
+      "schema_version": 1,
+      "account": {net_liquidation, total_cash, settled_cash,
+                  accrued_interest, gross_position_value,
+                  buying_power, unrealized_pnl, realized_pnl},
+      "positions": {ticker: {shares, market_value, avg_cost,
+                             unrealized_pnl, sector}},
+      "accrued_dividends": {ticker: float},
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+import boto3
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from ssm_secrets import load_secrets
+
+load_secrets()
+
+from executor.config_loader import load_config
+from executor.ibkr import IBKRClient
+
+from alpha_engine_lib.dates import now_dual
+from alpha_engine_lib.logging import setup_logging
+
+_FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
+_FLOW_DOCTOR_YAML = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "flow-doctor.yaml",
+)
+setup_logging(
+    "snapshot",
+    flow_doctor_yaml=_FLOW_DOCTOR_YAML,
+    exclude_patterns=_FLOW_DOCTOR_EXCLUDE_PATTERNS,
+)
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+def _snapshot_key(run_date: str) -> str:
+    return f"trades/snapshots/{run_date}.json"
+
+
+def run(run_date: str | None = None) -> None:
+    """Capture live IB state and write to S3 keyed by run_date.
+
+    Default `run_date` resolves via `now_dual().trading_day` (NYSE-aware,
+    Pacific-time "last completed trading day"). Explicit `run_date`
+    arguments are accepted but are expected to match today — capture
+    only makes sense for the current trading day since IB's account
+    state is now-as-of, not historical.
+    """
+    today_trading_day = now_dual().trading_day
+    if run_date is None:
+        run_date = today_trading_day
+        logger.info(
+            "Snapshot capture | run_date=%s (resolved from now_dual().trading_day)",
+            run_date,
+        )
+    else:
+        if run_date != today_trading_day:
+            raise RuntimeError(
+                f"Snapshot capturer refusing run_date={run_date!r} "
+                f"!= today's trading_day {today_trading_day!r}. "
+                f"Snapshots can only be captured live (`get_account_snapshot()` "
+                f"returns now-as-of state); a historical run_date would "
+                f"persist today's state under yesterday's key."
+            )
+        logger.info(
+            "Snapshot capture | run_date=%s (explicit; matches today's trading_day)",
+            run_date,
+        )
+
+    config = load_config()
+    bucket = config["trades_bucket"]
+
+    # ── Connect to IB Gateway ─────────────────────────────────────────────
+    ibkr = IBKRClient(
+        host=config["ibkr_host"],
+        port=config["ibkr_port"],
+        client_id=config["ibkr_client_id"],
+    )
+
+    try:
+        account = ibkr.get_account_snapshot()
+        positions = ibkr.get_positions()
+        accrued_dividends = ibkr.get_accrued_dividends_by_symbol()
+    finally:
+        ibkr.disconnect()
+
+    payload = {
+        "run_date": run_date,
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "schema_version": SCHEMA_VERSION,
+        "account": account,
+        "positions": positions,
+        "accrued_dividends": accrued_dividends,
+    }
+
+    # ── Write to S3 ─────────────────────────────────────────────────────────
+    s3 = boto3.client("s3", region_name=config.get("aws_region", "us-east-1"))
+    key = _snapshot_key(run_date)
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(payload, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    logger.info(
+        "Snapshot written | s3://%s/%s NAV=%s positions=%d dividends=%d",
+        bucket,
+        key,
+        account.get("net_liquidation"),
+        len(positions),
+        len(accrued_dividends),
+    )
+
+
+def load_snapshot(bucket: str, run_date: str, region: str = "us-east-1") -> dict | None:
+    """Load the snapshot for `run_date`. Returns None if not found.
+
+    Used by `eod_reconcile.py` to substitute for the three live IB calls
+    (`get_account_snapshot`, `get_positions`, `get_accrued_dividends_by_symbol`).
+    """
+    s3 = boto3.client("s3", region_name=region)
+    try:
+        obj = s3.get_object(Bucket=bucket, Key=_snapshot_key(run_date))
+    except s3.exceptions.NoSuchKey:
+        return None
+    except Exception as exc:
+        # 404 from raw HTTPClientError can also mean "not found" depending
+        # on bucket config — try parsing first, surface anything else loud.
+        if "NoSuchKey" in str(exc) or "404" in str(exc):
+            return None
+        raise
+    return json.loads(obj["Body"].read())
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Capture live IB state to S3 keyed by run_date. Defaults to "
+            "today's trading_day via now_dual; --date must equal today "
+            "(snapshots can only be captured live)."
+        )
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="YYYY-MM-DD; must equal today's trading_day or the run aborts.",
+    )
+    args = parser.parse_args()
+    run(run_date=args.date)

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -376,74 +376,114 @@ class TestPnLMath:
         assert spy_return == pytest.approx(1.1235955, rel=1e-4)
 
 
-# ── run_date gating ──────────────────────────────────────────────────────────
-# Historical reruns are unsafe: get_account_snapshot() always returns current
-# live IB state, which would be written against the historical row and
-# corrupt the prior_nav chain. The gate hard-fails before any IBKR call.
+# ── snapshot-driven contract (Phase 2 of EOD-SF cutover) ─────────────────────
+# Phase 1 (PR #116) hard-blocked historical reruns to stop live-IB
+# corruption. Phase 2 replaces that gate entirely: eod_reconcile reads
+# from a per-run_date S3 snapshot (written by snapshot_capturer in the
+# CaptureSnapshot SF step) instead of querying live IB. The snapshot is
+# the date-locked source of truth — today, last Tuesday, or any date
+# with a snapshot all work uniformly. The contract becomes "snapshot
+# must exist for run_date" instead of "run_date must equal today."
 
 
-class TestRunDateGating:
-    def test_explicit_past_date_raises(self):
-        """run(run_date=<yesterday>) must raise before any IB connection."""
-        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
-            mock_now_dual.return_value = SimpleNamespace(
-                trading_day="2026-04-28", calendar_date="2026-04-28"
-            )
-            with pytest.raises(RuntimeError, match="Historical reruns are unsafe"):
-                run(run_date="2026-04-27")
-
-    def test_explicit_future_date_raises(self):
-        """A future-dated rerun is also a mismatch and must raise."""
-        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
-            mock_now_dual.return_value = SimpleNamespace(
-                trading_day="2026-04-28", calendar_date="2026-04-28"
-            )
-            with pytest.raises(RuntimeError, match="refusing run_date"):
-                run(run_date="2026-04-29")
-
-    def test_error_message_names_both_dates(self):
-        """Error message must include both the requested and resolved dates
-        so the operator can immediately see what was rejected."""
-        with patch("executor.eod_reconcile.now_dual") as mock_now_dual:
-            mock_now_dual.return_value = SimpleNamespace(
-                trading_day="2026-04-28", calendar_date="2026-04-28"
-            )
-            with pytest.raises(RuntimeError) as exc:
-                run(run_date="2026-04-25")
-            msg = str(exc.value)
-            assert "2026-04-25" in msg
-            assert "2026-04-28" in msg
-            assert "backfill_eod_pnl_spy.py" in msg  # points operator to safe path
-
-    def test_default_resolves_to_now_dual_trading_day(self, monkeypatch, tmp_path):
+class TestSnapshotContract:
+    def test_default_resolves_to_now_dual_trading_day(self):
         """run() with no run_date resolves via now_dual().trading_day, not
         date.today() (which would be UTC on ae-trading and could drift past
         midnight Pacific)."""
         # Patch now_dual + bail out at the first IO boundary (load_config) so
-        # we don't need to mock the full IB/S3/SQLite plumbing — the gate
-        # check fires before any of that.
+        # we don't need to mock the full snapshot/SQLite plumbing — confirming
+        # run_date resolved to today is the only assertion here.
         with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
              patch("executor.eod_reconcile.load_config") as mock_cfg:
             mock_now_dual.return_value = SimpleNamespace(
                 trading_day="2026-04-28", calendar_date="2026-04-28"
             )
             mock_cfg.side_effect = RuntimeError("expected_test_sentinel")
-            # The fact that it reaches load_config (and not the historical
-            # gate) confirms run_date resolved to today.
             with pytest.raises(RuntimeError, match="expected_test_sentinel"):
                 run(run_date=None)
 
-    def test_explicit_today_succeeds_past_gate(self):
-        """Explicit --date matching today's trading_day is permitted."""
+    def test_explicit_run_date_passes_through(self):
+        """Phase 2 removed the run_date != today hard-block — explicit
+        historical run_dates are now valid as long as a snapshot exists.
+        This test confirms run() doesn't raise on the date itself; the
+        snapshot-existence check happens later in the flow."""
         with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
              patch("executor.eod_reconcile.load_config") as mock_cfg:
             mock_now_dual.return_value = SimpleNamespace(
                 trading_day="2026-04-28", calendar_date="2026-04-28"
             )
             mock_cfg.side_effect = RuntimeError("expected_test_sentinel")
-            # Same as above: reaches load_config means gate accepted today.
+            # An explicit historical run_date used to raise (PR #116). With
+            # Phase 2's snapshot contract it must reach load_config — the
+            # snapshot-existence check is the new gate.
             with pytest.raises(RuntimeError, match="expected_test_sentinel"):
+                run(run_date="2026-04-25")
+
+    def test_run_raises_when_snapshot_missing(self):
+        """If no snapshot exists at s3://...trades/snapshots/{run_date}.json,
+        run() must hard-fail with a message naming the run_date and pointing
+        to the canonical writer. This is the new contract that supersedes
+        PR #116's run_date-equality gate."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
+             patch("executor.eod_reconcile.load_config") as mock_cfg, \
+             patch("executor.preflight.ExecutorPreflight") as mock_preflight, \
+             patch("executor.eod_reconcile.init_db") as mock_db, \
+             patch("executor.snapshot_capturer.load_snapshot") as mock_load:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            mock_cfg.return_value = {
+                "db_path": "/tmp/x.db",
+                "trades_bucket": "alpha-engine-research",
+                "aws_region": "us-east-1",
+                "email_sender": "x@x.com",
+                "email_recipients": "y@y.com",
+            }
+            mock_preflight.return_value.run.return_value = None
+            mock_db.return_value = MagicMock()
+            mock_load.return_value = None  # snapshot missing
+            with pytest.raises(RuntimeError, match="No snapshot at s3://"):
                 run(run_date="2026-04-28")
+
+    def test_run_raises_message_points_to_capturer(self):
+        """The error message must name the missing key + reference
+        snapshot_capturer.py so the operator knows where to recover."""
+        with patch("executor.eod_reconcile.now_dual") as mock_now_dual, \
+             patch("executor.eod_reconcile.load_config") as mock_cfg, \
+             patch("executor.preflight.ExecutorPreflight") as mock_preflight, \
+             patch("executor.eod_reconcile.init_db") as mock_db, \
+             patch("executor.snapshot_capturer.load_snapshot") as mock_load:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-28", calendar_date="2026-04-28"
+            )
+            mock_cfg.return_value = {
+                "db_path": "/tmp/x.db",
+                "trades_bucket": "alpha-engine-research",
+                "aws_region": "us-east-1",
+                "email_sender": "x@x.com",
+                "email_recipients": "y@y.com",
+            }
+            mock_preflight.return_value.run.return_value = None
+            mock_db.return_value = MagicMock()
+            mock_load.return_value = None
+            with pytest.raises(RuntimeError) as exc:
+                run(run_date="2026-04-25")
+            msg = str(exc.value)
+            assert "2026-04-25" in msg
+            assert "snapshot_capturer.py" in msg
+            assert "trades/snapshots/" in msg
+
+    def test_eod_no_longer_imports_ibkrclient(self):
+        """eod_reconcile must NOT depend on IBKRClient — the live IB read
+        is now in snapshot_capturer.py. A future regression that re-adds
+        the import would re-couple reconciliation to live state."""
+        import executor.eod_reconcile as eod_mod
+        assert not hasattr(eod_mod, "IBKRClient"), (
+            "eod_reconcile.py must not import IBKRClient. The live IB "
+            "read belongs in snapshot_capturer.py (Phase 2 of EOD-SF "
+            "cutover); reconciliation reads from the S3 snapshot only."
+        )
 
     def test_cli_date_flag_forwards_to_run(self):
         """`python eod_reconcile.py --date YYYY-MM-DD` invokes run(run_date=...)."""

--- a/tests/test_snapshot_capturer.py
+++ b/tests/test_snapshot_capturer.py
@@ -1,0 +1,228 @@
+"""Unit tests for executor.snapshot_capturer — Phase 2 of EOD-SF cutover.
+
+Snapshot is the date-locked source of truth for end-of-day state. Capture
+runs as the CaptureSnapshot SF step (between PostMarketData and
+EODReconcile); eod_reconcile reads the snapshot instead of querying live
+IB. The architectural invariant: a row keyed by `run_date=X` sources its
+inputs from observations made at time X.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor.snapshot_capturer import _snapshot_key, load_snapshot, run
+
+
+# ── _snapshot_key ────────────────────────────────────────────────────────────
+
+
+def test_snapshot_key_format():
+    """S3 key path is `trades/snapshots/{run_date}.json` — locked-in
+    contract since eod_reconcile's load_snapshot reader uses the same."""
+    assert _snapshot_key("2026-04-29") == "trades/snapshots/2026-04-29.json"
+
+
+# ── load_snapshot ────────────────────────────────────────────────────────────
+
+
+class TestLoadSnapshot:
+    def test_returns_parsed_dict_on_success(self):
+        body = MagicMock()
+        body.read.return_value = json.dumps({
+            "run_date": "2026-04-29",
+            "account": {"net_liquidation": 1000000.0},
+            "positions": {},
+            "accrued_dividends": {},
+        }).encode("utf-8")
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body}
+        # NoSuchKey isn't raised in the success path so the exceptions
+        # attribute doesn't matter, but mock it for completeness.
+        s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+
+        with patch("boto3.client", return_value=s3):
+            result = load_snapshot("alpha-engine-research", "2026-04-29")
+
+        assert result["run_date"] == "2026-04-29"
+        assert result["account"]["net_liquidation"] == 1000000.0
+        s3.get_object.assert_called_once_with(
+            Bucket="alpha-engine-research",
+            Key="trades/snapshots/2026-04-29.json",
+        )
+
+    def test_returns_none_on_no_such_key(self):
+        """Missing snapshot returns None — the caller (eod_reconcile)
+        decides what to do (currently: raise with a helpful message)."""
+        no_such_key = type("NoSuchKey", (Exception,), {})
+        s3 = MagicMock()
+        s3.exceptions.NoSuchKey = no_such_key
+        s3.get_object.side_effect = no_such_key()
+
+        with patch("boto3.client", return_value=s3):
+            result = load_snapshot("alpha-engine-research", "2026-04-29")
+        assert result is None
+
+    def test_returns_none_on_404_string_in_error(self):
+        """Some S3-compatible backends raise raw HTTPClientError with '404'
+        in the string instead of a typed NoSuchKey — handle both."""
+        s3 = MagicMock()
+        s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        s3.get_object.side_effect = RuntimeError("HTTP 404 Not Found")
+
+        with patch("boto3.client", return_value=s3):
+            result = load_snapshot("alpha-engine-research", "2026-04-29")
+        assert result is None
+
+    def test_raises_loud_on_unrelated_errors(self):
+        """A genuine S3 error (auth, network, region, etc.) must NOT be
+        silenced — the snapshot path is load-bearing."""
+        s3 = MagicMock()
+        s3.exceptions.NoSuchKey = type("NoSuchKey", (Exception,), {})
+        s3.get_object.side_effect = RuntimeError("AccessDenied")
+
+        with patch("boto3.client", return_value=s3):
+            with pytest.raises(RuntimeError, match="AccessDenied"):
+                load_snapshot("alpha-engine-research", "2026-04-29")
+
+
+# ── run ──────────────────────────────────────────────────────────────────────
+
+
+def _mock_config():
+    return {
+        "trades_bucket": "alpha-engine-research",
+        "aws_region": "us-east-1",
+        "ibkr_host": "127.0.0.1",
+        "ibkr_port": 4002,
+        "ibkr_client_id": 99,
+    }
+
+
+class TestRun:
+    def test_default_resolves_to_now_dual_trading_day(self):
+        with patch("executor.snapshot_capturer.now_dual") as mock_now_dual, \
+             patch("executor.snapshot_capturer.load_config") as mock_cfg, \
+             patch("executor.snapshot_capturer.IBKRClient") as mock_ib_cls, \
+             patch("boto3.client") as mock_boto:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-29", calendar_date="2026-04-29"
+            )
+            mock_cfg.return_value = _mock_config()
+            ib = MagicMock()
+            ib.get_account_snapshot.return_value = {"net_liquidation": 1.0}
+            ib.get_positions.return_value = {}
+            ib.get_accrued_dividends_by_symbol.return_value = {}
+            mock_ib_cls.return_value = ib
+            s3 = MagicMock()
+            mock_boto.return_value = s3
+
+            run(run_date=None)
+
+            # Verify the put_object key was constructed from the resolved
+            # run_date, not from None or some other default.
+            kwargs = s3.put_object.call_args.kwargs
+            assert kwargs["Key"] == "trades/snapshots/2026-04-29.json"
+
+    def test_explicit_past_date_raises(self):
+        """Capture is intrinsically live — get_account_snapshot returns
+        now-as-of state. A historical run_date would persist today's
+        state under yesterday's key, corrupting the contract."""
+        with patch("executor.snapshot_capturer.now_dual") as mock_now_dual:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-29", calendar_date="2026-04-29"
+            )
+            with pytest.raises(RuntimeError, match="refusing run_date"):
+                run(run_date="2026-04-27")
+
+    def test_payload_shape(self):
+        """Snapshot must contain run_date + captured_at + schema_version
+        + the three IB-derived fields. eod_reconcile depends on this shape."""
+        with patch("executor.snapshot_capturer.now_dual") as mock_now_dual, \
+             patch("executor.snapshot_capturer.load_config") as mock_cfg, \
+             patch("executor.snapshot_capturer.IBKRClient") as mock_ib_cls, \
+             patch("boto3.client") as mock_boto:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-29", calendar_date="2026-04-29"
+            )
+            mock_cfg.return_value = _mock_config()
+            ib = MagicMock()
+            ib.get_account_snapshot.return_value = {
+                "net_liquidation": 1_000_000.0,
+                "total_cash": 250_000.0,
+                "settled_cash": 250_000.0,
+                "accrued_interest": 12.34,
+                "gross_position_value": 750_000.0,
+                "buying_power": 2_000_000.0,
+                "unrealized_pnl": 5_000.0,
+                "realized_pnl": -123.45,
+            }
+            ib.get_positions.return_value = {
+                "AAPL": {
+                    "shares": 100,
+                    "market_value": 20000.0,
+                    "avg_cost": 195.0,
+                    "unrealized_pnl": 500.0,
+                    "sector": "",
+                }
+            }
+            ib.get_accrued_dividends_by_symbol.return_value = {"PFE": 12.34}
+            mock_ib_cls.return_value = ib
+            s3 = MagicMock()
+            mock_boto.return_value = s3
+
+            run(run_date="2026-04-29")
+
+            kwargs = s3.put_object.call_args.kwargs
+            payload = json.loads(kwargs["Body"].decode("utf-8"))
+            assert payload["run_date"] == "2026-04-29"
+            assert "captured_at" in payload
+            assert payload["schema_version"] == 1
+            assert payload["account"]["net_liquidation"] == 1_000_000.0
+            assert payload["account"]["accrued_interest"] == 12.34
+            assert payload["positions"]["AAPL"]["shares"] == 100
+            assert payload["accrued_dividends"]["PFE"] == 12.34
+            assert kwargs["ContentType"] == "application/json"
+
+    def test_disconnects_ib_after_read(self):
+        """IBKR disconnect must run even on success path. Reuses the
+        existing eod_reconcile pattern; capturer is short-lived."""
+        with patch("executor.snapshot_capturer.now_dual") as mock_now_dual, \
+             patch("executor.snapshot_capturer.load_config") as mock_cfg, \
+             patch("executor.snapshot_capturer.IBKRClient") as mock_ib_cls, \
+             patch("boto3.client") as mock_boto:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-29", calendar_date="2026-04-29"
+            )
+            mock_cfg.return_value = _mock_config()
+            ib = MagicMock()
+            ib.get_account_snapshot.return_value = {"net_liquidation": 1.0}
+            ib.get_positions.return_value = {}
+            ib.get_accrued_dividends_by_symbol.return_value = {}
+            mock_ib_cls.return_value = ib
+            mock_boto.return_value = MagicMock()
+
+            run(run_date="2026-04-29")
+
+            ib.disconnect.assert_called_once()
+
+    def test_disconnects_ib_even_on_ib_failure(self):
+        """If get_account_snapshot raises, disconnect still runs (finally
+        block). Don't leak IB connections across capture-failure retries."""
+        with patch("executor.snapshot_capturer.now_dual") as mock_now_dual, \
+             patch("executor.snapshot_capturer.load_config") as mock_cfg, \
+             patch("executor.snapshot_capturer.IBKRClient") as mock_ib_cls:
+            mock_now_dual.return_value = SimpleNamespace(
+                trading_day="2026-04-29", calendar_date="2026-04-29"
+            )
+            mock_cfg.return_value = _mock_config()
+            ib = MagicMock()
+            ib.get_account_snapshot.side_effect = RuntimeError("IB outage")
+            mock_ib_cls.return_value = ib
+
+            with pytest.raises(RuntimeError, match="IB outage"):
+                run(run_date="2026-04-29")
+            ib.disconnect.assert_called_once()


### PR DESCRIPTION
Phase 1 of the EOD-SF cutover put the SF in front of the existing chain but left the live-IB-read pattern intact in eod_reconcile. The architectural invariant — a row keyed by `run_date=X` must source its inputs from observations made at time X — was still being satisfied by accident (timer + daemon both fire after market close, so live IB read happens at ~the right time). PR #116's hard-block prevented the corruption class from manifesting but the underlying coupling was latent; any future caller (SF retry after transient IB hiccup, parallel test path, etc.) could rediscover it. Phase 2 closes that class for good by separating capture from reconciliation.

New: executor/snapshot_capturer.py (~150 lines + 10 tests)

  Reads live IB once and writes immutable JSON to
  s3://alpha-engine-research/trades/snapshots/{run_date}.json. Idempotent.
  Hard-fails on IB connection failure or S3 write failure. Same
  now_dual().trading_day default-resolution + run_date \!= today
  hard-block as eod_reconcile (capture is intrinsically live —
  get_account_snapshot returns now-as-of state; a historical run_date
  would persist today's state under yesterday's key).

  Also exposes load_snapshot(bucket, run_date) helper used by
  eod_reconcile to substitute for the three live IB calls.

  Schema (additive-only per CLAUDE.md S3 contract):
    {run_date, captured_at, schema_version, account, positions,
     accrued_dividends}

Refactored: executor/eod_reconcile.py

  - Drops the IBKRClient connection block (~30 lines + retry loop) — no live IB connection at all in eod_reconcile anymore.
  - Drops the IBKRClient import.
  - Replaces with `_load_snapshot(bucket, run_date)` call. Three fields previously read from live IB now come from the snapshot dict: account (8 fields), positions, accrued_dividends.
  - PR #116's run_date \!= today_trading_day hard-block reverts — snapshot-existence check is the new contract. Today, last Tuesday, or any date with a snapshot all work uniformly.
  - On missing snapshot, raises with a message naming the missing S3 key + pointing the operator at snapshot_capturer.py for manual recovery.

Tests (388 → 405 across the broader EOD arc; +10 in this PR)

  - tests/test_snapshot_capturer.py (10 new): _snapshot_key format, load_snapshot success/NoSuchKey/404-string/auth-error paths, run() defaults to now_dual, run() rejects historical run_date, payload shape, IB disconnect on success + on failure.
  - tests/test_eod_reconcile.py (+5, replacing PR #116's 3 gating tests with the new contract):
      * default-resolves-to-now_dual still holds
      * explicit_run_date_passes_through (no more equality gate) * run_raises_when_snapshot_missing (new contract) * run_raises_message_points_to_capturer (operator UX) * eod_no_longer_imports_ibkrclient (anti-regression on re-coupling reconcile to live state)

Companion: alpha-engine-data PR adds infrastructure/update_eod_pipeline_sf.sh that inserts the CaptureSnapshot SF state between PostMarketData and EODReconcile (mirrors the existing SSM polling + Choice + Catch pattern). The SF update is idempotent.

Deploy sequence:
  1. Merge this PR + the alpha-engine-data PR
  2. Apply the SF update via update_eod_pipeline_sf.sh
  3. Wed 2026-04-29 ~6:11 AM PT — ae-trading boot-pulls main; both new files land on disk
  4. Wed ~13:15 PT — daemon shutdown triggers SF; chain runs: PostMarketData → CaptureSnapshot (NEW) → EODReconcile → StopTradingInstance