### PR TITLE
fix(iam): grant SF role ssm:DescribeInstanceInformation

### DIFF
--- a/infrastructure/iam/alpha-engine-step-functions-role/alpha-engine-step-functions-role-policy.json
+++ b/infrastructure/iam/alpha-engine-step-functions-role/alpha-engine-step-functions-role-policy.json
@@ -27,6 +27,11 @@
         },
         {
             "Effect": "Allow",
+            "Action": "ssm:DescribeInstanceInformation",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
             "Action": [
                 "ec2:StartInstances",
                 "ec2:StopInstances"


### PR DESCRIPTION
## Summary

Adds `ssm:DescribeInstanceInformation` (Resource `*`) to `alpha-engine-step-functions-role-policy.json`. Required by [alpha-engine-data PR #150](https://github.com/cipher813/alpha-engine-data/pull/150)'s polling SSM-readiness gate.

**Why `*`:** the API does not support resource-level perms. The existing `ssm:SendCommand` grant remains instance-scoped, so the SF still cannot run commands outside its allowlist — only query agent status.

## Stacking

Stacked on [#130](https://github.com/cipher813/alpha-engine/pull/130) (which establishes the codified file). Merge #130 first; this rebases cleanly onto main afterward.

The deploy-script-side inline policy that `alpha-engine-data/infrastructure/deploy_step_function_daily.sh` re-applies is updated in PR #150 of that repo, keeping codified ↔ live in lockstep.

## Test plan

- [x] `python3 -m json.tool` validates the policy
- [ ] After both PRs merge: run `deploy_step_function_daily.sh` (re-applies the inline policy) — confirm live policy now includes `ssm:DescribeInstanceInformation`
- [ ] Drift-check Lambda still reports `cf_drift:false` for alpha-engine-step-functions-role

🤖 Generated with [Claude Code](https://claude.com/claude-code)