### PR TITLE
chore: drop dead ALPHA_ENGINE_LIB_TOKEN PAT plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Configure git auth for private alpha-engine-lib
-        env:
-          ALPHA_ENGINE_LIB_TOKEN: ${{ secrets.ALPHA_ENGINE_LIB_TOKEN }}
-        run: |
-          if [ -z "$ALPHA_ENGINE_LIB_TOKEN" ]; then
-            echo "::error::ALPHA_ENGINE_LIB_TOKEN secret not set — required to install private alpha-engine-lib"
-            exit 1
-          fi
-          git config --global url."https://x-access-token:${ALPHA_ENGINE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
-
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -15,25 +15,6 @@ log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$LOG"; }
 
 log "=== boot-pull started ==="
 
-# ── Configure git auth for private alpha-engine-lib ──────────────────────────
-# requirements.txt in alpha-engine / alpha-engine-backtester pins
-# alpha-engine-lib from a private GitHub repo. pip install needs an HTTPS
-# auth path to clone it.
-#
-# The PAT lives in SSM as /alpha-engine/lib-token (SecureString). The EC2
-# instance role alpha-engine-executor-role grants ssm:GetParameter on
-# /alpha-engine/*. Fetching on every boot is idempotent and survives a
-# fresh EBS or ~/.gitconfig reset. Local shell var scope only; never
-# exported, never logged.
-AE_LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
-if [ -n "$AE_LIB_TOKEN" ]; then
-    git config --global url."https://x-access-token:${AE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
-    log "OK   git insteadOf rewrite configured for alpha-engine-lib (ssm:/alpha-engine/lib-token)"
-else
-    log "FAIL ssm:/alpha-engine/lib-token unreadable — pip install of alpha-engine-lib will fail"
-fi
-unset AE_LIB_TOKEN
-
 REPOS=(
     /home/ec2-user/alpha-engine-config
     /home/ec2-user/alpha-engine

--- a/infrastructure/setup-trading-ec2.sh
+++ b/infrastructure/setup-trading-ec2.sh
@@ -7,7 +7,6 @@
 #
 # Prerequisites:
 #   - Amazon Linux 2023 AMI
-#   - ~/.netrc with GitHub PAT (for git pull)
 #   - ~/.alpha-engine.env with secrets (GMAIL_APP_PASSWORD, ANTHROPIC_API_KEY,
 #     TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID)
 #   - IB Gateway + IBC installed at ~/ibgateway and ~/ibc
@@ -33,25 +32,6 @@ if [ ! -d ".venv" ]; then
     echo "Creating virtualenv..."
     python3.11 -m venv .venv
 fi
-
-# ── 2a. Configure git URL rewrite for private alpha-engine-lib ──────────────
-# requirements.txt pins alpha-engine-lib from a private GitHub repo. pip
-# needs an HTTPS auth path to clone it. The PAT lives in SSM at
-# /alpha-engine/lib-token (SecureString); the EC2 instance role
-# alpha-engine-executor-role grants ssm:GetParameter on /alpha-engine/*.
-# Local shell var scope only; never exported, never logged. boot-pull.sh
-# refreshes the same insteadOf rewrite on every boot so a ~/.gitconfig
-# reset or fresh EBS recovers automatically.
-echo "Fetching alpha-engine-lib PAT from SSM..."
-AE_LIB_TOKEN=$(aws ssm get-parameter --name /alpha-engine/lib-token --with-decryption --query 'Parameter.Value' --output text --region us-east-1 2>/dev/null || echo "")
-if [ -z "$AE_LIB_TOKEN" ]; then
-    echo "ERROR: ssm:/alpha-engine/lib-token unreadable — required to pip install private alpha-engine-lib" >&2
-    echo "       Create with: aws ssm put-parameter --name /alpha-engine/lib-token --type SecureString --value <PAT> --region us-east-1" >&2
-    echo "       PAT must have Contents:read on cipher813/alpha-engine-lib." >&2
-    exit 1
-fi
-git config --global url."https://x-access-token:${AE_LIB_TOKEN}@github.com/cipher813/alpha-engine-lib".insteadOf "https://github.com/cipher813/alpha-engine-lib"
-unset AE_LIB_TOKEN
 
 echo "Installing dependencies..."
 .venv/bin/pip install --quiet --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,13 +15,9 @@ arcticdb~=6.12
 anthropic~=0.40
 exchange-calendars~=4.5
 requests~=2.32
-# alpha-engine-lib provides setup_logging + BasePreflight. Executor
-# passes exclude_patterns=[r"Error 10197", r"Error 10349"] to suppress
-# benign IB Gateway noise (10197 = iOS app steals live-data session,
-# 10349 = TIF coerced to DAY per order preset — order still placed).
-# See daemon.py / main.py / eod_reconcile.py.
-# Private repo — pip install needs ALPHA_ENGINE_LIB_TOKEN:
-#   CI: .github/workflows/ci.yml wires a git URL insteadOf rewrite.
-#   EC2: ~/.netrc covers github.com with a PAT that has Contents:read
-#        on alpha-engine-lib (confirm via git ls-remote before deploy).
+# alpha-engine-lib provides setup_logging + BasePreflight. Executor passes
+# exclude_patterns=[r"Error 10197", r"Error 10349"] to suppress benign IB
+# Gateway noise (10197 = iOS app steals live-data session, 10349 = TIF
+# coerced to DAY per order preset — order still placed). See daemon.py /
+# main.py / eod_reconcile.py.
 alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.2


### PR DESCRIPTION
## Summary

`alpha-engine-lib` was flipped public 2026-05-03; the PAT auth machinery that existed to pip-install from a private repo is now dead weight. This PR removes it across all four touch points in this repo.

## Changes (4 files, +5 / −58)

| File | Removed |
|---|---|
| `requirements.txt` | Comment block about `ALPHA_ENGINE_LIB_TOKEN` / `~/.netrc` / `insteadOf` rewrite |
| `.github/workflows/ci.yml` | "Configure git auth for private alpha-engine-lib" step (env + insteadOf rewrite) |
| `infrastructure/setup-trading-ec2.sh` | `~/.netrc` prerequisite + section 2a (SSM PAT fetch + insteadOf rewrite) |
| `infrastructure/boot-pull.sh` | Per-boot SSM PAT fetch + insteadOf rewrite |

## Why this is presentation work

The PAT plumbing was visible to anyone reading the CI workflow + deploy scripts. With the lib public, the *absence* of auth machinery is the more honest read. Closes presentation-relevant ROADMAP follow-up "P3 Drop ALPHA_ENGINE_LIB_TOKEN PAT plumbing" (added 2026-05-03).

## Follow-ups outside this PR (can land anytime)

- Delete the `ALPHA_ENGINE_LIB_TOKEN` GitHub Actions secret on this repo
- Delete the `/alpha-engine/lib-token` SSM SecureString param (us-east-1)
- Clean `~/.netrc` on `ae-trading` + `ae-dashboard` EC2 instances

## Working as prototype

This is the first of 6 consumer-repo PRs in this cleanup arc. Same pattern (CI workflow + Dockerfile + deploy.sh + requirements.txt) lives in:
- `alpha-engine-data` (incl. Dockerfile + spot_data_weekly.sh + spot_drift_detection.sh + deploy.sh)
- `alpha-engine-research` (incl. Dockerfile + deploy.sh)
- `alpha-engine-predictor` (incl. Dockerfile + spot_train.sh + deploy.sh)
- `alpha-engine-backtester` (incl. lambda_health/Dockerfile + deploy_health.sh + setup-ec2.sh + spot_backtest.sh)
- `alpha-engine-dashboard` (CI only)

Once you approve this pattern, I'll batch the remaining 5 repos.

## Test plan

- [ ] CI passes on this PR (validates the install works without the PAT)
- [ ] Trading EC2 boots cleanly via boot-pull.sh on next reboot (no PAT lookup error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)