### PR TITLE
cleanup(iam): drop stale predictor/daily_closes/* grant from executor role

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
@@ -43,7 +43,6 @@
                 "arn:aws:s3:::alpha-engine-research/predictor/predictions/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache_slim/*",
-                "arn:aws:s3:::alpha-engine-research/predictor/daily_closes/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/metrics/*"
             ]
         },


### PR DESCRIPTION
## Summary

PR 4 of a coordinated 4-PR arc migrating `predictor/daily_closes/` → `staging/daily_closes/`. Drops the stale executor IAM grant.

The executor migrated off `predictor/daily_closes/*.parquet` on **2026-04-17 in PR #60** (`3255e2f`, "Migrate load_daily_vwap to ArcticDB — per-ticker, no parquet fallback"). All three executor call sites — `load_daily_vwap`, `eod_reconcile` SPY + per-position closes, and `main.py` freshness gate — now hard-fail on ArcticDB miss with no parquet fallback. The IAM grant became dead the day that PR merged.

## Coordinated 4-PR arc

| PR | Repo | What |
|---|---|---|
| #112 | alpha-engine-data | writer + 2 readers + lifecycle policy |
| #49 | alpha-engine-research | research reader cutover |
| #23 | alpha-engine-dashboard | dashboard observability cutover |
| **this** | alpha-engine | drop stale executor IAM grant |

## Out-of-scope grants noted

The same `ReadWritePredictorData` statement still grants access to `predictor/price_cache/*` and `predictor/price_cache_slim/*` which are also stale after the 2026-04-16 Phase 7a inference price-source cutover. Those are tracked as a separate cleanup once ROADMAP Phase 7e deletes the corresponding S3 prefixes — bundling them here would broaden blast radius beyond this arc.

## Operational note

The IAM drift detector (PR #106) will flag the codified JSON vs live AWS as drifted until `bash infrastructure/iam/apply.sh alpha-engine-executor-role` runs after merge — same as any other IAM change in this repo.

## Test plan

- [x] `python3 -c 'import json; json.load(open("infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json"))'` -> valid (10 statements)
- [x] `pytest tests/` -> 409 pass, 0 regressions