### PR TITLE
fix(iam): codify alpha-engine-eventbridge-sfn-role

### DIFF
--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -35,6 +35,15 @@ is the inline policy name on that role.
   publish, and CloudWatch Logs delivery. Codified 2026-05-04 after an
   asymmetric `ec2:StartInstances` / `ec2:StopInstances` grant let the EOD
   SF stall on `StopTradingInstance` for an entire afternoon.
+- **`alpha-engine-eventbridge-sfn-role`** — assumed by EventBridge to
+  start the saturday + weekday SFN executions on cron. One inline policy
+  granting `states:StartExecution` on both state machine ARNs. Codified
+  2026-05-06 after a third recurrence of the same regression: the
+  `alpha-engine-data` deploy scripts each contained an inline
+  `aws iam put-role-policy` against this role, but only the weekday
+  script listed both ARNs — the saturday script overwrote the policy
+  with the saturday ARN alone, dropping weekday's grant. Inline blocks
+  are removed from those scripts; `apply.sh` is the only writer now.
 - **`github-actions-iam-drift-check`** — assumed by GitHub Actions via
   OIDC for the daily IAM-drift-check workflow. Single inline policy
   granting `iam:ListRolePolicies` + `iam:GetRolePolicy` scoped to the

--- a/infrastructure/iam/alpha-engine-eventbridge-sfn-role/alpha-engine-eventbridge-sfn-role-policy.json
+++ b/infrastructure/iam/alpha-engine-eventbridge-sfn-role/alpha-engine-eventbridge-sfn-role-policy.json
@@ -1,0 +1,13 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "states:StartExecution",
+            "Resource": [
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline"
+            ]
+        }
+    ]
+}

--- a/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
+++ b/infrastructure/iam/github-actions-iam-drift-check/iam-readonly.json
@@ -11,6 +11,7 @@
             "Resource": [
                 "arn:aws:iam::711398986525:role/alpha-engine-executor-role",
                 "arn:aws:iam::711398986525:role/alpha-engine-step-functions-role",
+                "arn:aws:iam::711398986525:role/alpha-engine-eventbridge-sfn-role",
                 "arn:aws:iam::711398986525:role/github-actions-iam-drift-check"
             ]
         }


### PR DESCRIPTION
## Summary

- Codify `alpha-engine-eventbridge-sfn-role` (assumed by EventBridge to start saturday + weekday SFN executions) as a single source of truth in `infrastructure/iam/`.
- Add the role ARN to the OIDC drift-check read policy so CI catches future divergence.
- Closes the asymmetric-IAM-grant regression that hit prod three times (2026-04-21, 2026-05-04, 2026-05-06): the alpha-engine-data deploy scripts each ran an inline `aws iam put-role-policy` against this role with conflicting Resource lists (saturday-only vs both ARNs); whichever ran last won.

## Companion

cipher813/alpha-engine-data#170 — drops the inline IAM writes from both deploy scripts; this PR is now the only writer.

## Test plan
- [x] `apply.sh --role alpha-engine-eventbridge-sfn-role` applied live; manual recovery SF execution cleared `DescribeInstanceInfo` + `StartExecutorEC2` after the patch.
- [x] `check-drift.py` clean across all 4 codified roles.
- [ ] Saturday SF first auto-fire post-merge (Sat 2026-05-09 09:00 UTC) confirms no regression.
- [ ] Weekday SF first auto-fire post-merge (next Mon-Fri 13:00 UTC) confirms no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)