### PR TITLE
fix(preflight): drop universe/SPY check, SPY isn't in the universe library

### DIFF
--- a/executor/preflight.py
+++ b/executor/preflight.py
@@ -29,7 +29,6 @@ from alpha_engine_lib.preflight import BasePreflight
 # 4 days: covers Fri→Tue long weekends (US market holidays) + 1 day
 # buffer. Matches alpha-engine-data DataPreflight daily-mode thresholds.
 _MACRO_MAX_STALE_DAYS = 4
-_UNIVERSE_SYMBOL_MAX_STALE_DAYS = 4
 # 5 days: per-ticker scan threshold. Slightly more permissive than the
 # canonical-symbol check because individual tickers can legitimately
 # trail SPY by 1 day (DST/cross-listing edge cases). Backtester uses
@@ -53,23 +52,18 @@ class ExecutorPreflight(BasePreflight):
         self.check_s3_bucket()
 
         if self.mode in ("main", "daemon"):
-            # Canonical macro liveness (existing-class check) + matching
-            # universe-side liveness probe. The morning planner + daemon
-            # both read per-ticker OHLCV from `universe`; macro/SPY
-            # reports DataPhase1 health, universe/SPY reports daily_append
-            # health on the universe library.
+            # Canonical macro liveness — DataPhase1 health for SPY, which
+            # lives in the `macro` library only. SPY is the S&P 500 ETF
+            # tracker; the `universe` library holds the index constituents
+            # themselves and does not contain an SPY symbol.
             self.check_arcticdb_fresh(
                 "macro", "SPY", max_stale_days=_MACRO_MAX_STALE_DAYS,
             )
-            self.check_arcticdb_fresh(
-                "universe", "SPY",
-                max_stale_days=_UNIVERSE_SYMBOL_MAX_STALE_DAYS,
-            )
-            # Per-ticker freshness scan — catches the partial-write class
-            # (2026-04-21 ASGN/MOH) where macro.SPY + universe.SPY both
-            # stay fresh while individual tickers stop receiving writes.
-            # Without this, executor's load_atr_14_pct guard aborts deep
-            # in the morning run.
+            # Per-ticker freshness scan over the full universe library —
+            # catches the partial-write class (2026-04-21 ASGN/MOH) where
+            # macro.SPY stays fresh while individual constituents stop
+            # receiving writes. Validates daily_append health on the
+            # universe library by reading every symbol's tail(1).
             self.check_arcticdb_universe_fresh(
                 "universe",
                 max_stale_days=_UNIVERSE_PER_TICKER_MAX_STALE_DAYS,

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -25,8 +25,11 @@ class TestExecutorPreflight:
             ExecutorPreflight(bucket="b", mode="bogus")
 
     def test_main_mode_composes_full_check_sequence(self):
-        """main mode: env + S3 + macro/SPY freshness + universe/SPY
-        freshness + per-ticker universe scan."""
+        """main mode: env + S3 + macro/SPY freshness + per-ticker
+        universe scan. SPY is not in the universe library (it's the
+        S&P 500 ETF, not a constituent), so a single-symbol universe/SPY
+        check is structurally invalid — the full universe scan covers
+        daily_append health on every actual constituent."""
         pf = ExecutorPreflight(bucket="b", mode="main")
         with patch.object(pf, "check_env_vars") as env, \
              patch.object(pf, "check_s3_bucket") as s3, \
@@ -35,11 +38,8 @@ class TestExecutorPreflight:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
-        # macro/SPY + universe/SPY
-        assert fresh.call_count == 2
-        macro_call, universe_sym_call = fresh.call_args_list
-        assert macro_call.args[:2] == ("macro", "SPY")
-        assert universe_sym_call.args[:2] == ("universe", "SPY")
+        fresh.assert_called_once()
+        assert fresh.call_args.args[:2] == ("macro", "SPY")
         universe.assert_called_once()
         assert universe.call_args.args[0] == "universe"
 
@@ -53,7 +53,7 @@ class TestExecutorPreflight:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
-        assert fresh.call_count == 2
+        fresh.assert_called_once()
         universe.assert_called_once()
 
     def test_eod_mode_runs_macro_only(self):


### PR DESCRIPTION
## Summary
- PR #123's `universe/SPY` freshness check is structurally invalid — SPY is the S&P 500 ETF, not a constituent, and the data pipeline writes SPY only to the `macro` library (confirmed by `list_symbols()` on prod ArcticDB: 904 symbols, no SPY).
- This morning's (2026-05-01) systemd morning planner exited 1 with \`NoSuchVersionException\` for \`universe/SPY\`. Same fault has been intermittently breaking the morning service since #123 merged 2026-04-30 evening.

## Why this drop is safe
The original concern (\`daily_append\` health on the universe library) is already covered by \`check_arcticdb_universe_fresh(\"universe\", ...)\` on the next line — that scans every actual constituent's \`tail(1)\` and raises if any single symbol stalls. That's strictly stronger than a single-symbol probe on a missing symbol.

\`macro/SPY\` check stays (DataPhase1 health). \`_UNIVERSE_SYMBOL_MAX_STALE_DAYS\` constant becomes unused, removed.

## Test plan
- [x] Tests updated and green: \`pytest tests/test_preflight.py -x -q\` → 5 passed.
- [ ] After merge + EC2 deploy, restart \`alpha-engine-morning.service\` and confirm clean exit.

## Follow-up
Broader preflight consolidation work (move universe-freshness scan to its DataPhase1 producer, have consumers read a cheap \`health/universe_freshness.json\` receipt) is scoped as a separate PR arc — see alpha-engine-data PR #118 description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)