### PR TITLE
feat(trades): signal_date + prediction_date columns for artifact lineage

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -612,6 +612,12 @@ def run_daemon(dry_run: bool = False) -> None:
                     "spy_return_during_hold": _spy_ret,
                     "realized_alpha_pct": _ralpha,
                     "days_held": _dheld,
+                    # Phase 2 lineage — signal_date / prediction_date are
+                    # the artifact filename dates the urgent_exits_with_meta
+                    # record sourced from. Both default to None for COVER
+                    # orders generated outside the deciders path.
+                    "signal_date": urgent.get("signal_date"),
+                    "prediction_date": urgent.get("prediction_date"),
                 })
 
                 order_book.mark_urgent_executed(ticker, action)
@@ -1102,7 +1108,11 @@ def _execute_entry(
         # omitted); signal_trading_day links back to the signals.json that
         # originated this entry — threaded through OrderBook from main.py's
         # _read_signals(). See alpha-engine-docs/private/DATE_CONVENTIONS.md.
+        # signal_date and prediction_date are the artifact filename dates
+        # (Phase 2 transparency-inventory; ROADMAP entry 2026-05-05).
         "signal_trading_day": entry.get("signal_date"),
+        "signal_date": entry.get("signal_date"),
+        "prediction_date": entry.get("prediction_date"),
     })
 
     # Mark entry as executed in order book

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -281,6 +281,7 @@ def decide_entries(
     signal_age_days: int,
     earnings_by_ticker: dict,
     run_date: str,
+    predictions_date: str | None = None,
 ) -> EntryPlan:
     """Pure decision pipeline for ENTER signals.
 
@@ -492,10 +493,19 @@ def decide_entries(
         ticker_hist = (price_histories or {}).get(ticker)
         pred = predictions_by_ticker.get(ticker, {})
 
+        # signal_date = signals.json filename date the order sourced from
+        # (signals_raw["date"]); falls back to run_date when the payload
+        # omits the field. This is the artifact-lineage column requested
+        # by the Phase 2 transparency-inventory ROADMAP item — distinct
+        # from signal_trading_day (NYSE attribution day inside the payload).
+        # prediction_date = predictions/{date}.json filename date the GBM
+        # veto gate consulted; None when predictions weren't loaded.
+        signals_date = signals_raw.get("date", run_date) if signals_raw else run_date
         plan.entries_with_meta.append({
             "ticker": ticker,
             "signal": "ENTER",
-            "signal_date": run_date,
+            "signal_date": signals_date,
+            "prediction_date": predictions_date,
             "shares": sizing["shares"],
             "current_price": current_price,
             "dollar_size": sizing["dollar_size"],
@@ -550,6 +560,8 @@ def decide_exits_and_reduces(
     market_regime: str,
     portfolio_nav: float,
     run_date: str,
+    signals_date: str | None = None,
+    predictions_date: str | None = None,
 ) -> ExitPlan:
     """Pure decision pipeline for EXIT and REDUCE signals.
 
@@ -615,6 +627,8 @@ def decide_exits_and_reduces(
         plan.urgent_exits_with_meta.append({
             "ticker": ticker,
             "signal": "EXIT",
+            "signal_date": signals_date,
+            "prediction_date": predictions_date,
             "shares": shares_held,
             "reason": sig.get("reason", "research_signal"),
             "detail": sig.get("detail", ""),
@@ -686,6 +700,8 @@ def decide_exits_and_reduces(
         plan.urgent_exits_with_meta.append({
             "ticker": ticker,
             "signal": "REDUCE",
+            "signal_date": signals_date,
+            "prediction_date": predictions_date,
             "shares": shares_to_sell,
             "reason": sig.get("reason", "research_signal"),
             "detail": sig.get("detail", ""),

--- a/executor/main.py
+++ b/executor/main.py
@@ -267,10 +267,16 @@ def _read_signals(
     simulate: bool,
     signals_override: dict | None,
     conn,
-) -> tuple[dict, dict, str, dict]:
+) -> tuple[dict, dict, str, dict, str | None]:
     """Read and validate signals from S3 or override.
 
-    Returns (signals_raw, signals, run_date, predictions_by_ticker).
+    Returns ``(signals_raw, signals, run_date, predictions_by_ticker,
+    predictions_date)``. ``predictions_date`` is the
+    ``predictor/predictions/{date}.json`` filename date the GBM run
+    produced (None if predictions weren't loaded — simulate mode or S3
+    miss); ``signals_raw["date"]`` is the corresponding signals.json
+    filename date and is read directly off ``signals_raw`` by callers
+    that need it.
     """
     if signals_override is not None:
         signals_raw = signals_override
@@ -352,10 +358,11 @@ def _read_signals(
             logger.debug("Stale signals Telegram notification failed", exc_info=True)
 
     # Load GBM predictions for rationale capture
+    predictions_date: str | None = None
     if not simulate:
         try:
             from executor.signal_reader import read_predictions
-            predictions_by_ticker = read_predictions(signals_bucket)
+            predictions_by_ticker, predictions_date = read_predictions(signals_bucket)
         except Exception as e:
             logger.warning("Failed to load GBM predictions: %s", e)
             predictions_by_ticker = {}
@@ -379,7 +386,7 @@ def _read_signals(
         f"REDUCE={len(signals['reduce'])} HOLD={len(signals['hold'])}"
     )
 
-    return signals_raw, signals, run_date, predictions_by_ticker
+    return signals_raw, signals, run_date, predictions_by_ticker, predictions_date
 
 
 def _plan_entries(
@@ -405,6 +412,7 @@ def _plan_entries(
     run_date: str,
     dry_run: bool,
     simulate: bool,
+    predictions_date: str | None = None,
 ) -> tuple[int, list[dict], list[dict]]:
     """Live-shell wrapper around ``executor.deciders.decide_entries``.
 
@@ -454,6 +462,7 @@ def _plan_entries(
         signal_age_days=signal_age_days,
         earnings_by_ticker=earnings_by_ticker,
         run_date=run_date,
+        predictions_date=predictions_date,
     )
 
     # Dispatch decisions to side-effecting layer.
@@ -484,6 +493,8 @@ def _plan_exits_and_reduces(
     run_date: str,
     dry_run: bool,
     simulate: bool,
+    signals_date: str | None = None,
+    predictions_date: str | None = None,
 ) -> list[dict]:
     """Live-shell wrapper around ``executor.deciders.decide_exits_and_reduces``.
 
@@ -528,6 +539,8 @@ def _plan_exits_and_reduces(
         market_regime=market_regime,
         portfolio_nav=portfolio_nav,
         run_date=run_date,
+        signals_date=signals_date,
+        predictions_date=predictions_date,
     )
 
     if simulate:
@@ -869,7 +882,7 @@ def run(
 
     # ── 1. Read signals from S3 (or use injected override) ──────────────────
     try:
-        signals_raw, signals, run_date, predictions_by_ticker = _read_signals(
+        signals_raw, signals, run_date, predictions_by_ticker, predictions_date = _read_signals(
             config, signals_bucket, run_date, simulate, signals_override, conn,
         )
     except Exception as _sig_err:
@@ -1147,6 +1160,7 @@ def run(
             run_date=run_date,
             dry_run=dry_run,
             simulate=simulate,
+            predictions_date=predictions_date,
         )
         orders.extend(entry_orders)
 
@@ -1172,6 +1186,8 @@ def run(
             run_date=run_date,
             dry_run=dry_run,
             simulate=simulate,
+            signals_date=signals_raw.get("date") if signals_raw else None,
+            predictions_date=predictions_date,
         )
         orders.extend(exit_orders)
 

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -14,11 +14,21 @@ from botocore.exceptions import ClientError
 logger = logging.getLogger(__name__)
 
 
-def read_predictions(s3_bucket: str) -> dict[str, dict]:
+def read_predictions(s3_bucket: str) -> tuple[dict[str, dict], str | None]:
     """
     Read predictor/predictions/latest.json from S3.
 
-    Returns: {ticker: prediction_dict}. Empty dict if not available.
+    Returns: ``({ticker: prediction_dict}, predictions_date)`` where
+    ``predictions_date`` is the top-level ``date`` field on the JSON
+    payload (the ``predictions/{date}.json`` filename date the GBM run
+    produced). Returns ``({}, None)`` if not available.
+
+    The date is surfaced separately because ``latest.json`` is a pointer
+    that may resolve to a prior trading day's predictions during the
+    Saturday/holiday window — readers (esp. trade logging for
+    transparency lineage) need the actual filename date, not today's
+    date. See ROADMAP "Phase 2 transparency-inventory" → trade execution
+    decisions row.
     """
     s3 = boto3.client("s3")
     try:
@@ -31,12 +41,15 @@ def read_predictions(s3_bucket: str) -> dict[str, dict]:
             )
         preds = data.get("predictions", [])
         result = {p["ticker"]: p for p in preds if "ticker" in p}
-        logger.info("Predictions loaded | n=%d", len(result))
-        return result
+        predictions_date = data.get("date")
+        logger.info(
+            "Predictions loaded | n=%d | date=%s", len(result), predictions_date,
+        )
+        return result, predictions_date
     except ClientError as e:
         if e.response["Error"]["Code"] == "NoSuchKey":
             logger.warning("predictions/latest.json not found — running without GBM input")
-            return {}
+            return {}, None
         raise
 
 

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -80,6 +80,17 @@ _TRADES_MIGRATIONS = [
     # chain — get_entry_trade(...).sector now resolves instead of always
     # returning None and pushing the lookup through to constituents.json.
     "ALTER TABLE trades ADD COLUMN sector TEXT",
+    # ── Phase 2 transparency-inventory: artifact-filename lineage (2026-05-06) ──
+    # signal_date = signals/{date}/signals.json filename date the order was
+    # sourced from (distinct from signal_trading_day, which is the NYSE
+    # attribution day declared inside the payload — a holiday or backfilled
+    # file can have filename ≠ trading_day).
+    # prediction_date = predictor/predictions/{date}.json filename date the
+    # GBM veto gate consulted; NULL for non-predictor-gated orders (strategy-
+    # driven intraday exits, urgent COVERs).
+    # Both nullable for back-compat with rows logged before this PR.
+    "ALTER TABLE trades ADD COLUMN signal_date TEXT",
+    "ALTER TABLE trades ADD COLUMN prediction_date TEXT",
 ]
 
 _EOD_MIGRATIONS = [
@@ -194,8 +205,9 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             entry_trade_id, signal_price, trigger_price, trigger_type,
             spy_price_at_order, realized_pnl, realized_return_pct,
             spy_return_during_hold, realized_alpha_pct, days_held,
-            slippage_vs_signal, trading_day, signal_trading_day, created_at
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            slippage_vs_signal, trading_day, signal_trading_day,
+            signal_date, prediction_date, created_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             trade_id,
@@ -238,6 +250,8 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             trade.get("slippage_vs_signal"),
             trading_day,
             trade.get("signal_trading_day"),
+            trade.get("signal_date"),
+            trade.get("prediction_date"),
             datetime.now(timezone.utc).isoformat(),
         ),
     )

--- a/tests/test_deciders_signal_prediction_date.py
+++ b/tests/test_deciders_signal_prediction_date.py
@@ -1,0 +1,233 @@
+"""Tests that deciders.entries_with_meta + urgent_exits_with_meta carry
+artifact-filename lineage (signal_date + prediction_date).
+
+These fields are the producer side of the Phase 2 transparency-inventory
+lineage column on the trades table — daemon.py reads them off the
+order book record and threads them into log_trade(). If the producer
+stops emitting them, the daemon's log_trade call silently writes NULL,
+which would breach the going-forward coverage gate without surfacing
+as a test failure on log_trade alone.
+
+Coverage:
+  1. ENTER path — entries_with_meta carries both fields when supplied
+  2. ENTER path — signal_date sources from signals_raw["date"], not run_date
+     (the stale-signals fallback case where Research's Saturday SF was
+     missed and signal_reader.read_signals_with_fallback walks back)
+  3. ENTER path — prediction_date = None when caller doesn't supply
+  4. EXIT path — urgent_exits_with_meta carries both fields
+  5. REDUCE path — urgent_exits_with_meta carries both fields
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from executor.deciders import decide_entries, decide_exits_and_reduces
+
+
+def _df_history(n_bars: int = 100, base: float = 100.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open":  [base + i * 0.1 for i in range(n_bars)],
+            "high":  [base + i * 0.1 + 0.5 for i in range(n_bars)],
+            "low":   [base + i * 0.1 - 0.5 for i in range(n_bars)],
+            "close": [base + i * 0.1 + 0.2 for i in range(n_bars)],
+        },
+        index=pd.bdate_range("2024-01-01", periods=n_bars),
+    )
+
+
+def _base_config():
+    return {
+        "min_score_to_enter": 70,
+        "min_conviction_to_enter": ["rising", "stable"],
+        "max_position_pct": 0.05,
+        "bear_max_position_pct": 0.025,
+        "max_sector_pct": 0.25,
+        "max_equity_pct": 0.90,
+        "drawdown_circuit_breaker": 0.08,
+        "bear_block_underweight": True,
+        "earnings_proximity_warning_days": 2,
+        "momentum_gate_enabled": False,
+        "atr_sizing_enabled": True,
+        "correlation_block_enabled": False,
+        "coverage_sizing_enabled": False,
+        "reduce_fraction": 0.50,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": True,
+                "tiers": [(-0.02, 1.00, "tier1"), (-0.04, 0.50, "tier2")],
+            },
+        },
+    }
+
+
+def _base_strategy_config():
+    return {
+        "intraday_pullback_atr_multiple": 1.0,
+        "intraday_vwap_discount_pct": 0.005,
+        "intraday_support_lookback_days": 20,
+        "drawdown_forced_exit_enabled": False,
+    }
+
+
+def _build_entry_inputs(signals_filename_date: str, run_date: str):
+    enter = [{
+        "ticker": "NVDA",
+        "signal": "ENTER",
+        "score": 85,
+        "conviction": "rising",
+        "sector": "Technology",
+        "rating": "BUY",
+        "price_target_upside": 0.20,
+    }]
+    signals_raw = {
+        "date": signals_filename_date,
+        "market_regime": "neutral",
+        "sector_ratings": {"Technology": {"rating": "overweight"}},
+        "enter": enter,
+        "exit": [],
+        "reduce": [],
+        "hold": [],
+        "universe": enter,
+        "buy_candidates": enter,
+    }
+    tickers = ["NVDA", "SPY", "XLK", "XLV", "XLF", "XLY", "XLP", "XLE",
+               "XLU", "XLRE", "XLB", "XLI", "XLC"]
+    return {
+        "enter_signals": enter,
+        "signals_raw": signals_raw,
+        "predictions_by_ticker": {},
+        "config": _base_config(),
+        "strategy_config": _base_strategy_config(),
+        "market_regime": "neutral",
+        "sector_ratings": signals_raw["sector_ratings"],
+        "portfolio_nav": 1_000_000.0,
+        "peak_nav": 1_000_000.0,
+        "current_positions": {},
+        "prices_now": {t: 100.0 for t in tickers},
+        "price_histories": {t: _df_history(base=100 + i) for i, t in enumerate(tickers)},
+        "atr_map": {t: 0.02 for t in tickers},
+        "vwap_map": {t: 100.0 for t in tickers},
+        "coverage_map": {t: 1.0 for t in tickers},
+        "dd_multiplier": 1.0,
+        "signal_age_days": 0,
+        "earnings_by_ticker": {},
+        "run_date": run_date,
+    }
+
+
+def test_entries_with_meta_carries_signal_and_prediction_date():
+    inputs = _build_entry_inputs(
+        signals_filename_date="2026-05-02", run_date="2026-05-02",
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.entries_with_meta, "expected at least one entry to pass gates"
+    meta = plan.entries_with_meta[0]
+    assert meta["signal_date"] == "2026-05-02"
+    assert meta["prediction_date"] == "2026-05-06"
+
+
+def test_entries_with_meta_signal_date_sources_from_signals_raw_not_run_date():
+    """The stale-signals fallback case: signal_reader.read_signals_with_fallback
+    walked back to a prior Saturday's signals.json when this Saturday's run
+    didn't fire. signals_raw["date"] must win over run_date — otherwise the
+    lineage column points at today and the artifact-traceability claim breaks.
+    """
+    inputs = _build_entry_inputs(
+        signals_filename_date="2026-04-25",  # 11 days back — fallback hit
+        run_date="2026-05-06",                # today
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.entries_with_meta
+    meta = plan.entries_with_meta[0]
+    assert meta["signal_date"] == "2026-04-25", (
+        "signal_date must come from signals_raw['date'] (the artifact filename), "
+        "not run_date — otherwise stale-fallback rows misattribute lineage."
+    )
+
+
+def test_entries_with_meta_prediction_date_defaults_to_none():
+    """Caller path that doesn't load predictions (simulate mode, S3 miss)
+    must not crash and must persist None — which log_trade then writes
+    as NULL per the back-compat policy.
+    """
+    inputs = _build_entry_inputs(
+        signals_filename_date="2026-05-02", run_date="2026-05-02",
+    )
+    plan = decide_entries(**inputs)  # predictions_date omitted
+    assert plan.entries_with_meta
+    meta = plan.entries_with_meta[0]
+    assert meta["signal_date"] == "2026-05-02"
+    assert meta["prediction_date"] is None
+
+
+def test_urgent_exits_with_meta_carries_both_dates_for_research_exit():
+    """Research-driven EXIT — both dates threaded through from the
+    decide_exits_and_reduces caller. Distinct from strategy-driven
+    intraday exits which fire from daemon.py without these dates.
+    """
+    signals = {
+        "enter": [],
+        "exit": [{"ticker": "AAPL", "score": 50, "conviction": "declining",
+                  "rating": "SELL", "reason": "thesis_violation"}],
+        "reduce": [],
+        "hold": [],
+        "market_regime": "neutral",
+        "sector_ratings": {},
+    }
+    current_positions = {
+        "AAPL": {"shares": 100, "avg_cost": 150.0,
+                 "market_value": 15000, "sector": "Technology"},
+    }
+    plan = decide_exits_and_reduces(
+        signals=signals,
+        strategy_exits=[],
+        current_positions=current_positions,
+        prices_now={"AAPL": 145.0},
+        predictions_by_ticker={},
+        config=_base_config(),
+        market_regime="neutral",
+        portfolio_nav=1_000_000.0,
+        run_date="2026-05-06",
+        signals_date="2026-05-02",
+        predictions_date="2026-05-06",
+    )
+    assert len(plan.urgent_exits_with_meta) == 1
+    ue = plan.urgent_exits_with_meta[0]
+    assert ue["signal_date"] == "2026-05-02"
+    assert ue["prediction_date"] == "2026-05-06"
+    assert ue["signal"] == "EXIT"
+
+
+def test_urgent_exits_with_meta_carries_both_dates_for_research_reduce():
+    signals = {
+        "enter": [],
+        "exit": [],
+        "reduce": [{"ticker": "TSLA", "score": 60, "conviction": "stable",
+                    "rating": "HOLD", "reason": "drawdown_tier_reduction"}],
+        "hold": [],
+        "market_regime": "neutral",
+        "sector_ratings": {},
+    }
+    current_positions = {
+        "TSLA": {"shares": 200, "avg_cost": 200.0,
+                 "market_value": 40000, "sector": "Consumer Cyclical"},
+    }
+    plan = decide_exits_and_reduces(
+        signals=signals,
+        strategy_exits=[],
+        current_positions=current_positions,
+        prices_now={"TSLA": 195.0},
+        predictions_by_ticker={},
+        config=_base_config(),
+        market_regime="neutral",
+        portfolio_nav=1_000_000.0,
+        run_date="2026-05-06",
+        signals_date="2026-05-02",
+        predictions_date="2026-05-06",
+    )
+    assert len(plan.urgent_exits_with_meta) == 1
+    ue = plan.urgent_exits_with_meta[0]
+    assert ue["signal_date"] == "2026-05-02"
+    assert ue["prediction_date"] == "2026-05-06"
+    assert ue["signal"] == "REDUCE"

--- a/tests/test_signal_reader_predictions_date.py
+++ b/tests/test_signal_reader_predictions_date.py
@@ -1,0 +1,89 @@
+"""Tests that read_predictions surfaces the predictions/{date}.json
+filename date alongside the per-ticker dict.
+
+The date is read off latest.json's top-level ``date`` field. It's
+distinct from today's date when the latest pointer resolves to a prior
+trading day's predictions (Saturday window, holiday, weekday SF
+delayed). Trade logging needs the actual filename for the lineage
+column; surfacing run_date instead would silently misattribute.
+
+Closes the artifact-lineage producer side of the Phase 2
+transparency-inventory ROADMAP item — the daemon's log_trade call
+inherits this value through entries_with_meta + urgent_exits_with_meta.
+"""
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from executor.signal_reader import read_predictions
+
+
+def _fake_s3_client_with_payload(payload: dict):
+    """Return a MagicMock that mimics boto3.client('s3') and replies to
+    get_object with ``payload`` as the JSON body."""
+    from unittest.mock import MagicMock
+
+    s3 = MagicMock()
+    s3.get_object.return_value = {
+        "Body": io.BytesIO(json.dumps(payload).encode()),
+    }
+    return s3
+
+
+def test_read_predictions_returns_dict_and_date():
+    """Happy-path: latest.json with a top-level date and per-ticker
+    predictions list. read_predictions surfaces both."""
+    payload = {
+        "date": "2026-05-06",
+        "model_version": "v3.0-meta",
+        "predictions": [
+            {"ticker": "NVDA", "predicted_direction": "UP", "p_up": 0.62},
+            {"ticker": "AAPL", "predicted_direction": "DOWN", "p_up": 0.38},
+        ],
+    }
+    s3 = _fake_s3_client_with_payload(payload)
+    with patch("executor.signal_reader.boto3.client", return_value=s3):
+        result, date = read_predictions("alpha-engine-research")
+
+    assert date == "2026-05-06"
+    assert set(result.keys()) == {"NVDA", "AAPL"}
+    assert result["NVDA"]["predicted_direction"] == "UP"
+
+
+def test_read_predictions_date_is_none_when_payload_missing_field():
+    """Defensive: if the predictor's payload regresses and stops
+    emitting `date` at top level, the executor still loads the
+    per-ticker dict (lineage just shows NULL). Better than hard-failing
+    the whole executor on a non-load-bearing field."""
+    payload = {
+        "predictions": [
+            {"ticker": "NVDA", "predicted_direction": "UP"},
+        ],
+    }
+    s3 = _fake_s3_client_with_payload(payload)
+    with patch("executor.signal_reader.boto3.client", return_value=s3):
+        result, date = read_predictions("alpha-engine-research")
+
+    assert date is None
+    assert "NVDA" in result
+
+
+def test_read_predictions_returns_empty_and_none_on_no_such_key():
+    """latest.json missing — daemon runs without GBM (degraded mode).
+    Both halves of the tuple stay NULL/empty so callers can branch."""
+    from unittest.mock import MagicMock
+
+    s3 = MagicMock()
+    s3.get_object.side_effect = ClientError(
+        error_response={"Error": {"Code": "NoSuchKey"}},
+        operation_name="GetObject",
+    )
+    with patch("executor.signal_reader.boto3.client", return_value=s3):
+        result, date = read_predictions("alpha-engine-research")
+
+    assert result == {}
+    assert date is None

--- a/tests/test_trades_signal_prediction_date.py
+++ b/tests/test_trades_signal_prediction_date.py
@@ -1,0 +1,141 @@
+"""
+Tests for the `signal_date` + `prediction_date` columns on the trades table.
+
+Phase 2 transparency-inventory item — closes the *trade execution decisions*
+row in the gate checklist. Every fill is now traceable to the specific
+signals.json filename date that drove it (signal_date) and the
+predictor/predictions/{date}.json filename the GBM veto consulted
+(prediction_date, NULL when the order wasn't predictor-gated).
+
+Distinct from `signal_trading_day` (NYSE attribution day inside the payload):
+holiday or backfilled signals files can have filename ≠ trading_day.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from executor.trade_logger import init_db, log_trade
+
+
+def _columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute("PRAGMA table_info(trades)")
+    cols = {row[1] for row in cur.fetchall()}
+    conn.close()
+    return cols
+
+
+def test_init_db_creates_signal_and_prediction_date_columns(tmp_path):
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    cols = _columns(db_path)
+    assert "signal_date" in cols
+    assert "prediction_date" in cols
+
+
+def test_init_db_idempotent_for_new_columns(tmp_path):
+    """Re-running init_db on an existing schema must not raise — the
+    sqlite ADD COLUMN guard rails treat duplicates as expected."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    # Second init_db should be a no-op
+    conn = init_db(str(db_path))
+    conn.close()
+    cols = _columns(db_path)
+    assert "signal_date" in cols
+    assert "prediction_date" in cols
+
+
+def test_log_trade_persists_signal_and_prediction_date(tmp_path):
+    """log_trade writes both columns when caller supplies them — the
+    intended live path through daemon.py:_execute_entry."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-06",
+        "ticker": "NVDA",
+        "action": "ENTER",
+        "shares": 50,
+        "signal_date": "2026-05-02",        # last Saturday's signals.json
+        "prediction_date": "2026-05-06",    # today's predictions/latest
+    })
+    row = conn.execute(
+        "SELECT signal_date, prediction_date FROM trades WHERE ticker='NVDA'"
+    ).fetchone()
+    conn.close()
+    assert row == ("2026-05-02", "2026-05-06")
+
+
+def test_log_trade_dates_default_to_null(tmp_path):
+    """Legacy callers that don't pass either date get NULL, not a hard
+    fail — matches the back-compat policy on every other additive
+    column (sector, signal_trading_day, etc.)."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-06",
+        "ticker": "AAPL",
+        "action": "ENTER",
+        "shares": 100,
+    })
+    row = conn.execute(
+        "SELECT signal_date, prediction_date FROM trades WHERE ticker='AAPL'"
+    ).fetchone()
+    conn.close()
+    assert row == (None, None)
+
+
+def test_log_trade_prediction_date_null_for_strategy_exit(tmp_path):
+    """Strategy-driven intraday exits (ATR stop, profit-take, time-decay)
+    are NOT predictor-gated — the daemon's exit path leaves
+    prediction_date unset, which must persist as NULL. Distinct from
+    research-driven EXIT/REDUCE which carry both dates from the
+    urgent_exits_with_meta payload.
+    """
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-06",
+        "ticker": "MSFT",
+        "action": "EXIT",
+        "shares": 50,
+        "exit_reason": "intraday_atr_stop",
+        # signal_date / prediction_date intentionally omitted
+    })
+    row = conn.execute(
+        "SELECT signal_date, prediction_date, exit_reason "
+        "FROM trades WHERE ticker='MSFT'"
+    ).fetchone()
+    conn.close()
+    assert row == (None, None, "intraday_atr_stop")
+
+
+def test_signal_date_distinct_from_signal_trading_day(tmp_path):
+    """The two columns capture different facts: signal_date is the
+    signals.json filename date (artifact lineage); signal_trading_day
+    is the NYSE attribution day declared inside the payload. They CAN
+    differ when Research backfills a holiday or runs off-cadence.
+    """
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-06",
+        "ticker": "TSLA",
+        "action": "ENTER",
+        "shares": 30,
+        "signal_date": "2026-05-04",          # signals.json filename (off-cadence backfill)
+        "signal_trading_day": "2026-05-02",   # NYSE attribution day
+        "prediction_date": "2026-05-06",
+    })
+    row = conn.execute(
+        "SELECT signal_date, signal_trading_day, prediction_date "
+        "FROM trades WHERE ticker='TSLA'"
+    ).fetchone()
+    conn.close()
+    assert row == ("2026-05-04", "2026-05-02", "2026-05-06")


### PR DESCRIPTION
## Summary
Phase 2 transparency-inventory P1 — closes the *trade execution decisions* row in the gate checklist (ROADMAP entry added 2026-05-05 late evening).

Every fill is now traceable to:
- `signal_date` — the `signals/{date}/signals.json` filename date that drove the order
- `prediction_date` — the `predictor/predictions/{date}.json` filename date the GBM veto consulted (NULL when the order wasn't predictor-gated)

## Why
> "Every fill should be traceable to the *specific* signal and prediction that drove it."

Today `trades_full.csv` records ticker, action, shares, fill_price, entry trigger, sizing — but not which `(signal_date, prediction_date)` pair the daemon was acting on when it placed the order. Without this lineage, *"every fill traced from research to P&L"* is asserted but not query-checkable.

## Distinct from `signal_trading_day`

`signal_trading_day` (added 2026-04-24, date-conventions dual-tracking) is the **NYSE attribution day declared inside the signals payload**. The new `signal_date` is the **artifact filename**. They can differ when Research backfills a holiday or runs off-cadence. Both are now first-class columns:
- `signal_date` answers *"which signals.json file did we read?"*
- `signal_trading_day` answers *"which trading day did this signal apply to?"*

## Changes

| File | Change |
|---|---|
| `trade_logger.py` | Schema migration adds 2 nullable columns; `log_trade()` plumbs through `trade.get()` |
| `signal_reader.py` | `read_predictions()` returns `(dict, date)` tuple — surfaces `latest.json`'s top-level `date` field |
| `deciders.py` | `decide_entries` + `decide_exits_and_reduces` gain `predictions_date` (and `signals_date` for the exit path) kwargs; entries_with_meta + urgent_exits_with_meta carry both |
| `main.py` | `_read_signals` returns `predictions_date`; threaded through both planners |
| `daemon.py` | Entry + urgent-exit `log_trade` calls read `signal_date` / `prediction_date` off the order book payload |

### Subtle bug fix
`deciders.py:498` was setting `entries_with_meta["signal_date"] = run_date` — wrong when `signals_raw["date"]` differs (stale-fallback case where Research's Saturday SF was missed and `read_signals_with_fallback` walked back). Now sources from `signals_raw["date"]`.

### Strategy-driven intraday exits
ATR stops, profit-take, time-decay are NOT predictor-gated and don't originate from a signals.json EXIT signal — both fields stay NULL on these rows. Entry lineage already flows via `entry_trade_id`.

## Tests (14 new, 429/429 total)
- `test_trades_signal_prediction_date.py` — 6 tests (schema migration idempotent, log_trade plumbing, NULL defaults, distinct from `signal_trading_day`)
- `test_deciders_signal_prediction_date.py` — 5 tests (entries_with_meta + urgent_exits_with_meta carry both; signal_date sources from `signals_raw` not run_date)
- `test_signal_reader_predictions_date.py` — 3 tests (date surfaced; defensive None when payload missing field; `(empty, None)` on `NoSuchKey`)

## Test plan
- [x] All 429 executor tests pass
- [x] Schema migration idempotent (re-run `init_db` doesn't raise)
- [x] Decider parity tests still pass (no drift between direct decider call vs `_plan_entries` shell)
- [ ] Live verification — first ENTER on next trading day populates both columns:
  ```
  ae-trading "sqlite3 ~/alpha-engine/trades.db 'SELECT trade_id, ticker, signal_date, prediction_date, signal_trading_day FROM trades WHERE date=\"2026-05-07\" AND action=\"ENTER\" LIMIT 5; PRAGMA table_info(trades);'"
  ```
- [ ] CSV export carries both — uses `SELECT *` so flows automatically:
  ```
  aws s3 cp s3://alpha-engine-research/trades/trades_full.csv - | head -1 | tr ',' '\n' | grep -E 'signal_date|prediction_date'
  ```

## Backfill
Historical rows are a P3 follow-up — going-forward coverage is the gate per the ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)