### PR TITLE
fix(docs): correct predictor meta-ensemble framing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Orchestrated by three AWS Step Functions (Saturday, weekday, EOD). S3 as the com
 | # | Module | Repo | Role |
 |---|--------|------|------|
 | 1 | **Research** | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) | 6 LLM sector teams + CIO scan ~900 stocks weekly, produce composite scores (0-100) as `signals.json` |
-| 2 | **Predictor** | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) | Meta-model (4 GBMs + ridge) predicts 5-day sector-relative alpha; veto gate blocks high-confidence DOWN |
+| 2 | **Predictor** | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) | Stacked meta-ensemble (Layer-1 LightGBM momentum + LightGBM volatility + research-score calibrator → Layer-2 Ridge) predicts 5-day sector-relative alpha; veto gate blocks high-confidence DOWN |
 | 3 | **Executor** | [`alpha-engine`](https://github.com/cipher813/alpha-engine) *(this repo)* | Morning planner + intraday daemon: risk rules, position sizing, technical entry triggers, trailing stops |
 | 4 | **Backtester** | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) | Weekly evaluation (component grades, P/R/F1) + 6 autonomous optimizers → S3 config feedback loop |
 | 5 | **Dashboard** | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) | Streamlit monitoring: portfolio performance, signal quality, system report card, execution evaluation |
@@ -118,7 +118,7 @@ s3://alpha-engine-research/
 | Component | Technology |
 |-----------|------------|
 | LLM provider | Anthropic Claude (Haiku-4.5 per-ticker, Sonnet-4.6 synthesis) |
-| ML framework | LightGBM (meta-model: 4 specialized GBMs + ridge) |
+| ML framework | LightGBM (Layer-1 momentum + volatility components) + scikit-learn Ridge (Layer-2 meta-learner) |
 | Agent orchestration | LangGraph |
 | Price data | ArcticDB (S3-backed) + Polygon.io + yfinance fallback |
 | Broker | Interactive Brokers (paper account via IB Gateway) |


### PR DESCRIPTION
## Summary

Corrects two stale predictor architecture references in this repo's README:

1. **Modules table** (line 67) — predictor row "Meta-model (4 GBMs + ridge)" → accurate L1+L2 description
2. **Tech stack** (line 121) — "LightGBM (meta-model: 4 specialized GBMs + ridge)" → "LightGBM (Layer-1 momentum + volatility components) + scikit-learn Ridge (Layer-2 meta-learner)"

## Why

Verified against actual code in `alpha-engine-predictor/model/meta_model.py` + `training/meta_trainer.py`:

- Currently 3 Layer-1 models, not 4 (RegimePredictor pruned 2026-04-16 after walk-forward validation showed 39.5% OOS accuracy below majority class)
- Only 2 of the 3 are LightGBM (momentum + volatility); the research-score calibrator is currently a bucket lookup table (GBM v1 on roadmap per `model/research_calibrator.py:5`)
- Layer-2 is a scikit-learn Ridge meta-learner, not "ridge" generically

## Companion PRs

Same correction landed across the four documentation surfaces:

- `alpha-engine-docs` PR #17 (system-overview README rewrite — broader presentation revamp arc)
- `alpha-engine-dashboard` PR #27 (public site /Docs page — recruiter-visible)
- `alpha-engine-predictor` PR #74 (predictor's own README + architecture diagram)
- `alpha-engine` (this PR) — executor repo's modules table + tech stack

Single source of truth across all four surfaces is `model/meta_model.py` + `training/meta_trainer.py`.

Note: CLAUDE.md in this repo is gitignored — equivalent correction made locally for future Claude Code sessions but not committed.

## Test plan

- [ ] Verify README modules table renders correctly
- [ ] No remaining "4 GBMs" / "4 specialized" references in docs
- [ ] Tech stack row still parses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)