### PR TITLE
refactor(preflight): drop data-freshness checks from executor

### DIFF
--- a/executor/preflight.py
+++ b/executor/preflight.py
@@ -6,34 +6,24 @@ Primitives live in ``alpha_engine_lib.preflight.BasePreflight``; this
 module composes them into a mode-specific sequence. See the
 alpha-engine-lib README for the rationale.
 
+Data-freshness assertions (universe + macro/SPY) live upstream in
+``alpha-engine-data``'s preflight, which runs before ``RunMorningPlanner``
++ ``RunDaemon`` + EOD steps in the weekday + EOD Step Functions. If
+upstream data is stale, the data step hard-fails and the SF never reaches
+the executor — re-checking here was redundant.
+
 Modes:
 
 - ``"main"`` — ``executor/main.py``, the morning order-book planner.
-  Reads per-ticker OHLCV for ATR sizing + macro/SPY for alpha context.
-  Both ArcticDB libraries must be readable + fresh; per-ticker
-  freshness scan catches the partial-write class (2026-04-21 ASGN/MOH)
-  that single-symbol checks miss.
-- ``"daemon"`` — ``executor/daemon.py``, the sole order executor. Same
-  ArcticDB freshness gates as ``main`` plus the IB paper-account guard
-  is invoked separately by the daemon after IBKRClient connects.
-- ``"eod"`` — ``executor/eod_reconcile.py``. macro/SPY only — eod
-  computes alpha vs SPY + reads held-ticker closes; full-universe scan
-  is overkill since only the ~20 held names matter.
+- ``"daemon"`` — ``executor/daemon.py``, the sole order executor. The IB
+  paper-account guard is invoked separately by the daemon after IBKRClient
+  connects.
+- ``"eod"`` — ``executor/eod_reconcile.py``.
 """
 
 from __future__ import annotations
 
 from alpha_engine_lib.preflight import BasePreflight
-
-# ArcticDB freshness thresholds for executor mode runs.
-# 4 days: covers Fri→Tue long weekends (US market holidays) + 1 day
-# buffer. Matches alpha-engine-data DataPreflight daily-mode thresholds.
-_MACRO_MAX_STALE_DAYS = 4
-# 5 days: per-ticker scan threshold. Slightly more permissive than the
-# canonical-symbol check because individual tickers can legitimately
-# trail SPY by 1 day (DST/cross-listing edge cases). Backtester uses
-# the same 5d default for the same reason.
-_UNIVERSE_PER_TICKER_MAX_STALE_DAYS = 5
 
 
 class ExecutorPreflight(BasePreflight):
@@ -46,35 +36,5 @@ class ExecutorPreflight(BasePreflight):
         self.mode = mode
 
     def run(self) -> None:
-        # Cheap-first ordering: env (~ms) → S3 HEAD (~ms) → ArcticDB
-        # canonical liveness (~100ms) → universe-wide scan (~5-10s).
         self.check_env_vars("AWS_REGION")
         self.check_s3_bucket()
-
-        if self.mode in ("main", "daemon"):
-            # Canonical macro liveness — DataPhase1 health for SPY, which
-            # lives in the `macro` library only. SPY is the S&P 500 ETF
-            # tracker; the `universe` library holds the index constituents
-            # themselves and does not contain an SPY symbol.
-            self.check_arcticdb_fresh(
-                "macro", "SPY", max_stale_days=_MACRO_MAX_STALE_DAYS,
-            )
-            # Per-ticker freshness scan over the full universe library —
-            # catches the partial-write class (2026-04-21 ASGN/MOH) where
-            # macro.SPY stays fresh while individual constituents stop
-            # receiving writes. Validates daily_append health on the
-            # universe library by reading every symbol's tail(1).
-            self.check_arcticdb_universe_fresh(
-                "universe",
-                max_stale_days=_UNIVERSE_PER_TICKER_MAX_STALE_DAYS,
-            )
-
-        if self.mode == "eod":
-            # EOD reconcile reads macro.SPY for alpha-vs-SPY computation
-            # and per-position closes from universe — but only the ~20
-            # held tickers matter, not the full ~900 universe. Single-
-            # symbol macro check is sufficient; per-ticker validation
-            # happens at the held-position read site.
-            self.check_arcticdb_fresh(
-                "macro", "SPY", max_stale_days=_MACRO_MAX_STALE_DAYS,
-            )

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -4,6 +4,11 @@ Tests for ExecutorPreflight mode composition.
 BasePreflight primitives are tested in alpha-engine-lib. These tests
 verify that each executor mode composes the expected primitive calls
 and rejects unknown modes.
+
+Data-freshness checks (universe + macro/SPY) moved upstream to
+alpha-engine-data's preflight 2026-05-05; the data step in every Step
+Function hard-fails on staleness before the executor runs, so re-checking
+here is redundant.
 """
 
 from __future__ import annotations
@@ -24,53 +29,46 @@ class TestExecutorPreflight:
         with pytest.raises(ValueError, match="unknown mode"):
             ExecutorPreflight(bucket="b", mode="bogus")
 
-    def test_main_mode_composes_full_check_sequence(self):
-        """main mode: env + S3 + macro/SPY freshness + per-ticker
-        universe scan. SPY is not in the universe library (it's the
-        S&P 500 ETF, not a constituent), so a single-symbol universe/SPY
-        check is structurally invalid — the full universe scan covers
-        daily_append health on every actual constituent."""
+    def test_main_mode_composes_check_sequence(self):
+        """main mode: env + S3. Data-freshness moved upstream."""
         pf = ExecutorPreflight(bucket="b", mode="main")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3, \
-             patch.object(pf, "check_arcticdb_fresh") as fresh, \
-             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
+             patch.object(pf, "check_s3_bucket") as s3:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
-        fresh.assert_called_once()
-        assert fresh.call_args.args[:2] == ("macro", "SPY")
-        universe.assert_called_once()
-        assert universe.call_args.args[0] == "universe"
 
-    def test_daemon_mode_composes_full_check_sequence(self):
-        """daemon mode mirrors main — same ArcticDB liveness gates."""
+    def test_daemon_mode_composes_check_sequence(self):
+        """daemon mode: same as main."""
         pf = ExecutorPreflight(bucket="b", mode="daemon")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3, \
-             patch.object(pf, "check_arcticdb_fresh") as fresh, \
-             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
+             patch.object(pf, "check_s3_bucket") as s3:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
-        fresh.assert_called_once()
-        universe.assert_called_once()
 
-    def test_eod_mode_runs_macro_only(self):
-        """eod reads macro/SPY for alpha + per-position closes; full
-        universe scan is overkill since only the ~20 held names matter."""
+    def test_eod_mode_composes_check_sequence(self):
+        """eod mode: env + S3 only."""
         pf = ExecutorPreflight(bucket="b", mode="eod")
         with patch.object(pf, "check_env_vars") as env, \
-             patch.object(pf, "check_s3_bucket") as s3, \
-             patch.object(pf, "check_arcticdb_fresh") as fresh, \
-             patch.object(pf, "check_arcticdb_universe_fresh") as universe:
+             patch.object(pf, "check_s3_bucket") as s3:
             pf.run()
         env.assert_called_once_with("AWS_REGION")
         s3.assert_called_once()
-        # Only macro/SPY — no universe-side checks
-        fresh.assert_called_once()
-        assert fresh.call_args.args[:2] == ("macro", "SPY")
-        universe.assert_not_called()
+
+    def test_no_mode_calls_data_freshness_primitives(self):
+        """Regression: no executor mode may call macro or universe
+        freshness checks. Those moved to alpha-engine-data's preflight,
+        which is the SF data step's responsibility."""
+        for mode in ("main", "daemon", "eod"):
+            pf = ExecutorPreflight(bucket="b", mode=mode)
+            with patch.object(pf, "check_env_vars"), \
+                 patch.object(pf, "check_s3_bucket"), \
+                 patch.object(pf, "check_arcticdb_fresh") as fresh, \
+                 patch.object(pf, "check_arcticdb_universe_fresh") as universe:
+                pf.run()
+            fresh.assert_not_called()
+            universe.assert_not_called()
 
     def test_check_ib_paper_account_available_on_instance(self):
         """Daemon reuses the preflight instance to validate the IB


### PR DESCRIPTION
## Summary
- Data-freshness assertions (universe + macro/SPY) move upstream to alpha-engine-data's preflight
- The data step in every Step Function (weekday MorningEnrich, EOD PostMarketData) hard-fails on staleness before the executor runs — re-checking here was redundant
- Removes 3x `check_arcticdb_fresh` + 1x `check_arcticdb_universe_fresh` across main/daemon/eod modes

## What stays
- IB paper-account guard (`check_ib_paper_account`) — safety-critical, prevents pointing at live brokerage
- env vars + S3 bucket reachability checks

## Cross-repo arc
PR B of 4 — drops data-freshness preflight from data consumers, trusting SF ordering as the single gate. Sibling PRs:
- alpha-engine-predictor #80 (training + inference)
- alpha-engine-backtester (next)
- alpha-engine-lib (next, deprecate `check_arcticdb_universe_fresh`)

## Test plan
- [x] `tests/test_preflight.py` rewritten — pins `run()` calls only env + S3
- [x] New regression test `test_no_mode_calls_data_freshness_primitives`
- [x] IB paper-account guard test still passes
- [x] Full suite: 415/415 pass
- [ ] First weekday SF after merge — confirm `RunMorningPlanner` + `RunDaemon` still run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)