### PR TITLE
docs(presentation): lean README + OVERVIEW.md code index

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,0 +1,80 @@
+# alpha-engine (executor) — Code Index
+
+> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
+
+## Module purpose
+
+Risk-gated trade executor — reads signals + predictions, sizes positions, routes orders through IB Gateway via a morning planner + intraday daemon split.
+
+## Entry points
+
+| File | What it does |
+|---|---|
+| [`executor/main.py`](executor/main.py) | Morning order-book planner — never places orders |
+| [`executor/daemon.py`](executor/daemon.py) | Sole order executor — urgent exits + intraday entry triggers |
+| [`executor/eod_reconcile.py`](executor/eod_reconcile.py) | 1:20 PM PT — NAV, alpha, positions, EOD email |
+| [`executor/connection_test.py`](executor/connection_test.py) | IB Gateway connection check |
+| [`executor/liquidate_all.py`](executor/liquidate_all.py) | Emergency manual liquidation |
+
+## Where things live
+
+| Concept | File |
+|---|---|
+| Signal reader (signals.json + predictions.json from S3) | [`executor/signal_reader.py`](executor/signal_reader.py) |
+| Hard risk-rule enforcement + graduated drawdown | [`executor/risk_guard.py`](executor/risk_guard.py) |
+| Position sizer (equal-weight + adjustments) | [`executor/position_sizer.py`](executor/position_sizer.py) |
+| IB Gateway wrapper (NAV, positions, prices, orders) | [`executor/ibkr.py`](executor/ibkr.py) |
+| Trade logger (SQLite + S3 backup) | [`executor/trade_logger.py`](executor/trade_logger.py) |
+| Order book (intraday JSON state) | [`executor/order_book.py`](executor/order_book.py) |
+| Bracket orders (BUY + trailing stop as parent/child) | [`executor/bracket_orders.py`](executor/bracket_orders.py) |
+| Intraday entry triggers (pullback / VWAP / support / expiry) | [`executor/entry_triggers.py`](executor/entry_triggers.py) |
+| Intraday exit manager (trail / profit-take / collapse) | [`executor/intraday_exit_manager.py`](executor/intraday_exit_manager.py) |
+| Strategy layer — ATR stops + time decay | [`executor/strategies/exit_manager.py`](executor/strategies/exit_manager.py) |
+| Strategy config (YAML override) | [`executor/strategies/config.py`](executor/strategies/config.py) |
+| 15-min delayed price subscriptions | [`executor/price_monitor.py`](executor/price_monitor.py) |
+| Price cache loader (ArcticDB slim → ATR) | [`executor/price_cache.py`](executor/price_cache.py) |
+| Feature lookup (ArcticDB) | [`executor/feature_lookup.py`](executor/feature_lookup.py) |
+| Decision deciders (entry / hold / reduce / exit logic) | [`executor/deciders.py`](executor/deciders.py) |
+| EOD email builder (HTML + plain) | [`executor/eod_emailer.py`](executor/eod_emailer.py) |
+| Telegram push notifications for trades | [`executor/notifier.py`](executor/notifier.py) |
+| Snapshot capturer (intraday state) | [`executor/snapshot_capturer.py`](executor/snapshot_capturer.py) |
+| Market hours helpers | [`executor/market_hours.py`](executor/market_hours.py) |
+| Uptime tracker | [`executor/uptime_tracker.py`](executor/uptime_tracker.py) |
+| Emergency shutdown handler | [`executor/emergency_shutdown.py`](executor/emergency_shutdown.py) |
+| Config loader | [`executor/config_loader.py`](executor/config_loader.py) |
+
+## Inputs / outputs
+
+### Reads
+| Source | Path |
+|---|---|
+| Research signals | `s3://alpha-engine-research/signals/{date}/signals.json` |
+| Predictor predictions | `s3://alpha-engine-research/predictor/predictions/{date}.json` |
+| Predictor veto threshold + auto-tuned params | `s3://alpha-engine-research/config/predictor_params.json` |
+| Executor risk + sizing params | `s3://alpha-engine-research/config/executor_params.json` |
+| Price slim cache (ATR + intraday lookups) | `s3://alpha-engine-research/arcticdb/universe_slim/` |
+
+### Writes
+| Destination | Path |
+|---|---|
+| Trade audit log | `s3://alpha-engine-research/trades/trades_full.csv` + SQLite `trades.db` |
+| Daily NAV / alpha / positions | `s3://alpha-engine-research/trades/eod_pnl.csv` + SQLite `eod_pnl` table |
+| Per-day intraday snapshots | `s3://alpha-engine-research/trades/snapshots/{date}/` |
+| Health status (planner + daemon completion) | `s3://alpha-engine-research/health/executor_*.json` |
+
+## Run modes
+
+| Mode | Where | Command |
+|---|---|---|
+| Production planner | `ae-trading` EC2 (boot via systemd, ~6:15 AM PT) | Weekday SF starts the EC2 instance |
+| Production daemon | `ae-trading` EC2 (boot via systemd, ~6:20 AM PT) | Boot-triggered; safety-net systemd timer at 9:29 AM ET |
+| Production EOD | `ae-trading` EC2 (SSM, 1:20 PM PT) | EOD Step Function |
+| Local dry run | venv | `python executor/main.py --dry-run` |
+| Connection test | venv or EC2 | `python executor/connection_test.py` |
+| Manual liquidation | venv or EC2 | `python executor/liquidate_all.py` |
+
+Deploy: `git push origin main && ae-trading "cd ~/alpha-engine && git pull"`. IB Gateway runs in Docker (gnzsnz/ib-gateway-docker) with TOTP-based 2FA on paper account port 4002.
+
+## Tests
+
+`pytest tests/` covers risk-guard rules, position sizing math, signal-reader fallbacks, trade-logger SQLite roundtrips, intraday exit manager state machines, entry-trigger evaluation, EOD reconciliation, and bracket-order construction.

--- a/README.md
+++ b/README.md
@@ -1,279 +1,59 @@
-# Nous Ergon: Alpha Engine
+# alpha-engine (executor)
 
-[![Python](https://img.shields.io/badge/python-3.11+-blue.svg)]()
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-152_passing-brightgreen.svg)]()
+> Part of [**Nous Ergon**](https://nousergon.ai) — Autonomous Multi-Agent Trading System. Repo and S3 names use the underlying project name `alpha-engine`.
 
-**[Nous Ergon](https://nousergon.ai)** (νοῦς ἔργον — "intelligence at work") is a fully autonomous trading system that combines AI-driven research, quantitative prediction, and rule-based execution to generate market alpha.
+[![Part of Nous Ergon](https://img.shields.io/badge/Part_of-Nous_Ergon-1a73e8?style=flat-square)](https://nousergon.ai)
+[![Python](https://img.shields.io/badge/python-3.11+-blue?style=flat-square)](https://www.python.org/)
+[![Interactive Brokers](https://img.shields.io/badge/IBKR-1a73e8?style=flat-square)](https://www.interactivebrokers.com/)
+[![ArcticDB](https://img.shields.io/badge/ArcticDB-0e1117?style=flat-square)](https://docs.arcticdb.io/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
+[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/cipher813/alpha-engine-docs#phase-trajectory)
 
-```
-Alpha = Portfolio Return − SPY Return
-```
+Risk-gated trade executor. Reads research signals + predictor verdicts from S3, applies hard risk rules, sizes positions, and routes orders through IB Gateway. The morning planner writes the order book; an intraday daemon is the sole order executor.
 
-**[Website](https://nousergon.ai)** | **[Blog](https://nousergon.ai/blog)** | **[Full Documentation Index](https://github.com/cipher813/alpha-engine-docs#readme)**
+> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
 
-## Table of Contents
+## What this does
 
-- [System Architecture](#system-architecture)
-- [Modules](#modules)
-- [S3 Layout](#s3-layout)
-- [Key Metrics](#key-metrics)
-- [Stack](#stack)
-- [Executor Module](#executor)
+- **Risk-gated position sizing** — equal-weight base × sector rating × conviction × price-target upside × graduated drawdown tier; hard caps on max position, max sector exposure, max total equity. EXIT and REDUCE bypass all gates.
+- **Predictor veto integration** — high-confidence DOWN predictions override BUY signals before they reach the order book.
+- **Intraday entry triggers** — pullback / VWAP discount / support bounce / 3:30 PM ET time-expiry. Daemon waits for a trigger to fire rather than crossing the spread at market open.
+- **Strategy layer** (backtestable) — ATR trailing stops + time-based exit decay + graduated drawdown response (tiered sizing reduction → circuit-breaker halt).
+- **EOD reconciliation** — captures NAV, computes daily return vs SPY, persists to SQLite, sends EOD email.
 
-## System Architecture
+## Phase 2 measurement contribution
 
-Six modules run on AWS, connected through a shared S3 bucket. Each module reads its inputs from S3 and writes its outputs back — no shared state beyond the bucket.
-
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    WEEKLY CADENCE (Saturday)                         │
-│                                                                     │
-│  Data Phase 1 ──── prices (ArcticDB), macro, constituents          │
-│  RAG Ingestion ──── SEC filings, 8-Ks, earnings → research KB     │
-│  Research ──── scan 900 tickers, rotate population, write signals  │
-│  Data Phase 2 ──── alternative data for promoted tickers           │
-│  Predictor Training ──── meta-model retrain, walk-forward validate │
-│  Backtester ──── signal quality + evaluation + param optimization  │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                    DAILY CADENCE (Mon–Fri)                           │
-│                                                                     │
-│  Daily Data (6:05 AM PT) ──── daily closes + macro refresh         │
-│  Predictor (6:07 AM PT) ──── reads signals, predicts 5d alpha     │
-│       │  predictions.json                                           │
-│  Executor (6:15 AM PT) ──── order book ───► entries + exits        │
-│       │  order book (approved entries + urgent exits + stops)       │
-│  Intraday Daemon (6:20 AM – 1:15 PM PT) ──── sole order executor  │
-│       │  (market close)                                             │
-│  EOD Reconcile (1:20 PM PT) ──── NAV, alpha ───► email + EC2 stop │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                    ALWAYS-ON                                        │
-│                                                                     │
-│  Dashboard (Streamlit) ──── read-only monitoring via S3             │
-└─────────────────────────────────────────────────────────────────────┘
-```
-
-Orchestrated by three AWS Step Functions (Saturday, weekday, EOD). S3 as the communication bus means any module can be replaced, rewritten, or tested independently.
-
-## Modules
-
-| # | Module | Repo | Role |
-|---|--------|------|------|
-| 1 | **Research** | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) | 6 LLM sector teams + CIO scan ~900 stocks weekly, produce composite scores (0-100) as `signals.json` |
-| 2 | **Predictor** | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) | Meta-model (4 GBMs + ridge) predicts 5-day sector-relative alpha; veto gate blocks high-confidence DOWN |
-| 3 | **Executor** | [`alpha-engine`](https://github.com/cipher813/alpha-engine) *(this repo)* | Morning planner + intraday daemon: risk rules, position sizing, technical entry triggers, trailing stops |
-| 4 | **Backtester** | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) | Weekly evaluation (component grades, P/R/F1) + 6 autonomous optimizers → S3 config feedback loop |
-| 5 | **Dashboard** | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) | Streamlit monitoring: portfolio performance, signal quality, system report card, execution evaluation |
-| 6 | **Data** | [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) | Centralized data collection: ArcticDB price store (909 tickers), macro, alternative data |
-
-Each module has its own README with Quick Start, Architecture, and S3 Contract sections.
-
-## S3 Layout
-
-All inter-module communication flows through a single S3 bucket:
-
-```
-s3://alpha-engine-research/
-├── signals/{date}/signals.json          ← Research → Predictor + Executor
-├── arcticdb/
-│   ├── universe/                        ← 10y OHLCV, 909 tickers (ArcticDB)
-│   └── universe_slim/                   ← 2y slices for inference (ArcticDB)
-├── predictor/
-│   ├── daily_closes/{date}.parquet      ← Daily OHLCV archive
-│   ├── feature_store/{date}/            ← Pre-computed features (54 x 903 tickers)
-│   ├── weights/                         ← GBM + meta-model weights
-│   ├── predictions/{date}.json          ← Daily predictions
-│   └── metrics/latest.json              ← Model performance
-├── trades/
-│   ├── trades_full.csv                  ← Complete trade audit log
-│   └── eod_pnl.csv                      ← Daily NAV, return, alpha
-├── backtest/{date}/                     ← Weekly: report, grades, trigger/shadow/exit/veto analysis
-├── backtest/grade_history.json          ← 52-week rolling component grades
-├── config/                              ← Auto-optimized by backtester
-│   ├── scoring_weights.json             ← → Research
-│   ├── executor_params.json             ← → Executor
-│   ├── predictor_params.json            ← → Predictor
-│   └── research_params.json             ← → Research (deferred)
-├── health/{module}.json                 ← Module completion markers
-└── research.db                          ← SQLite (signal history, theses, macro)
-```
-
-## Key Metrics
-
-| Metric | What It Measures |
-|--------|-----------------|
-| Total alpha | Portfolio cumulative return − SPY cumulative return |
-| Sharpe ratio | Risk-adjusted return (annualized) |
-| Signal accuracy | % of BUY signals beating SPY over configurable windows |
-| GBM IC | Rank correlation of predicted vs actual forward returns |
-| Max drawdown | Peak-to-trough portfolio decline |
-| System grade | Weekly A-F scorecard across all components (backtester) |
-
-## Stack
-
-| Component | Technology |
-|-----------|------------|
-| LLM provider | Anthropic Claude (Haiku-4.5 per-ticker, Sonnet-4.6 synthesis) |
-| ML framework | LightGBM (meta-model: 4 specialized GBMs + ridge) |
-| Agent orchestration | LangGraph |
-| Price data | ArcticDB (S3-backed) + Polygon.io + yfinance fallback |
-| Broker | Interactive Brokers (paper account via IB Gateway) |
-| Cloud | AWS (Lambda, S3, SES, EC2, Step Functions, SSM, EventBridge) |
-| Dashboard | Streamlit + Plotly |
-| Secrets | AWS SSM Parameter Store (24 params under /alpha-engine/*) |
-| Config | Private config repo (alpha-engine-config) with per-module search |
-
----
-
-# Executor
-
-> Reads signals and predictions from S3, applies hard risk rules, sizes positions, and executes orders via IB Gateway. The morning planner writes the order book; the daemon is the sole order executor.
-
-**Part of the [Nous Ergon](https://nousergon.ai) autonomous trading system.**
-
-## Quick Start
-
-### Prerequisites
-
-- Python 3.11+
-- IB Gateway running in paper mode on port 4002
-- AWS credentials with S3 read/write and SES send permission
-
-### Setup
-
-```bash
-git clone https://github.com/cipher813/alpha-engine.git
-cd alpha-engine
-python -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-
-cp config/risk.yaml.example config/risk.yaml
-# Edit config/risk.yaml — set S3 bucket names, email addresses, risk parameters
-
-python executor/connection_test.py   # verify IB Gateway
-python executor/main.py --dry-run    # full loop, no orders placed
-```
-
-### Key Files
-
-```
-executor/main.py              # Morning order-book planner (no orders placed)
-executor/daemon.py            # Sole order executor — urgent exits + technical entry triggers
-executor/order_book.py        # JSON-based intraday order book
-executor/signal_reader.py     # Reads signals.json from S3
-executor/risk_guard.py        # 9-rule enforcement + graduated drawdown
-executor/position_sizer.py    # Equal-weight base with 9 sizing adjustments
-executor/ibkr.py              # IB Gateway wrapper (ib_insync)
-executor/entry_triggers.py    # Pullback, VWAP, support, graduated expiry
-executor/intraday_exit_manager.py  # Trail, profit-take, collapse exits
-executor/eod_reconcile.py     # EOD P&L vs SPY + email (Step Function orchestrated)
-executor/strategies/          # ATR stops, time-decay, profit-take, momentum
-config/risk.yaml.example      # Safe template — copy to config/risk.yaml
-```
+Every fill, sizing decision, and risk-guard override is logged to SQLite + backed up to S3. Daily P&L is attributed in `eod_pnl.csv` with breakdowns for portfolio return, SPY benchmark, alpha, total cash, accrued interest, and unrealized vs realized P&L. The sizing path captures the input ladder (sector rating × conviction × upside × drawdown tier) at decision time so any position can be replayed against a different parameter set.
 
 ## Architecture
 
-### Daily Execution Flow
-
-| Step | Time (PT) | What happens |
-|------|-----------|--------------|
-| **Morning Planner** | ~6:15 AM | Read signals, evaluate exits, apply risk rules, size positions → write order book (no orders) |
-| **Intraday Daemon** | ~6:20 AM – 1:15 PM | Execute urgent exits at open. Monitor entries for technical triggers. Monitor stops for exit rules. |
-| **EOD Reconcile** | 1:20 PM | Capture NAV, compute daily return vs SPY, log alpha, send email. Step Function stops EC2 after. |
-
-### Decision Pipeline
-
-Every ENTER signal flows through this pipeline:
-
-```
-signals.json (S3)
-       │
-Signal Reader ──── read today's signals; fall back up to 5 prior trading days
-       │
-Exit Manager ──── evaluate held positions against 5 exit strategies
-       │
-Risk Guard ──── 9 rule layers (all must pass for entry)
-       │
-Position Sizer ──── compute shares (base × 9 adjustments, capped)
-       │
-Order Book ──── write approved entry with trigger levels + metadata
-       │
-Daemon ──── waits for technical trigger, places bracket order, logs trade
+```mermaid
+flowchart LR
+    Signals[signals.json + predictions.json<br/>S3] --> Plan
+    Plan[Morning Planner<br/>~6:15 AM PT<br/>risk gates · sizing · veto] --> Book[(Order Book<br/>entries · urgent exits · stops)]
+    Book --> Daemon[Intraday Daemon<br/>~6:20 AM – 1:15 PM PT<br/>entry triggers + exit manager]
+    Daemon --> IB[IB Gateway<br/>paper · port 4002]
+    Daemon --> Reconcile[EOD Reconcile<br/>1:20 PM PT<br/>NAV · α · positions]
+    Reconcile --> Email((EOD email))
 ```
 
-### Entry Triggers (Intraday, OR Logic)
+The daemon is the sole order executor — main.py never places orders, only writes the book. Urgent exits run immediately at market open; entries wait for technical triggers or the 3:30 PM ET time expiry.
 
-| Trigger | Default | Fires When |
-|---------|---------|------------|
-| Pullback | 2% | (day_high - current) / day_high >= 2% |
-| VWAP Discount | 0.5% | (vwap - current) / vwap >= 0.5% (previous day's VWAP from daily_closes) |
-| Support Bounce | 1% | 0 <= (current - support) / support <= 1% |
-| Graduated Expiry | 3-tier | Technical-only before 2 PM → graduated (price <= open+1%) 2-3:30 PM → unconditional 3:55 PM |
+## Configuration
 
-### Risk Guard Rules
+This repo is **public**. `config/risk.yaml` is gitignored locally; real risk thresholds, sizing parameters, and IB credentials live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo. Tunable safe-to-tune params auto-applied weekly by the Backtester via `s3://alpha-engine-research/config/executor_params.json`. Architecture and approach are public; specific values are private.
 
-1. Score minimum (score >= min_score_to_enter)
-2. Conviction gate (blocks "declining" conviction)
-3. Momentum gate (20d return must exceed threshold)
-4. Graduated drawdown (tiered sizing reduction → halt at circuit breaker)
-5. Max single position (% of NAV, adjustable by regime)
-6. Bear regime block (blocks entries in underweight sectors)
-7. Sector exposure limit (default 25% NAV)
-8. Cross-ticker correlation (alerts on concentrated correlated holdings)
-9. Predictor veto (high-confidence DOWN prediction overrides BUY)
+## Sister repos
 
-### S3 Contract
-
-**Reads:**
-| Path | Source | Content |
-|------|--------|---------|
-| `signals/{date}/signals.json` | Research | Per-ticker signal, score, conviction, sector |
-| `predictor/predictions/{date}.json` | Predictor | Direction, confidence, predicted alpha |
-| `config/executor_params.json` | Backtester | Auto-tuned risk parameters |
-| ArcticDB `universe_slim` | Data | 2y OHLCV for ATR computation |
-
-**Writes:**
-| Path | Content |
-|------|---------|
-| `trades/trades_full.csv` | Complete trade audit log |
-| `trades/eod_pnl.csv` | Daily NAV, return, alpha |
-| `trades/shadow_book.csv` | Risk guard blocked entries |
-| `health/executor.json` | Module health marker |
-
-## Testing
-
-```bash
-# Simulate mode: real signals from S3, synthetic IB positions, no orders placed
-python executor/main.py --simulate
-
-# Dry run on EC2: real IB prices + positions, no order book written
-python executor/main.py --dry-run
-
-# Full test suite (152 tests)
-pytest tests/ -v
-```
-
-## Deployment
-
-- **EC2 trading instance** (t3.small, market hours only): Started by weekday Step Function, stopped by EOD Step Function
-- **Boot sequence** (systemd): boot-pull → IB Gateway → morning planner → daemon
-- **Deploy gate**: boot-pull runs `--dry-run` after code update, auto-rollback on failure
-- **Config**: Reads from alpha-engine-config (private repo) first, falls back to local risk.yaml
-- **Secrets**: SSM Parameter Store (`/alpha-engine/*`), loaded at runtime
-
-## Related Modules
-
-- [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) — Autonomous LLM research pipeline
-- [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) — Meta-model predictor (5-day alpha predictions)
-- [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) — Signal quality analysis, evaluation framework, and parameter optimization
-- [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) — Streamlit monitoring dashboard
-- [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) — Centralized data collection and ArcticDB price store
-- [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) — Documentation index and system audits
+| Module | Repo |
+|---|---|
+| Data | [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) |
+| Research | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) |
+| Predictor | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) |
+| Backtester | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) |
+| Dashboard | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) |
+| Library | [`alpha-engine-lib`](https://github.com/cipher813/alpha-engine-lib) |
+| Docs | [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) |
 
 ## License
 


### PR DESCRIPTION
## Summary

Phase 1 Day 6 of the presentation revamp arc. Applies the locked lean template (alpha-engine-docs PR #20) and **drops the duplicate system-overview content** that this README had been carrying.

## Changes

**README** (was 277 lines, now 60 lines):
- Drops the entire system-overview block: "Nous Ergon: Alpha Engine" H1, System Architecture box diagram, cross-module Modules table, S3 Layout enumeration, Key Metrics, Stack table → all live canonically in `alpha-engine-docs` (per Decision 7: alpha-engine-docs is the system home; this repo is the executor module only)
- Drops Quick Start, env-var listing, Risk Rules detail, EC2 architecture, Deployment commands, IB Gateway setup → push to OVERVIEW.md or stay in CLAUDE.md (gitignored)
- Mermaid architecture (~6 boxes): signals → planner → order book → daemon → IB Gateway + EOD reconcile
- "Predictor veto integration" replaces the "4 GBMs" reference — **supersedes PR #126** (framing-only fix), which can be closed

**OVERVIEW.md** (new, 80 lines): 7 sections, ~22 concept→file mappings, full S3 contract, all file paths verified.

## Working references

- alpha-engine-docs PR #20 (templates locked)
- alpha-engine-data PR #144 (approved prototype)
- alpha-engine-research PR #98, alpha-engine-predictor PR #75 (same shape)

## Test plan

- [ ] All 6 badges render
- [ ] Mermaid diagram renders cleanly
- [ ] All file links in OVERVIEW.md resolve
- [ ] No "4 GBMs" / fabricated paths
- [ ] No remaining system-overview content

🤖 Generated with [Claude Code](https://claude.com/claude-code)