### PR TITLE
iam: codify alpha-engine-step-functions-role + widen drift-check scope

### DIFF
--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -28,6 +28,13 @@ is the inline policy name on that role.
   `alpha-engine-ssm-read`, which already had the superset of actions).
   Trust policy + role creation are NOT managed here (out of scope for the
   flat-file approach).
+- **`alpha-engine-step-functions-role`** — assumed by all three Step
+  Functions (`alpha-engine-saturday-pipeline`, `alpha-engine-weekday-pipeline`,
+  `alpha-engine-eod-pipeline`). One consolidated inline policy granting
+  Lambda invoke, SSM run, EC2 start/stop on the trading instance, SNS
+  publish, and CloudWatch Logs delivery. Codified 2026-05-04 after an
+  asymmetric `ec2:StartInstances` / `ec2:StopInstances` grant let the EOD
+  SF stall on `StopTradingInstance` for an entire afternoon.
 - **`github-actions-iam-drift-check`** — assumed by GitHub Actions via
   OIDC for the daily IAM-drift-check workflow. Single inline policy
   granting `iam:ListRolePolicies` + `iam:GetRolePolicy` scoped to the

--- a/infrastructure/iam/alpha-engine-step-functions-role/alpha-engine-step-functions-role-policy.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role/alpha-engine-step-functions-role-policy.json
@@ -1,0 +1,59 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "lambda:InvokeFunction",
+            "Resource": [
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-runner*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-judge*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-research-eval-rolling-mean*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-data-collector*",
+                "arn:aws:lambda:us-east-1:711398986525:function:alpha-engine-predictor-inference*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ssm:SendCommand",
+                "ssm:GetCommandInvocation"
+            ],
+            "Resource": [
+                "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
+                "arn:aws:ec2:us-east-1:711398986525:instance/i-09b539c844515d549",
+                "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf",
+                "arn:aws:ssm:us-east-1:711398986525:*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:StartInstances",
+                "ec2:StopInstances"
+            ],
+            "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/i-018eb3307a21329bf"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "sns:Publish",
+            "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:CreateLogDelivery",
+                "logs:GetLogDelivery",
+                "logs:UpdateLogDelivery",
+                "logs:DeleteLogDelivery",
+                "logs:ListLogDeliveries",
+                "logs:PutResourcePolicy",
+                "logs:DescribeResourcePolicies",
+                "logs:DescribeLogGroups"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
+++ b/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
@@ -10,6 +10,7 @@
             ],
             "Resource": [
                 "arn:aws:iam::711398986525:role/alpha-engine-executor-role",
+                "arn:aws:iam::711398986525:role/alpha-engine-step-functions-role",
                 "arn:aws:iam::711398986525:role/github-actions-iam-drift-check"
             ]
         }


### PR DESCRIPTION
## Summary

- Codify `alpha-engine-step-functions-role` under `infrastructure/iam/` (one inline policy, content matches live AWS state after today's `ec2:StopInstances` patch).
- Widen `github-actions-iam-drift-check` OIDC scope to include the new role so the daily CI drift workflow can read it.
- Update README to document the second managed role.

## Why

Today's EOD SF (`eod-2026-05-04-...`) stalled for ~12 minutes retrying `StopTradingInstance` because the SF role had `ec2:StartInstances` but **not** `ec2:StopInstances` — an asymmetric grant added when the EOD SF was wired up. Because the role wasn't codified, neither PR review nor `check-drift.py` could catch it. NAV/alpha email still sent, but the trading EC2 wouldn't have auto-stopped without manual intervention.

Live patch (consolidating `Start/StopInstances` under one statement) was applied first. This PR codifies the role so:
- Future asymmetric grants surface as JSON diffs at PR review.
- The daily IAM drift workflow catches out-of-band edits.

## Verification

```bash
python3 infrastructure/iam/check-drift.py
# OK: no IAM drift for alpha-engine-executor-role, alpha-engine-step-functions-role, github-actions-iam-drift-check
```

OIDC scope widening was applied to live AWS prior to commit so the next daily drift run won't fail on `iam:GetRolePolicy` for the newly codified role.

## Out of scope

- Re-enabling `alpha-engine-stop-trading` EventBridge Scheduler as a backstop. Disabled deliberately per `alpha-engine/CLAUDE.md` ("no cost-protection backstop, by design"). Today's incident reopens that design question, but reversing the call belongs in a separate PR with explicit decision context.
- Splitting the SF role's single inline policy into multiple files matching the executor-role per-concern pattern. Not worth the prod-mutation risk; current 1-policy structure is preserved.

## Test plan

- [x] `check-drift.py` clean across all 3 codified roles
- [x] Pre-push executor dry-run gate passed
- [ ] CI iam-drift-check workflow on this PR
- [ ] Tomorrow's daily drift workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)