### PR TITLE
feat(preflight): tighten ExecutorPreflight with ArcticDB freshness gates

### DIFF
--- a/executor/preflight.py
+++ b/executor/preflight.py
@@ -3,27 +3,38 @@ Executor preflight: connectivity + safety checks run at the top of each
 entrypoint before any real work starts.
 
 Primitives live in ``alpha_engine_lib.preflight.BasePreflight``; this
-module only composes them into a mode-specific sequence. See the
+module composes them into a mode-specific sequence. See the
 alpha-engine-lib README for the rationale.
 
 Modes:
 
 - ``"main"`` — ``executor/main.py``, the morning order-book planner.
-  S3 reachable + AWS_REGION set. Does not place orders; the IB paper-
-  account guard is not strictly required here, but main.py connects
-  to IB for NAV/positions and the guard is available on the preflight
-  instance via :meth:`check_ib_paper_account` for callers that want it.
+  Reads per-ticker OHLCV for ATR sizing + macro/SPY for alpha context.
+  Both ArcticDB libraries must be readable + fresh; per-ticker
+  freshness scan catches the partial-write class (2026-04-21 ASGN/MOH)
+  that single-symbol checks miss.
 - ``"daemon"`` — ``executor/daemon.py``, the sole order executor. Same
-  S3 + env checks as ``main``. The daemon calls
-  :meth:`check_ib_paper_account` after IBKRClient connects — a live-
-  account connection hard-halts the daemon via SystemExit(1).
-- ``"eod"`` — ``executor/eod_reconcile.py``. S3 + env only; no IB
-  connection (reads trades.db + computes NAV vs SPY from S3 cache).
+  ArcticDB freshness gates as ``main`` plus the IB paper-account guard
+  is invoked separately by the daemon after IBKRClient connects.
+- ``"eod"`` — ``executor/eod_reconcile.py``. macro/SPY only — eod
+  computes alpha vs SPY + reads held-ticker closes; full-universe scan
+  is overkill since only the ~20 held names matter.
 """
 
 from __future__ import annotations
 
 from alpha_engine_lib.preflight import BasePreflight
+
+# ArcticDB freshness thresholds for executor mode runs.
+# 4 days: covers Fri→Tue long weekends (US market holidays) + 1 day
+# buffer. Matches alpha-engine-data DataPreflight daily-mode thresholds.
+_MACRO_MAX_STALE_DAYS = 4
+_UNIVERSE_SYMBOL_MAX_STALE_DAYS = 4
+# 5 days: per-ticker scan threshold. Slightly more permissive than the
+# canonical-symbol check because individual tickers can legitimately
+# trail SPY by 1 day (DST/cross-listing edge cases). Backtester uses
+# the same 5d default for the same reason.
+_UNIVERSE_PER_TICKER_MAX_STALE_DAYS = 5
 
 
 class ExecutorPreflight(BasePreflight):
@@ -36,5 +47,40 @@ class ExecutorPreflight(BasePreflight):
         self.mode = mode
 
     def run(self) -> None:
+        # Cheap-first ordering: env (~ms) → S3 HEAD (~ms) → ArcticDB
+        # canonical liveness (~100ms) → universe-wide scan (~5-10s).
         self.check_env_vars("AWS_REGION")
         self.check_s3_bucket()
+
+        if self.mode in ("main", "daemon"):
+            # Canonical macro liveness (existing-class check) + matching
+            # universe-side liveness probe. The morning planner + daemon
+            # both read per-ticker OHLCV from `universe`; macro/SPY
+            # reports DataPhase1 health, universe/SPY reports daily_append
+            # health on the universe library.
+            self.check_arcticdb_fresh(
+                "macro", "SPY", max_stale_days=_MACRO_MAX_STALE_DAYS,
+            )
+            self.check_arcticdb_fresh(
+                "universe", "SPY",
+                max_stale_days=_UNIVERSE_SYMBOL_MAX_STALE_DAYS,
+            )
+            # Per-ticker freshness scan — catches the partial-write class
+            # (2026-04-21 ASGN/MOH) where macro.SPY + universe.SPY both
+            # stay fresh while individual tickers stop receiving writes.
+            # Without this, executor's load_atr_14_pct guard aborts deep
+            # in the morning run.
+            self.check_arcticdb_universe_fresh(
+                "universe",
+                max_stale_days=_UNIVERSE_PER_TICKER_MAX_STALE_DAYS,
+            )
+
+        if self.mode == "eod":
+            # EOD reconcile reads macro.SPY for alpha-vs-SPY computation
+            # and per-position closes from universe — but only the ~20
+            # held tickers matter, not the full ~900 universe. Single-
+            # symbol macro check is sufficient; per-ticker validation
+            # happens at the held-position read site.
+            self.check_arcticdb_fresh(
+                "macro", "SPY", max_stale_days=_MACRO_MAX_STALE_DAYS,
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ requests~=2.32
 #   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
 #   EC2: ~/.netrc covers github.com with a PAT that has Contents:read
 #        on alpha-engine-lib (confirm via git ls-remote before deploy).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.2

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -24,29 +24,53 @@ class TestExecutorPreflight:
         with pytest.raises(ValueError, match="unknown mode"):
             ExecutorPreflight(bucket="b", mode="bogus")
 
-    def test_main_mode_runs_env_and_s3(self):
+    def test_main_mode_composes_full_check_sequence(self):
+        """main mode: env + S3 + macro/SPY freshness + universe/SPY
+        freshness + per-ticker universe scan."""
         pf = ExecutorPreflight(bucket="b", mode="main")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3:
+             patch.object(pf, "check_s3_bucket") as s3, \
+             patch.object(pf, "check_arcticdb_fresh") as fresh, \
+             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
+        # macro/SPY + universe/SPY
+        assert fresh.call_count == 2
+        macro_call, universe_sym_call = fresh.call_args_list
+        assert macro_call.args[:2] == ("macro", "SPY")
+        assert universe_sym_call.args[:2] == ("universe", "SPY")
+        universe.assert_called_once()
+        assert universe.call_args.args[0] == "universe"
 
-    def test_daemon_mode_runs_env_and_s3(self):
+    def test_daemon_mode_composes_full_check_sequence(self):
+        """daemon mode mirrors main — same ArcticDB liveness gates."""
         pf = ExecutorPreflight(bucket="b", mode="daemon")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3:
+             patch.object(pf, "check_s3_bucket") as s3, \
+             patch.object(pf, "check_arcticdb_fresh") as fresh, \
+             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
+        assert fresh.call_count == 2
+        universe.assert_called_once()
 
-    def test_eod_mode_runs_env_and_s3(self):
+    def test_eod_mode_runs_macro_only(self):
+        """eod reads macro/SPY for alpha + per-position closes; full
+        universe scan is overkill since only the ~20 held names matter."""
         pf = ExecutorPreflight(bucket="b", mode="eod")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3:
+             patch.object(pf, "check_s3_bucket") as s3, \
+             patch.object(pf, "check_arcticdb_fresh") as fresh, \
+             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
+        # Only macro/SPY — no universe-side checks
+        fresh.assert_called_once()
+        assert fresh.call_args.args[:2] == ("macro", "SPY")
+        universe.assert_not_called()
 
     def test_check_ib_paper_account_available_on_instance(self):
         """Daemon reuses the preflight instance to validate the IB


### PR DESCRIPTION
## Summary
Pre-PR ExecutorPreflight only checked AWS_REGION + S3 bucket HEAD across all three modes (40 LOC). For an executor that places trades and reads per-ticker OHLCV from ArcticDB on every morning run, that's thin — the 2026-04-21 ASGN/MOH partial-write incident class would only surface deep in load_atr_14_pct after ~30 min of work.

This PR composes the new check_arcticdb_universe_fresh primitive (alpha-engine-lib v0.2.2) plus per-mode ArcticDB liveness gates.

## Per-mode composition

main + daemon modes:
- env (AWS_REGION) + S3 bucket HEAD
- macro/SPY freshness (≤4 days) — DataPhase1 health
- universe/SPY freshness (≤4 days) — daily_append health on universe
- per-ticker universe scan (≤5 days) — partial-write class catch

eod mode:
- env + S3 + macro/SPY freshness only — alpha-vs-SPY needs SPY; per-position closes are validated at the held-position read site, full-universe scan would be overkill since only ~20 held names matter

## Lib pin bump
alpha-engine-lib v0.2.0 → v0.2.2. v0.2.1 added trading_calendar arithmetic, v0.2.2 adds the new preflight primitive consumed here. Lib v0.2.1 + v0.2.2 git tags pushed earlier today (catch-up tagging — v0.2.1 was version-bumped on merge but never tagged).

## Why
Per-ticker freshness scan catches the partial-write class (2026-04-21 ASGN/MOH) where macro.SPY + universe.SPY both stay fresh while individual tickers stop receiving writes. ~5-10s at preflight saves ~30min of morning planner runtime when the condition fires. Backtester has had this primitive locally since 2026-04-21; this PR brings the executor into parity.

## Context
Third PR of the ROADMAP P1 'Pre-flight health check pattern across all 5 modules' arc:
- PR 1 (alpha-engine-data #115, merged) consolidated dual preflight files
- PR 2 (alpha-engine-lib #11, merged) added the per-symbol scan primitive
- PR 3 (this) tightens executor
- PR 4 (alpha-engine-predictor) adds the same primitive to inference preflight
- PR 5 (alpha-engine-docs) closes the ROADMAP entry

## Test plan
- [x] tests/test_preflight.py 5/5 pass (was 5; same count, expanded assertions)
- [x] Full executor suite 414/414 pass
- [ ] Live verification on next ae-trading boot: morning preflight log shows the new four-line sequence (macro/SPY fresh, universe/SPY fresh, per-ticker scan passes); preflight wall-clock under 15s on cold-cache run
- [ ] Friday 2026-05-01 first weekday SF post-merge: morning planner + daemon preflights both succeed with the bumped lib pin