### PR TITLE
feat(risk): structured veto/override/halt event log from risk_guard

### DIFF
--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -226,6 +226,13 @@ class EntryPlan:
     blocked: list[dict] = field(default_factory=list)
     n_entered: int = 0
     entries_with_meta: list[dict] = field(default_factory=list)
+    # Phase 2 transparency-inventory: structured veto/override events.
+    # Sibling of `blocked` — same family, different axis. `blocked` is the
+    # per-ENTER shadow-book row; `risk_events` is the structured-rule log
+    # consumed by `trade_logger.log_risk_event`. Free-text `block_reason`
+    # stays in `blocked` for evaluator backtesting; rule + value + threshold
+    # land here. The live shell (main.py) iterates and persists.
+    risk_events: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -308,6 +315,12 @@ def decide_entries(
     """
     plan = EntryPlan()
 
+    # signal_date is the signals.json filename date the orders sourced from.
+    # Distinct from signal_trading_day (NYSE attribution day inside the
+    # payload). Both stamped on every structured risk event for artifact
+    # lineage parity with PR #138's trades.signal_date column.
+    signals_date = signals_raw.get("date", run_date) if signals_raw else run_date
+
     for sig in enter_signals:
         ticker = sig["ticker"]
         sector = sig.get("sector", "Technology")
@@ -323,6 +336,19 @@ def decide_entries(
             "conviction": sig.get("conviction"),
             "market_regime": market_regime,
             "portfolio_nav": portfolio_nav,
+        }
+
+        # Structured-event base: every risk event stamps the same lineage
+        # fields (date, ticker, sector, market_regime, signal_date,
+        # prediction_date) — rule-specific fields (event_type, rule, value,
+        # threshold, reason) are merged in at each emit site.
+        _event_base = {
+            "date": run_date,
+            "ticker": ticker,
+            "sector": sector,
+            "market_regime": market_regime,
+            "signal_date": signals_date,
+            "prediction_date": predictions_date,
         }
 
         if ticker in current_positions:
@@ -341,6 +367,13 @@ def decide_entries(
                     reason = f"momentum gate: 20d={momentum_20d:.1f}% < {mom_threshold}%"
                     logger.info(f"SKIP ENTER {ticker} — {reason}")
                     plan.blocked.append({**_shadow_base, "block_reason": reason})
+                    plan.risk_events.append({**_event_base,
+                        "event_type": "veto",
+                        "rule": "momentum_gate",
+                        "reason": reason,
+                        "value": float(momentum_20d) / 100.0,
+                        "threshold": float(mom_threshold) / 100.0,
+                    })
                     continue
 
         # Earnings proximity warning (logs only)
@@ -400,10 +433,13 @@ def decide_entries(
             })
             continue
 
-        # GBM veto
+        # GBM veto — predictor overriding research's ENTER signal.
+        # event_type="override" (predictor overrides research, distinct
+        # from a risk-rule veto).
         if pred_data.get("gbm_veto"):
+            predicted_alpha = pred_data.get("predicted_alpha", 0)
             reason = (
-                f"GBM veto: α={pred_data.get('predicted_alpha', 0):.2%}, "
+                f"GBM veto: α={predicted_alpha:.2%}, "
                 f"rank={pred_data.get('combined_rank')}"
             )
             logger.info(f"VETO {ticker} — {reason}")
@@ -417,10 +453,28 @@ def decide_entries(
                 "predicted_direction": pred_data.get("predicted_direction"),
                 "prediction_confidence": pred_data.get("prediction_confidence"),
             })
+            plan.risk_events.append({**_event_base,
+                "event_type": "override",
+                "rule": "predictor_gbm_veto",
+                "reason": reason,
+                "value": float(predicted_alpha) if predicted_alpha is not None else None,
+                "context": {
+                    "predicted_direction": pred_data.get("predicted_direction"),
+                    "prediction_confidence": pred_data.get("prediction_confidence"),
+                    "combined_rank": pred_data.get("combined_rank"),
+                },
+            })
             continue
 
         sig_with_sector = {**sig, "sector_rating": sector_rating_str}
 
+        # Per-ticker events sink — risk_guard appends one event per veto
+        # rule (min_score, max_position, bear_underweight, max_sector,
+        # max_equity, correlation). Drawdown halt/throttle is emitted
+        # once at the portfolio level by the caller; risk_guard does not
+        # propagate `events` to its inner compute_drawdown_multiplier
+        # call.
+        check_events: list[dict] = []
         approved, reason = check_order(
             ticker=ticker,
             action="ENTER",
@@ -433,7 +487,16 @@ def decide_entries(
             signal=sig_with_sector,
             config=config,
             price_histories=price_histories,
+            events=check_events,
         )
+        # Merge per-ticker risk-guard events into the plan-level log,
+        # stamping the lineage fields that risk_guard doesn't know about
+        # (signal_date, prediction_date).
+        for ev in check_events:
+            ev.setdefault("date", run_date)
+            ev.setdefault("signal_date", signals_date)
+            ev.setdefault("prediction_date", predictions_date)
+            plan.risk_events.append(ev)
 
         if not approved:
             logger.info(f"BLOCKED {ticker} — {reason}")

--- a/executor/main.py
+++ b/executor/main.py
@@ -49,7 +49,14 @@ from executor.price_cache import (
     load_feature_coverage,
     load_price_histories,
 )
-from executor.trade_logger import backup_to_s3, get_entry_dates, init_db, log_trade, log_shadow_book_block
+from executor.trade_logger import (
+    backup_to_s3,
+    get_entry_dates,
+    init_db,
+    log_risk_event,
+    log_shadow_book_block,
+    log_trade,
+)
 
 from alpha_engine_lib.logging import setup_logging
 # Suppress benign IB Error codes that don't represent real failures:
@@ -413,7 +420,7 @@ def _plan_entries(
     dry_run: bool,
     simulate: bool,
     predictions_date: str | None = None,
-) -> tuple[int, list[dict], list[dict]]:
+) -> tuple[int, list[dict], list[dict], list[dict]]:
     """Live-shell wrapper around ``executor.deciders.decide_entries``.
 
     Resolves ``prices_now`` from the IB / sim client, calls the pure
@@ -424,8 +431,10 @@ def _plan_entries(
         ``entries_with_meta`` to write the daemon's order book.
       * dry_run: log only, no side effects.
 
-    Returns the (n_entered, orders, blocked) tuple for back-compat with
-    callers that pre-date the deciders extraction.
+    Returns ``(n_entered, orders, blocked, risk_events)``. The fourth
+    element is the structured veto/override log emitted by
+    ``decide_entries`` (Phase 2 transparency-inventory). Caller persists
+    via ``trade_logger.log_risk_event``.
     """
     from executor.deciders import decide_entries
 
@@ -477,7 +486,7 @@ def _plan_entries(
         for entry in plan.entries_with_meta:
             ob.add_entry(entry)
 
-    return plan.n_entered, plan.orders, plan.blocked
+    return plan.n_entered, plan.orders, plan.blocked, plan.risk_events
 
 
 def _plan_exits_and_reduces(
@@ -931,9 +940,29 @@ def run(
             logger.info(f"Entry dates resolved for {len(entry_dates)}/{len(current_positions)} positions")
     
         # ── 2c. Compute graduated drawdown multiplier ──────────────────────────
-        dd_multiplier, dd_reason = compute_drawdown_multiplier(portfolio_nav, peak_nav, config)
+        # Pass an events sink so any halt/throttle event lands in
+        # `risk_events` ONCE per planning cycle (the per-ticker check_order
+        # call deliberately does NOT propagate events to its inner
+        # compute_drawdown_multiplier — see risk_guard.py:check_order).
+        dd_events: list[dict] = []
+        dd_multiplier, dd_reason = compute_drawdown_multiplier(
+            portfolio_nav, peak_nav, config, events=dd_events,
+        )
         if dd_multiplier < 1.0:
             logger.info(f"Drawdown tier active: {dd_reason}")
+        # Stamp lineage + persist immediately. Any subsequent per-ticker
+        # vetoes get persisted alongside after _plan_entries returns.
+        if conn and dd_events:
+            signals_date_for_events = signals_raw.get("date", run_date) if signals_raw else run_date
+            for ev in dd_events:
+                ev.setdefault("date", run_date)
+                ev.setdefault("market_regime", market_regime)
+                ev.setdefault("signal_date", signals_date_for_events)
+                ev.setdefault("prediction_date", predictions_date)
+                try:
+                    log_risk_event(conn, ev)
+                except Exception as e:
+                    logger.debug("risk_event log failed (drawdown): %s", e)
     
         # ── 2d. Strategy layer: evaluate exit rules on held positions ──────────
         strategy_config = load_strategy_config(config)
@@ -1137,7 +1166,7 @@ def run(
                             )
 
         # ── 3. Process ENTER signals ─────────────────────────────────────────────
-        n_entered, entry_orders, blocked_entries = _plan_entries(
+        n_entered, entry_orders, blocked_entries, plan_risk_events = _plan_entries(
             enter_signals=enter_signals,
             signals_raw=signals_raw,
             predictions_by_ticker=predictions_by_ticker,
@@ -1171,6 +1200,22 @@ def run(
                     log_shadow_book_block(conn, be)
                 except Exception as e:
                     logger.debug("Shadow book log failed for %s: %s", be.get("ticker"), e)
+
+        # Persist structured veto/override events (Phase 2 transparency-
+        # inventory — *risk decisions* row). Sibling of the shadow-book
+        # log: same family, different axis. Free-text block_reason stays
+        # in shadow_book; rule + value + threshold lands in risk_events.
+        if conn and plan_risk_events:
+            for ev in plan_risk_events:
+                try:
+                    log_risk_event(conn, ev)
+                except Exception as e:
+                    logger.debug(
+                        "risk_event log failed (%s/%s): %s",
+                        ev.get("event_type"),
+                        ev.get("rule"),
+                        e,
+                    )
 
         # ── 4–5. Process EXIT and REDUCE signals ────────────────────────────────
         exit_orders = _plan_exits_and_reduces(

--- a/executor/risk_guard.py
+++ b/executor/risk_guard.py
@@ -8,6 +8,15 @@ Graduated drawdown response (added 2026-03-14):
   Instead of a binary -8% circuit breaker, position sizing scales down
   through tiers as drawdown deepens. The hard halt at -8% is preserved
   as the final tier.
+
+Structured risk-event emission (added 2026-05-06, ROADMAP Phase 2 transparency
+inventory — *risk decisions* row):
+  `check_order` and `compute_drawdown_multiplier` accept an optional
+  `events: list[dict] | None` kwarg. When provided, each veto/halt/throttle
+  appends a structured dict (rule + value + threshold + reason) to the list,
+  alongside the existing free-text reason returned to the caller. The
+  caller persists each event via `trade_logger.log_risk_event`. Default
+  `events=None` preserves the existing 2-tuple return contract.
 """
 
 from __future__ import annotations
@@ -21,11 +30,18 @@ from executor.strategies.config import load_strategy_config
 logger = logging.getLogger(__name__)
 
 
+def _emit(events: list[dict] | None, event: dict) -> None:
+    """Append a structured event to the caller's sink, or no-op if None."""
+    if events is not None:
+        events.append(event)
+
+
 def check_correlation(
     ticker: str,
     current_positions: dict[str, dict],
     price_histories: dict[str, pd.DataFrame],
     config: dict,
+    events: list[dict] | None = None,
 ) -> tuple[bool, str]:
     """
     Check if a new entry is too correlated with existing same-sector positions.
@@ -100,9 +116,20 @@ def check_correlation(
 
     if mean_corr > threshold:
         tickers_str = ", ".join(f"{t}({c:.2f})" for t, c in correlations)
-        return False, (
+        reason = (
             f"Mean correlation {mean_corr:.2f} > {threshold:.2f} with same-sector positions: {tickers_str}"
         )
+        _emit(events, {
+            "event_type": "veto",
+            "rule": "correlation",
+            "ticker": ticker,
+            "sector": candidate_sector,
+            "reason": reason,
+            "value": float(mean_corr),
+            "threshold": float(threshold),
+            "context": {"per_ticker": [(t, round(c, 4)) for t, c in correlations]},
+        })
+        return False, reason
 
     return True, f"correlation check passed (mean={mean_corr:.2f}, threshold={threshold:.2f})"
 
@@ -111,6 +138,7 @@ def compute_drawdown_multiplier(
     portfolio_nav: float,
     peak_nav: float,
     config: dict,
+    events: list[dict] | None = None,
 ) -> tuple[float, str]:
     """
     Compute position sizing multiplier based on current drawdown tier.
@@ -118,6 +146,10 @@ def compute_drawdown_multiplier(
     Returns:
         (multiplier, description)
         multiplier=0.0 means full halt (circuit breaker).
+
+    When `events` is supplied, appends a structured `halt` event on
+    circuit-breaker fire or a `throttle` event when an active tier is
+    reducing sizing below 1.0. No event is emitted at full sizing.
     """
     if peak_nav <= 0:
         return 1.0, "no peak NAV recorded"
@@ -130,7 +162,16 @@ def compute_drawdown_multiplier(
         # Fall back to original binary circuit breaker
         threshold = -config.get("drawdown_circuit_breaker", 0.08)
         if drawdown <= threshold:
-            return 0.0, f"circuit breaker: {drawdown:.1%} from peak (limit {threshold:.1%})"
+            reason = f"circuit breaker: {drawdown:.1%} from peak (limit {threshold:.1%})"
+            _emit(events, {
+                "event_type": "halt",
+                "rule": "drawdown_halt",
+                "reason": reason,
+                "value": float(drawdown),
+                "threshold": float(threshold),
+                "context": {"graduated_disabled": True},
+            })
+            return 0.0, reason
         return 1.0, f"drawdown {drawdown:.1%} — within limit"
 
     tiers = strategy_cfg.get("drawdown_tiers", [])
@@ -139,16 +180,41 @@ def compute_drawdown_multiplier(
     # Walk through tiers; the last tier whose threshold is breached applies.
     active_multiplier = 1.0
     active_desc = f"drawdown {drawdown:.1%} — full sizing"
+    active_threshold: float | None = None
+    active_tier_desc: str | None = None
 
     for threshold, multiplier, description in tiers:
         if drawdown <= threshold:
             active_multiplier = multiplier
             active_desc = f"drawdown {drawdown:.1%} — {description} (multiplier={multiplier})"
+            active_threshold = float(threshold)
+            active_tier_desc = description
 
     # Hard halt at the deepest configured tier (circuit breaker preserved)
     hard_halt = -config.get("drawdown_circuit_breaker", 0.08)
     if drawdown <= hard_halt:
-        return 0.0, f"circuit breaker: {drawdown:.1%} from peak (limit {hard_halt:.1%})"
+        reason = f"circuit breaker: {drawdown:.1%} from peak (limit {hard_halt:.1%})"
+        _emit(events, {
+            "event_type": "halt",
+            "rule": "drawdown_halt",
+            "reason": reason,
+            "value": float(drawdown),
+            "threshold": float(hard_halt),
+        })
+        return 0.0, reason
+
+    if active_multiplier < 1.0:
+        _emit(events, {
+            "event_type": "throttle",
+            "rule": "drawdown_tier_throttle",
+            "reason": active_desc,
+            "value": float(drawdown),
+            "threshold": active_threshold,
+            "context": {
+                "multiplier": float(active_multiplier),
+                "tier_description": active_tier_desc,
+            },
+        })
 
     return active_multiplier, active_desc
 
@@ -165,6 +231,7 @@ def check_order(
     signal: dict,
     config: dict,
     price_histories: dict[str, pd.DataFrame] | None = None,
+    events: list[dict] | None = None,
 ) -> tuple[bool, str]:
     """
     Validate an order against all risk rules.
@@ -180,12 +247,25 @@ def check_order(
         market_regime: "bull" | "neutral" | "bear"
         signal: full signal entry from signals.json
         config: loaded from config/risk.yaml
+        events: optional sink for structured veto/halt/throttle events. The
+            callable persists each entry via `trade_logger.log_risk_event`.
 
     Returns:
         (approved, reason)
     """
+    base_event_ctx = {
+        "ticker": ticker,
+        "sector": sector,
+        "market_regime": market_regime,
+    }
+
     if portfolio_nav <= 0:
-        return False, "Portfolio NAV is zero or negative"
+        reason = "Portfolio NAV is zero or negative"
+        _emit(events, {**base_event_ctx,
+            "event_type": "veto", "rule": "nav_nonpositive",
+            "reason": reason, "value": float(portfolio_nav), "threshold": 0.0,
+        })
+        return False, reason
 
     position_pct = dollar_size / portfolio_nav
 
@@ -199,14 +279,26 @@ def check_order(
     score = signal.get("score") or 0
     min_score = config.get("min_score_to_enter", 70)
     if score < min_score:
-        return False, f"Score {score:.1f} < minimum {min_score}"
+        reason = f"Score {score:.1f} < minimum {min_score}"
+        _emit(events, {**base_event_ctx,
+            "event_type": "veto", "rule": "min_score",
+            "reason": reason, "value": float(score), "threshold": float(min_score),
+        })
+        return False, reason
 
     # 2. Conviction: no hard gate — declining conviction is handled by position
     #    sizer (0.7x multiplier).  Research conviction is weekly, too stale to
     #    block daily entries that the predictor scores positively.
 
-    # 3. Graduated drawdown response (replaces binary circuit breaker)
-    dd_multiplier, dd_reason = compute_drawdown_multiplier(portfolio_nav, peak_nav, config)
+    # 3. Graduated drawdown response (replaces binary circuit breaker).
+    #    Drawdown halt/throttle is portfolio-state — the caller emits the
+    #    structured event ONCE per planning cycle (see main.py's call to
+    #    compute_drawdown_multiplier at the top of the planner). Don't
+    #    propagate `events` here, or we'd append one halt/throttle event
+    #    per ticker checked.
+    dd_multiplier, dd_reason = compute_drawdown_multiplier(
+        portfolio_nav, peak_nav, config,
+    )
     if dd_multiplier <= 0.0:
         return False, f"Drawdown halt: {dd_reason}"
     if dd_multiplier < 1.0:
@@ -219,13 +311,26 @@ def check_order(
         else config.get("max_position_pct", 0.05)
     )
     if position_pct > effective_max_pct:
-        return False, f"Position size {position_pct:.1%} exceeds max {effective_max_pct:.1%}"
+        reason = f"Position size {position_pct:.1%} exceeds max {effective_max_pct:.1%}"
+        _emit(events, {**base_event_ctx,
+            "event_type": "veto", "rule": "max_position",
+            "reason": reason, "value": float(position_pct),
+            "threshold": float(effective_max_pct),
+            "context": {"dollar_size": float(dollar_size), "portfolio_nav": float(portfolio_nav)},
+        })
+        return False, reason
 
     # 5. Bear regime: block new entries in underweight sectors
     if market_regime == "bear" and config.get("bear_block_underweight", True):
         sector_rating_str = signal.get("sector_rating", "market_weight")
         if sector_rating_str == "underweight":
-            return False, f"Bear regime: new entries blocked in underweight sector ({sector})"
+            reason = f"Bear regime: new entries blocked in underweight sector ({sector})"
+            _emit(events, {**base_event_ctx,
+                "event_type": "veto", "rule": "bear_underweight",
+                "reason": reason,
+                "context": {"sector_rating": sector_rating_str},
+            })
+            return False, reason
 
     # 6. Max sector exposure
     sector_exposure = sum(
@@ -236,19 +341,36 @@ def check_order(
     sector_pct = (sector_exposure + dollar_size) / portfolio_nav
     max_sector = config.get("max_sector_pct", 0.25)
     if sector_pct > max_sector:
-        return False, f"Sector exposure {sector_pct:.1%} would exceed max {max_sector:.1%} for {sector}"
+        reason = f"Sector exposure {sector_pct:.1%} would exceed max {max_sector:.1%} for {sector}"
+        _emit(events, {**base_event_ctx,
+            "event_type": "veto", "rule": "max_sector",
+            "reason": reason, "value": float(sector_pct),
+            "threshold": float(max_sector),
+            "context": {
+                "existing_sector_exposure": float(sector_exposure),
+                "added_dollar_size": float(dollar_size),
+            },
+        })
+        return False, reason
 
     # 7. Max total equity exposure
     total_equity = sum(pos["market_value"] for pos in current_positions.values())
     equity_pct = (total_equity + dollar_size) / portfolio_nav
     max_equity = config.get("max_equity_pct", 0.90)
     if equity_pct > max_equity:
-        return False, f"Total equity exposure {equity_pct:.1%} would exceed max {max_equity:.1%}"
+        reason = f"Total equity exposure {equity_pct:.1%} would exceed max {max_equity:.1%}"
+        _emit(events, {**base_event_ctx,
+            "event_type": "veto", "rule": "max_equity",
+            "reason": reason, "value": float(equity_pct),
+            "threshold": float(max_equity),
+            "context": {"existing_equity": float(total_equity)},
+        })
+        return False, reason
 
     # 8. Cross-ticker correlation
     if price_histories is not None:
         corr_approved, corr_reason = check_correlation(
-            ticker, current_positions, price_histories, config,
+            ticker, current_positions, price_histories, config, events=events,
         )
         if not corr_approved:
             return False, corr_reason

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -136,13 +136,52 @@ CREATE TABLE IF NOT EXISTS eod_pnl (
 """
 
 
+# Phase 2 transparency-inventory: structured veto/override/halt event log.
+# Closes the *risk decisions* row in the gate checklist (ROADMAP 2026-05-05).
+# `executor_shadow_book` is the ENTER-block sibling — same family, different
+# axis. Shadow book is keyed per-ticker per-day with free-text `block_reason`
+# for downstream evaluator backtesting. `risk_events` is the structured-rule
+# log that answers *"how often is rule X firing, and how close was the
+# measured value to the threshold?"* — the answer the inventory checklist
+# requires per gate.
+CREATE_RISK_EVENTS_TABLE = """
+CREATE TABLE IF NOT EXISTS risk_events (
+    event_id          TEXT PRIMARY KEY,
+    date              TEXT NOT NULL,
+    trading_day       TEXT,
+    event_type        TEXT NOT NULL,
+    rule              TEXT NOT NULL,
+    ticker            TEXT,
+    sector            TEXT,
+    reason            TEXT,
+    value             REAL,
+    threshold         REAL,
+    market_regime     TEXT,
+    signal_date       TEXT,
+    prediction_date   TEXT,
+    context_json      TEXT,
+    created_at        TEXT NOT NULL
+);
+"""
+
+_RISK_EVENTS_MIGRATIONS: list[str] = [
+    # Placeholder — future column adds follow the same idempotent pattern as
+    # `_TRADES_MIGRATIONS` (catch "duplicate column" on re-run).
+]
+
+
 def init_db(db_path: str) -> sqlite3.Connection:
     """Create tables if they don't exist and run any pending migrations. Returns open connection."""
     conn = sqlite3.connect(db_path)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA busy_timeout=5000")
-    conn.executescript(CREATE_TRADES_TABLE + CREATE_EOD_TABLE + CREATE_SHADOW_BOOK_TABLE)
+    conn.executescript(
+        CREATE_TRADES_TABLE
+        + CREATE_EOD_TABLE
+        + CREATE_SHADOW_BOOK_TABLE
+        + CREATE_RISK_EVENTS_TABLE
+    )
     for migration in _TRADES_MIGRATIONS:
         try:
             conn.execute(migration)
@@ -154,6 +193,16 @@ def init_db(db_path: str) -> sqlite3.Connection:
                 logging.getLogger(__name__).error("Migration failed: %s — %s", migration.strip()[:80], e)
                 raise
     for migration in _EOD_MIGRATIONS:
+        try:
+            conn.execute(migration)
+            conn.commit()
+        except sqlite3.OperationalError as e:
+            if "duplicate column" in str(e).lower() or "already exists" in str(e).lower():
+                pass  # Column already exists — expected on re-run
+            else:
+                logging.getLogger(__name__).error("Migration failed: %s — %s", migration.strip()[:80], e)
+                raise
+    for migration in _RISK_EVENTS_MIGRATIONS:
         try:
             conn.execute(migration)
             conn.commit()
@@ -299,6 +348,68 @@ def log_shadow_book_block(conn: sqlite3.Connection, entry: dict) -> str:
     conn.commit()
     logger.info("Shadow book: BLOCKED %s — %s | id=%s", entry["ticker"], entry["block_reason"], shadow_id)
     return shadow_id
+
+
+def log_risk_event(conn: sqlite3.Connection, event: dict) -> str:
+    """
+    Insert a structured veto/override/halt/throttle event. Returns event_id.
+
+    Required keys: date, event_type, rule.
+    Optional keys: trading_day, ticker, sector, reason, value, threshold,
+                   market_regime, signal_date, prediction_date, context.
+
+    `context` (dict) is serialized to context_json. Use it for rule-specific
+    extra context that doesn't justify a top-level column (e.g., per-ticker
+    correlation map for the correlation rule, breached tier description for
+    drawdown_tier_throttle). Keep it small — this is a structured log, not
+    a debug dump.
+    """
+    import json
+    event_id = str(uuid.uuid4())
+    trading_day = event.get("trading_day")
+    if trading_day is None:
+        try:
+            from alpha_engine_lib.dates import now_dual
+            trading_day = now_dual().trading_day
+        except Exception:
+            trading_day = None
+    context = event.get("context")
+    context_json = json.dumps(context) if context else None
+    conn.execute(
+        """
+        INSERT INTO risk_events (
+            event_id, date, trading_day, event_type, rule, ticker, sector,
+            reason, value, threshold, market_regime, signal_date,
+            prediction_date, context_json, created_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+        """,
+        (
+            event_id,
+            event["date"],
+            trading_day,
+            event["event_type"],
+            event["rule"],
+            event.get("ticker"),
+            event.get("sector"),
+            event.get("reason"),
+            event.get("value"),
+            event.get("threshold"),
+            event.get("market_regime"),
+            event.get("signal_date"),
+            event.get("prediction_date"),
+            context_json,
+            datetime.now(timezone.utc).isoformat(),
+        ),
+    )
+    conn.commit()
+    logger.info(
+        "Risk event logged: %s/%s ticker=%s | id=%s",
+        event["event_type"],
+        event["rule"],
+        event.get("ticker") or "-",
+        event_id,
+    )
+    return event_id
 
 
 def log_eod(conn: sqlite3.Connection, eod: dict) -> None:

--- a/tests/test_decider_parity.py
+++ b/tests/test_decider_parity.py
@@ -178,7 +178,7 @@ class TestDecideEntriesParity:
         # seeded with prices so ibkr.get_current_price returns the same
         # values the direct call used.
         sim_client = SimulatedIBKRClient(prices=dict(prices_now), nav=inputs["portfolio_nav"])
-        n_b, orders_b, blocked_b = _plan_entries(
+        n_b, orders_b, blocked_b, _events_b = _plan_entries(
             enter_signals=inputs["enter_signals"],
             signals_raw=inputs["signals_raw"],
             predictions_by_ticker=inputs["predictions_by_ticker"],

--- a/tests/test_deciders_risk_events.py
+++ b/tests/test_deciders_risk_events.py
@@ -1,0 +1,267 @@
+"""Tests that decide_entries accumulates structured risk events on
+plan.risk_events for momentum-gate vetoes, GBM-veto overrides, and
+risk_guard rule vetoes. The live shell (main._plan_entries) returns
+this list to the caller for persistence via trade_logger.log_risk_event.
+
+Phase 2 transparency-inventory — closes the *risk decisions* row.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from executor.deciders import decide_entries
+
+
+def _df_history(n_bars: int = 100, base: float = 100.0,
+                trend: float = 0.1) -> pd.DataFrame:
+    """Construct a synthetic OHLCV history with configurable trend.
+
+    `trend` of 0.1 = +0.1/bar (uptrend, momentum gate passes).
+    `trend` of -0.5 = aggressive downtrend (momentum gate fails).
+    """
+    return pd.DataFrame(
+        {
+            "open":  [base + i * trend for i in range(n_bars)],
+            "high":  [base + i * trend + 0.5 for i in range(n_bars)],
+            "low":   [base + i * trend - 0.5 for i in range(n_bars)],
+            "close": [base + i * trend + 0.2 for i in range(n_bars)],
+        },
+        index=pd.bdate_range("2024-01-01", periods=n_bars),
+    )
+
+
+def _base_config(**overrides):
+    cfg = {
+        "min_score_to_enter": 70,
+        "max_position_pct": 0.05,
+        "bear_max_position_pct": 0.025,
+        "max_sector_pct": 0.25,
+        "max_equity_pct": 0.90,
+        "drawdown_circuit_breaker": 0.08,
+        "bear_block_underweight": True,
+        "earnings_proximity_warning_days": 2,
+        "momentum_gate_enabled": False,
+        "momentum_gate_threshold": -5.0,
+        "atr_sizing_enabled": True,
+        "correlation_block_enabled": False,
+        "coverage_sizing_enabled": False,
+        "reduce_fraction": 0.50,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": True,
+                "tiers": [(-0.02, 1.00, "tier1"), (-0.04, 0.50, "tier2")],
+            },
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _strategy_config():
+    return {
+        "intraday_pullback_atr_multiple": 1.0,
+        "intraday_vwap_discount_pct": 0.005,
+        "intraday_support_lookback_days": 20,
+        "drawdown_forced_exit_enabled": False,
+    }
+
+
+def _make_inputs(*, signals_date: str, run_date: str, enter_signals: list[dict],
+                 predictions_by_ticker: dict | None = None,
+                 config_overrides: dict | None = None,
+                 price_histories: dict | None = None):
+    sig_payload = {
+        "date": signals_date,
+        "market_regime": "neutral",
+        "sector_ratings": {"Technology": {"rating": "overweight"},
+                           "Defensives": {"rating": "underweight"}},
+        "enter": enter_signals,
+        "exit": [], "reduce": [], "hold": [],
+        "universe": enter_signals,
+        "buy_candidates": enter_signals,
+    }
+    tickers = sorted({s["ticker"] for s in enter_signals} | {
+        "SPY", "XLK", "XLV", "XLF", "XLY", "XLP", "XLE",
+        "XLU", "XLRE", "XLB", "XLI", "XLC",
+    })
+    return {
+        "enter_signals": enter_signals,
+        "signals_raw": sig_payload,
+        "predictions_by_ticker": predictions_by_ticker or {},
+        "config": _base_config(**(config_overrides or {})),
+        "strategy_config": _strategy_config(),
+        "market_regime": "neutral",
+        "sector_ratings": sig_payload["sector_ratings"],
+        "portfolio_nav": 1_000_000.0,
+        "peak_nav": 1_000_000.0,
+        "current_positions": {},
+        "prices_now": {t: 100.0 for t in tickers},
+        "price_histories": price_histories or {
+            t: _df_history(base=100 + i) for i, t in enumerate(tickers)
+        },
+        "atr_map": {t: 0.02 for t in tickers},
+        "vwap_map": {t: 100.0 for t in tickers},
+        "coverage_map": {t: 1.0 for t in tickers},
+        "dd_multiplier": 1.0,
+        "signal_age_days": 0,
+        "earnings_by_ticker": {},
+        "run_date": run_date,
+    }
+
+
+# ── Approval path ────────────────────────────────────────────────────────────
+
+
+def test_approved_enter_emits_no_risk_events():
+    enter = [{"ticker": "NVDA", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
+              "rating": "BUY", "price_target_upside": 0.20}]
+    inputs = _make_inputs(
+        signals_date="2026-05-02", run_date="2026-05-02",
+        enter_signals=enter,
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 1
+    assert plan.risk_events == []
+
+
+# ── Momentum-gate veto ───────────────────────────────────────────────────────
+
+
+def test_momentum_gate_emits_veto_event():
+    enter = [{"ticker": "NVDA", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
+              "rating": "BUY", "price_target_upside": 0.20}]
+    # Aggressive downtrend pushes 20d momentum well below the -5% gate.
+    bad_history = _df_history(trend=-0.5)
+    histories = {"NVDA": bad_history}
+    # Pad in flat histories for ETFs so price_histories isn't sparse.
+    for t in ("SPY", "XLK", "XLV", "XLF", "XLY"):
+        histories[t] = _df_history()
+    inputs = _make_inputs(
+        signals_date="2026-05-06", run_date="2026-05-06",
+        enter_signals=enter,
+        config_overrides={"momentum_gate_enabled": True,
+                          "momentum_gate_threshold": -5.0},
+        price_histories=histories,
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 0
+    assert len(plan.risk_events) == 1
+    ev = plan.risk_events[0]
+    assert ev["event_type"] == "veto"
+    assert ev["rule"] == "momentum_gate"
+    assert ev["ticker"] == "NVDA"
+    assert ev["signal_date"] == "2026-05-06"
+    assert ev["prediction_date"] == "2026-05-06"
+
+
+# ── Predictor GBM veto override ─────────────────────────────────────────────
+
+
+def test_gbm_veto_emits_override_event():
+    enter = [{"ticker": "TSLA", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
+              "rating": "BUY", "price_target_upside": 0.20}]
+    predictions = {"TSLA": {
+        "gbm_veto": True,
+        "predicted_alpha": -0.018,
+        "predicted_direction": "DOWN",
+        "prediction_confidence": 0.72,
+        "combined_rank": 412,
+    }}
+    inputs = _make_inputs(
+        signals_date="2026-05-02", run_date="2026-05-02",
+        enter_signals=enter,
+        predictions_by_ticker=predictions,
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 0
+    assert len(plan.risk_events) == 1
+    ev = plan.risk_events[0]
+    assert ev["event_type"] == "override"
+    assert ev["rule"] == "predictor_gbm_veto"
+    assert ev["ticker"] == "TSLA"
+    assert ev["value"] == -0.018
+    assert ev["context"]["predicted_direction"] == "DOWN"
+    assert ev["context"]["combined_rank"] == 412
+    assert ev["signal_date"] == "2026-05-02"
+    assert ev["prediction_date"] == "2026-05-06"
+
+
+# ── Risk-guard rule veto threaded through ───────────────────────────────────
+
+
+def test_min_score_veto_threads_through_to_plan_events():
+    enter = [{"ticker": "KO", "signal": "ENTER", "score": 60,  # below 70
+              "conviction": "stable", "sector": "Defensives",
+              "rating": "BUY", "price_target_upside": 0.10}]
+    inputs = _make_inputs(
+        signals_date="2026-05-02", run_date="2026-05-02",
+        enter_signals=enter,
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 0
+    assert len(plan.risk_events) == 1
+    ev = plan.risk_events[0]
+    assert ev["event_type"] == "veto"
+    assert ev["rule"] == "min_score"
+    assert ev["ticker"] == "KO"
+    assert ev["value"] == 60
+    assert ev["threshold"] == 70
+    # Lineage stamped by deciders even though risk_guard didn't know.
+    assert ev["signal_date"] == "2026-05-02"
+    assert ev["prediction_date"] == "2026-05-06"
+
+
+def test_max_sector_veto_threads_through():
+    enter = [{"ticker": "NVDA", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
+              "rating": "BUY", "price_target_upside": 0.20}]
+    inputs = _make_inputs(
+        signals_date="2026-05-02", run_date="2026-05-02",
+        enter_signals=enter,
+    )
+    # Push existing Technology exposure over the cap so the order breaches.
+    inputs["current_positions"] = {
+        "MSFT": {"market_value": 200_000, "sector": "Technology"},
+        "GOOG": {"market_value": 50_000, "sector": "Technology"},
+    }
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 0
+    rules = [ev["rule"] for ev in plan.risk_events]
+    assert "max_sector" in rules
+    sector_ev = next(ev for ev in plan.risk_events if ev["rule"] == "max_sector")
+    assert sector_ev["sector"] == "Technology"
+    assert sector_ev["signal_date"] == "2026-05-02"
+
+
+# ── Multi-ticker accumulation ───────────────────────────────────────────────
+
+
+def test_multiple_blocked_tickers_all_emit_events():
+    enter = [
+        {"ticker": "KO",  "signal": "ENTER", "score": 50,  # min_score veto
+         "conviction": "stable", "sector": "Defensives",
+         "rating": "BUY", "price_target_upside": 0.10},
+        {"ticker": "TSLA", "signal": "ENTER", "score": 85,  # gbm_veto override
+         "conviction": "rising", "sector": "Technology",
+         "rating": "BUY", "price_target_upside": 0.20},
+    ]
+    predictions = {"TSLA": {"gbm_veto": True, "predicted_alpha": -0.02,
+                            "predicted_direction": "DOWN",
+                            "prediction_confidence": 0.7,
+                            "combined_rank": 500}}
+    inputs = _make_inputs(
+        signals_date="2026-05-02", run_date="2026-05-02",
+        enter_signals=enter,
+        predictions_by_ticker=predictions,
+    )
+    plan = decide_entries(predictions_date="2026-05-06", **inputs)
+    assert plan.n_entered == 0
+    assert len(plan.risk_events) == 2
+    by_ticker = {ev["ticker"]: ev for ev in plan.risk_events}
+    assert by_ticker["KO"]["rule"] == "min_score"
+    assert by_ticker["KO"]["event_type"] == "veto"
+    assert by_ticker["TSLA"]["rule"] == "predictor_gbm_veto"
+    assert by_ticker["TSLA"]["event_type"] == "override"

--- a/tests/test_risk_events_schema.py
+++ b/tests/test_risk_events_schema.py
@@ -1,0 +1,151 @@
+"""Schema + log_risk_event tests for the structured risk-event log.
+
+Phase 2 transparency-inventory: closes the *risk decisions* row.
+Sibling of `executor_shadow_book` — same family, different axis.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from executor.trade_logger import init_db, log_risk_event
+
+
+@pytest.fixture
+def conn():
+    db_path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+    c = init_db(db_path)
+    yield c
+    c.close()
+    os.unlink(db_path)
+
+
+class TestRiskEventsSchema:
+    def test_table_created_on_init_db(self, conn):
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='risk_events'"
+        ).fetchall()
+        assert rows, "risk_events table should exist after init_db"
+
+    def test_init_db_idempotent(self):
+        """Re-running init_db on the same path must not raise."""
+        db_path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            c1 = init_db(db_path)
+            c1.close()
+            # Second init on the same file — must be a no-op for the schema.
+            c2 = init_db(db_path)
+            c2.close()
+        finally:
+            os.unlink(db_path)
+
+    def test_columns_present(self, conn):
+        cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(risk_events)").fetchall()
+        }
+        expected = {
+            "event_id", "date", "trading_day", "event_type", "rule",
+            "ticker", "sector", "reason", "value", "threshold",
+            "market_regime", "signal_date", "prediction_date",
+            "context_json", "created_at",
+        }
+        assert expected.issubset(cols), f"missing columns: {expected - cols}"
+
+
+class TestLogRiskEvent:
+    def test_minimal_event_inserts(self, conn):
+        eid = log_risk_event(conn, {
+            "date": "2026-05-06",
+            "event_type": "veto",
+            "rule": "min_score",
+        })
+        row = conn.execute(
+            "SELECT event_type, rule, ticker, value, threshold "
+            "FROM risk_events WHERE event_id=?",
+            (eid,),
+        ).fetchone()
+        assert row == ("veto", "min_score", None, None, None)
+
+    def test_full_event_roundtrip(self, conn):
+        eid = log_risk_event(conn, {
+            "date": "2026-05-06",
+            "event_type": "veto",
+            "rule": "max_position",
+            "ticker": "NVDA",
+            "sector": "Technology",
+            "reason": "Position size 6.2% exceeds max 5.0%",
+            "value": 0.062,
+            "threshold": 0.05,
+            "market_regime": "neutral",
+            "signal_date": "2026-05-04",
+            "prediction_date": "2026-05-05",
+            "context": {"dollar_size": 6200.0, "portfolio_nav": 100000.0},
+        })
+        row = conn.execute(
+            "SELECT date, event_type, rule, ticker, sector, reason, "
+            "value, threshold, market_regime, signal_date, "
+            "prediction_date, context_json "
+            "FROM risk_events WHERE event_id=?",
+            (eid,),
+        ).fetchone()
+        assert row[0] == "2026-05-06"
+        assert row[1] == "veto"
+        assert row[2] == "max_position"
+        assert row[3] == "NVDA"
+        assert row[4] == "Technology"
+        assert "6.2%" in row[5]
+        assert row[6] == pytest.approx(0.062)
+        assert row[7] == pytest.approx(0.05)
+        assert row[8] == "neutral"
+        assert row[9] == "2026-05-04"
+        assert row[10] == "2026-05-05"
+        ctx = json.loads(row[11])
+        assert ctx["dollar_size"] == 6200.0
+        assert ctx["portfolio_nav"] == 100000.0
+
+    def test_event_id_is_uuid(self, conn):
+        eid = log_risk_event(conn, {
+            "date": "2026-05-06",
+            "event_type": "halt",
+            "rule": "drawdown_halt",
+        })
+        # uuid4 is 36 chars with 4 dashes
+        assert len(eid) == 36 and eid.count("-") == 4
+
+    def test_no_context_yields_null_json(self, conn):
+        eid = log_risk_event(conn, {
+            "date": "2026-05-06",
+            "event_type": "throttle",
+            "rule": "drawdown_tier_throttle",
+        })
+        row = conn.execute(
+            "SELECT context_json FROM risk_events WHERE event_id=?", (eid,)
+        ).fetchone()
+        assert row[0] is None
+
+    def test_query_by_date_and_rule(self, conn):
+        log_risk_event(conn, {"date": "2026-05-06", "event_type": "veto", "rule": "min_score", "ticker": "KO"})
+        log_risk_event(conn, {"date": "2026-05-06", "event_type": "veto", "rule": "min_score", "ticker": "HSY"})
+        log_risk_event(conn, {"date": "2026-05-06", "event_type": "veto", "rule": "max_sector", "ticker": "AAPL"})
+        log_risk_event(conn, {"date": "2026-05-07", "event_type": "veto", "rule": "min_score", "ticker": "NVDA"})
+
+        rows = conn.execute(
+            "SELECT ticker FROM risk_events WHERE date=? AND rule=? ORDER BY ticker",
+            ("2026-05-06", "min_score"),
+        ).fetchall()
+        assert [r[0] for r in rows] == ["HSY", "KO"]
+
+    def test_required_keys_missing_raises(self, conn):
+        # event_type missing → KeyError on the dict access
+        with pytest.raises(KeyError):
+            log_risk_event(conn, {"date": "2026-05-06", "rule": "min_score"})
+        # rule missing
+        with pytest.raises(KeyError):
+            log_risk_event(conn, {"date": "2026-05-06", "event_type": "veto"})
+        # date missing
+        with pytest.raises(KeyError):
+            log_risk_event(conn, {"event_type": "veto", "rule": "min_score"})

--- a/tests/test_risk_guard_structured_events.py
+++ b/tests/test_risk_guard_structured_events.py
@@ -1,0 +1,311 @@
+"""Structured-event emission tests for risk_guard.check_order +
+compute_drawdown_multiplier.
+
+Phase 2 transparency-inventory: closes the *risk decisions* row.
+Each rule appends one structured dict (rule + value + threshold + reason)
+to the caller's `events` list. Default `events=None` preserves the
+existing 2-tuple return contract — covered by test_risk_guard.py.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from executor.risk_guard import (
+    check_correlation,
+    check_order,
+    compute_drawdown_multiplier,
+)
+
+
+def _df_from_closes(closes: list[float]) -> pd.DataFrame:
+    n = len(closes)
+    return pd.DataFrame(
+        {"open": closes, "high": closes, "low": closes, "close": closes},
+        index=pd.bdate_range("2024-01-01", periods=n),
+    )
+
+
+def _base_config(**overrides):
+    cfg = {
+        "min_score_to_enter": 70,
+        "max_position_pct": 0.05,
+        "bear_max_position_pct": 0.025,
+        "max_sector_pct": 0.25,
+        "max_equity_pct": 0.90,
+        "drawdown_circuit_breaker": 0.08,
+        "bear_block_underweight": True,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": True,
+                "tiers": [
+                    (-0.02, 1.00, "0% to -2%"),
+                    (-0.04, 0.50, "-2% to -4%"),
+                    (-0.06, 0.25, "-4% to -6%"),
+                ],
+            },
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _base_signal(**overrides):
+    sig = {
+        "score": 80,
+        "conviction": "stable",
+        "price_target_upside": 0.15,
+        "sector_rating": "market_weight",
+        "signal": "ENTER",
+    }
+    sig.update(overrides)
+    return sig
+
+
+def _call(events=None, **kwargs):
+    defaults = dict(
+        ticker="AAPL",
+        action="ENTER",
+        dollar_size=4000,
+        portfolio_nav=100_000,
+        peak_nav=100_000,
+        current_positions={},
+        sector="Technology",
+        market_regime="neutral",
+        signal=_base_signal(),
+        config=_base_config(),
+        price_histories=None,
+    )
+    defaults.update(kwargs)
+    return check_order(**defaults, events=events)
+
+
+# ── compute_drawdown_multiplier ──────────────────────────────────────────────
+
+
+class TestDrawdownEventEmission:
+    def test_no_drawdown_emits_no_event(self):
+        events: list[dict] = []
+        compute_drawdown_multiplier(100_000, 100_000, _base_config(), events=events)
+        assert events == []
+
+    def test_throttle_event_on_active_tier(self):
+        """-4% drawdown hits tier 2 (mult 0.50) — emits a throttle event."""
+        events: list[dict] = []
+        mult, _ = compute_drawdown_multiplier(96_000, 100_000, _base_config(), events=events)
+        assert mult == 0.50
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event_type"] == "throttle"
+        assert ev["rule"] == "drawdown_tier_throttle"
+        assert ev["value"] == pytest.approx(-0.04)
+        assert ev["threshold"] == pytest.approx(-0.04)
+        assert ev["context"]["multiplier"] == 0.50
+
+    def test_halt_event_on_circuit_breaker(self):
+        """-9% drawdown trips the circuit breaker — emits a halt event."""
+        events: list[dict] = []
+        mult, _ = compute_drawdown_multiplier(91_000, 100_000, _base_config(), events=events)
+        assert mult == 0.0
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event_type"] == "halt"
+        assert ev["rule"] == "drawdown_halt"
+        assert ev["value"] == pytest.approx(-0.09)
+        assert ev["threshold"] == pytest.approx(-0.08)
+
+    def test_no_event_at_full_sizing_under_tier_floor(self):
+        """-1% drawdown — no tier breached, no event."""
+        events: list[dict] = []
+        mult, _ = compute_drawdown_multiplier(99_000, 100_000, _base_config(), events=events)
+        assert mult == 1.0
+        assert events == []
+
+    def test_default_events_none_preserves_legacy_contract(self):
+        """No events kwarg → 2-tuple return unchanged."""
+        result = compute_drawdown_multiplier(91_000, 100_000, _base_config())
+        assert isinstance(result, tuple) and len(result) == 2
+        mult, reason = result
+        assert mult == 0.0
+        assert "circuit breaker" in reason.lower()
+
+
+# ── check_order rule-by-rule ─────────────────────────────────────────────────
+
+
+class TestCheckOrderEventEmission:
+    def test_min_score_emits_veto(self):
+        events: list[dict] = []
+        approved, _ = _call(events=events, signal=_base_signal(score=50))
+        assert not approved
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event_type"] == "veto"
+        assert ev["rule"] == "min_score"
+        assert ev["ticker"] == "AAPL"
+        assert ev["value"] == 50
+        assert ev["threshold"] == 70
+
+    def test_max_position_emits_veto(self):
+        events: list[dict] = []
+        approved, _ = _call(events=events, dollar_size=6000)  # 6% of 100k > 5%
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "max_position"
+        assert ev["value"] == pytest.approx(0.06)
+        assert ev["threshold"] == pytest.approx(0.05)
+        assert "dollar_size" in ev["context"]
+
+    def test_max_sector_emits_veto(self):
+        events: list[dict] = []
+        positions = {
+            "MSFT": {"market_value": 20_000, "sector": "Technology"},
+            "GOOG": {"market_value": 5_000, "sector": "Technology"},
+        }
+        approved, _ = _call(events=events, dollar_size=1000, current_positions=positions)
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "max_sector"
+        assert ev["value"] == pytest.approx(0.26)
+        assert ev["threshold"] == pytest.approx(0.25)
+        assert ev["sector"] == "Technology"
+        assert ev["context"]["existing_sector_exposure"] == 25_000
+
+    def test_max_equity_emits_veto(self):
+        events: list[dict] = []
+        positions = {
+            f"STOCK{i}": {"market_value": 10_000, "sector": f"Sector{i}"}
+            for i in range(9)
+        }
+        approved, _ = _call(events=events, dollar_size=4000, current_positions=positions)
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "max_equity"
+        assert ev["value"] == pytest.approx(0.94)
+        assert ev["threshold"] == pytest.approx(0.90)
+
+    def test_bear_underweight_emits_veto(self):
+        events: list[dict] = []
+        approved, _ = _call(
+            events=events,
+            dollar_size=1000,
+            market_regime="bear",
+            signal=_base_signal(sector_rating="underweight"),
+        )
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "bear_underweight"
+        assert ev["context"]["sector_rating"] == "underweight"
+
+    def test_correlation_breach_emits_veto(self):
+        history = _df_from_closes([100 + i for i in range(70)])
+        positions = {"MSFT": {"market_value": 5000, "sector": "Technology"}}
+        events: list[dict] = []
+        approved, _ = _call(
+            events=events,
+            ticker="AAPL",
+            dollar_size=4000,
+            current_positions=positions,
+            price_histories={"AAPL": history, "MSFT": history},
+            config=_base_config(
+                correlation_block_enabled=True,
+                correlation_block_threshold=0.80,
+            ),
+        )
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "correlation"
+        assert ev["value"] >= 0.80
+        assert ev["threshold"] == pytest.approx(0.80)
+
+    def test_drawdown_halt_does_not_double_emit_per_ticker(self):
+        """check_order's inner compute_drawdown_multiplier call deliberately
+        does NOT propagate `events` — the portfolio-level halt is logged
+        once at the planner top, not N times per ticker."""
+        events: list[dict] = []
+        approved, _ = _call(events=events, portfolio_nav=91_000, peak_nav=100_000)
+        assert not approved
+        # No drawdown_halt event from the per-ticker call
+        rules = [ev["rule"] for ev in events]
+        assert "drawdown_halt" not in rules
+
+    def test_approved_enter_emits_no_events(self):
+        events: list[dict] = []
+        approved, _ = _call(events=events)
+        assert approved
+        assert events == []
+
+    def test_exit_action_emits_no_events(self):
+        events: list[dict] = []
+        approved, _ = _call(events=events, action="EXIT")
+        assert approved
+        assert events == []
+
+    def test_first_failure_short_circuits(self):
+        """Score gate fires before max_position even when both would fail."""
+        events: list[dict] = []
+        approved, _ = _call(
+            events=events,
+            signal=_base_signal(score=50),
+            dollar_size=6000,  # would also breach max_position
+        )
+        assert not approved
+        assert len(events) == 1
+        assert events[0]["rule"] == "min_score"
+
+    def test_default_events_none_preserves_legacy_contract(self):
+        """No events kwarg → 2-tuple return unchanged."""
+        result = check_order(
+            ticker="AAPL", action="ENTER", dollar_size=4000,
+            portfolio_nav=100_000, peak_nav=100_000, current_positions={},
+            sector="Technology", market_regime="neutral",
+            signal=_base_signal(score=50), config=_base_config(),
+        )
+        assert isinstance(result, tuple) and len(result) == 2
+        approved, reason = result
+        assert not approved
+        assert "Score" in reason
+
+
+# ── check_correlation event emission (standalone) ────────────────────────────
+
+
+class TestCheckCorrelationEvents:
+    def test_breach_emits_event_with_per_ticker_context(self):
+        history = _df_from_closes([100 + i for i in range(70)])
+        positions = {
+            "AAPL": {"sector": "Technology"},
+            "MSFT": {"market_value": 5000, "sector": "Technology"},
+            "GOOG": {"market_value": 5000, "sector": "Technology"},
+        }
+        events: list[dict] = []
+        approved, _ = check_correlation(
+            "AAPL", positions,
+            {"AAPL": history, "MSFT": history, "GOOG": history},
+            {"correlation_block_enabled": True, "correlation_lookback_days": 60,
+             "correlation_block_threshold": 0.80},
+            events=events,
+        )
+        assert not approved
+        ev = events[0]
+        assert ev["rule"] == "correlation"
+        assert ev["sector"] == "Technology"
+        # Per-ticker breakdown is preserved
+        assert isinstance(ev["context"]["per_ticker"], list)
+        per_t = {t: c for t, c in ev["context"]["per_ticker"]}
+        assert "MSFT" in per_t and "GOOG" in per_t
+
+    def test_no_event_when_passing(self):
+        history_a = _df_from_closes([100 + i for i in range(70)])
+        history_b = _df_from_closes([100 + (-1) ** i for i in range(70)])
+        events: list[dict] = []
+        approved, _ = check_correlation(
+            "AAPL",
+            {"AAPL": {"sector": "Tech"}, "MSFT": {"market_value": 5000, "sector": "Tech"}},
+            {"AAPL": history_a, "MSFT": history_b},
+            {"correlation_block_enabled": True, "correlation_lookback_days": 60,
+             "correlation_block_threshold": 0.80},
+            events=events,
+        )
+        assert approved
+        assert events == []


### PR DESCRIPTION
## Summary

Phase 2 transparency-inventory P1 — closes the **risk decisions** row in the gate checklist (ROADMAP entry added 2026-05-05 late evening). Sibling of #138 (trade execution decisions): same family, different axis. Three of the four ⚠️ rows now closed; only the backtester `decision_capture_coverage` % and EOD residual % remain.

Every veto / override / halt / throttle now lands in a new `risk_events` SQLite table with structured **rule + value at threshold** — the inventory's headline question "*how often is rule X firing, and how close is the measured value to the threshold?*" is now a single SQL query.

## Why

> Per-event log with rule + reason + value at threshold.

`executor_shadow_book` already records per-ENTER blocks with free-text `block_reason` for evaluator backtesting (does the block reproduce on replay?), but the inventory question requires structured rule + value + threshold counts. Drawdown halts and tier throttles weren't persisted at all — only `logger.info`'d.

## Distinct from `executor_shadow_book`

| | `executor_shadow_book` (existing) | `risk_events` (new) |
|---|---|---|
| Axis | per-ENTER block | per-rule event |
| Reason format | free-text | structured slug + value + threshold |
| Coverage | ENTERs only | every veto/override/halt/throttle |
| Consumer | evaluator shadow-book backtest | transparency-inventory + future console |

Both populate from the same call sites — complementary, not competing.

## Event taxonomy

| event_type | rule slug | Source site |
|---|---|---|
| veto | nav_nonpositive | `risk_guard.check_order` |
| veto | min_score | `risk_guard.check_order` |
| veto | max_position | `risk_guard.check_order` |
| veto | bear_underweight | `risk_guard.check_order` |
| veto | max_sector | `risk_guard.check_order` |
| veto | max_equity | `risk_guard.check_order` |
| veto | correlation | `risk_guard.check_correlation` |
| veto | momentum_gate | `deciders.decide_entries` |
| override | predictor_gbm_veto | `deciders.decide_entries` |
| halt | drawdown_halt | `risk_guard.compute_drawdown_multiplier` |
| throttle | drawdown_tier_throttle | `risk_guard.compute_drawdown_multiplier` |

## Non-breaking refactor

`check_order` and `compute_drawdown_multiplier` keep their 2-tuple return contract. Each gains an optional `events: list[dict] | None` kwarg — when provided, structured events get appended; when `None`, behaviour is identical to today. Saves rewriting 30+ existing test sites.

## Drawdown emission de-duplication

`check_order` calls `compute_drawdown_multiplier` per-ticker as the gate for ENTERs **and** the planner top-level (main.py:941) calls it once to compute the cycle's sizing multiplier. Without care that's N+1 halt/throttle events per cycle.

Fix: the per-ticker call inside `check_order` deliberately does **not** propagate the events sink to its inner `compute_drawdown_multiplier`. The portfolio-level halt/throttle is emitted ONCE from main.py's call site. Per-ticker rejections at `dd_multiplier==0` still write to shadow_book with a "Drawdown halt" reason — that path is unchanged.

## Lineage

Every event stamps `signal_date` + `prediction_date` (matching #138's `trades` columns) so risk events can be joined against the fills they prevented or shaped.

## Schema

\`\`\`
risk_events (
    event_id          TEXT PRIMARY KEY,
    date              TEXT NOT NULL,
    trading_day       TEXT,
    event_type        TEXT NOT NULL,    -- veto | override | halt | throttle
    rule              TEXT NOT NULL,
    ticker            TEXT,
    sector            TEXT,
    reason            TEXT,
    value             REAL,
    threshold         REAL,
    market_regime     TEXT,
    signal_date       TEXT,
    prediction_date   TEXT,
    context_json      TEXT,
    created_at        TEXT NOT NULL
)
\`\`\`

## Files

| File | Change |
|---|---|
| \`trade_logger.py\` | New \`risk_events\` table + \`log_risk_event()\` helper; \`init_db\` wires it in idempotently |
| \`risk_guard.py\` | \`events=\` kwarg on \`check_order\`, \`check_correlation\`, \`compute_drawdown_multiplier\`; structured dict appended at each veto/halt/throttle site; inner dd call skips event propagation |
| \`deciders.py\` | \`EntryPlan.risk_events\` field; structured events for momentum_gate veto + GBM-veto override; passes events sink into check_order; stamps signal_date + prediction_date on every event |
| \`main.py\` | Portfolio-level dd halt/throttle logged once at planner top; plan.risk_events persisted via \`log_risk_event\` after \`_plan_entries\` returns; \`_plan_entries\` return type now 4-tuple |
| Tests | 33 new across 3 new test files; 1 existing test updated for 4-tuple unpack |

## Tests (33 new, 462/462 total)

- \`test_risk_events_schema.py\` — 10 tests (table exists, columns present, init_db idempotent, full + minimal event roundtrip, query by date+rule, required-key validation)
- \`test_risk_guard_structured_events.py\` — 18 tests (every rule's event_type/rule/value/threshold; first-failure short-circuit; no events on approval; legacy 2-tuple contract preserved when events=None; drawdown halt does not double-emit per-ticker)
- \`test_deciders_risk_events.py\` — 5 tests (momentum_gate veto threaded; gbm_veto override; risk_guard vetoes flow through with lineage stamped; multi-ticker accumulation)

## Test plan

- [x] All 462 executor tests pass (pre-existing 429 + 33 new)
- [x] Schema migration idempotent (re-run \`init_db\` doesn't raise)
- [x] Smoke: synthetic 3-event cycle inserts + groups-by-rule cleanly
- [x] Decider parity tests still pass
- [x] Pre-existing risk_guard tests still pass with no signature change visible
- [ ] Live verification — first ENTER block on next trading day populates \`risk_events\`:
  \`\`\`
  ae-trading "sqlite3 ~/alpha-engine/trades.db 'SELECT date, event_type, rule, ticker, value, threshold FROM risk_events WHERE date=\"2026-05-07\" ORDER BY created_at;'"
  \`\`\`
- [ ] CSV export: confirm \`risk_events\` snapshot lands alongside \`shadow_book.csv\` on next EOD run (follow-up — eod_reconcile dump path not yet wired; tracked separately)

## Out of scope

- **Backfill** of historical events: going-forward coverage is the gate per the inventory framing
- **Console surfacing** at \`console.nousergon.ai/Risk_Events\`: queryable today; rendering is the next step
- **Symmetric EXIT/REDUCE coverage**: risk_guard fast-paths EXIT/REDUCE without rule evaluation
- **Codifying schema in alpha-engine-lib**: kept local since this is the only consumer; promote if dashboard/backtester also needs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)