### PR TITLE
feat(eod): publish unattributed P&L residual % in eod_pnl.csv

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -39,6 +39,27 @@ logger = logging.getLogger(__name__)
 from executor.config_loader import load_config
 
 
+def _compute_unattributed_residual_pct(
+    unattributed_usd: float | None,
+    nav: float | None,
+) -> float | None:
+    """Headline metric for the *P&L attribution* row of the Phase 2
+    transparency-inventory: ``unattributed_usd / portfolio_nav × 100``.
+
+    Returns None when either input is None or when nav is zero/falsy
+    (a divide-by-zero protection — a NAV of 0 means we can't compute a
+    meaningful residual % regardless of the dollar amount).
+
+    The inventory gate is ≤1%. Sign is preserved — a negative value
+    means position-pnl + interest exceeded the actual NAV change
+    (typically an unaccounted fee). Consumers should compare on
+    absolute value when alarming.
+    """
+    if unattributed_usd is None or not nav:
+        return None
+    return (unattributed_usd / nav) * 100.0
+
+
 def _spy_close(run_date: str, config: dict | None = None) -> float:
     """Fetch SPY close for run_date from ArcticDB macro library.
 
@@ -660,6 +681,18 @@ def run(run_date: str | None = None) -> None:
     # reads this snapshot via closing_price (same source as today's
     # daily_closes), closing the source-mismatch gap that was causing NAV
     # residuals to land in cash.
+    #
+    # Phase 2 transparency-inventory: persist the NAV-reconciliation
+    # waterfall (nav_change / position_pnl / interest / dividend /
+    # unattributed) and the headline residual % as named fields. Closes
+    # the *P&L attribution* row in the gate checklist — until now these
+    # values existed in logs + the email body but weren't queryable from
+    # eod_pnl.csv. nav_reconciliation can be {} when prior_nav is None
+    # (first-ever EOD run); .get() defaults to None for those columns.
+    unattributed_for_log = nav_reconciliation.get("unattributed_usd")
+    unattributed_pct_for_log = _compute_unattributed_residual_pct(
+        unattributed_for_log, nav,
+    )
     log_eod(conn, {
         "date": run_date,
         "portfolio_nav": nav,
@@ -672,6 +705,12 @@ def run(run_date: str | None = None) -> None:
         "accrued_interest": account.get("accrued_interest"),
         "unrealized_pnl": account.get("unrealized_pnl"),
         "realized_pnl": account.get("realized_pnl"),
+        "nav_change_usd": nav_reconciliation.get("nav_change_usd"),
+        "position_pnl_usd": nav_reconciliation.get("position_pnl_usd"),
+        "interest_usd": nav_reconciliation.get("interest_usd"),
+        "dividend_usd": nav_reconciliation.get("dividend_usd"),
+        "unattributed_usd": unattributed_for_log,
+        "unattributed_residual_pct": unattributed_pct_for_log,
     })
 
     # ── Sector attribution ──────────────────────────────────────────────────

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -99,6 +99,19 @@ _EOD_MIGRATIONS = [
     "ALTER TABLE eod_pnl ADD COLUMN accrued_interest REAL",
     "ALTER TABLE eod_pnl ADD COLUMN unrealized_pnl REAL",
     "ALTER TABLE eod_pnl ADD COLUMN realized_pnl REAL",
+    # Phase 2 transparency-inventory: per-day P&L attribution lineage.
+    # Closes the *P&L attribution* row in the gate checklist by
+    # publishing the previously log-only NAV-reconciliation breakdown
+    # as named columns. The headline metric is unattributed_residual_pct
+    # = unattributed_usd / portfolio_nav × 100; the inventory gate is
+    # ≤1%. The other columns ride along so a downstream reader can
+    # reconstruct the attribution waterfall without re-running reconcile.
+    "ALTER TABLE eod_pnl ADD COLUMN nav_change_usd REAL",
+    "ALTER TABLE eod_pnl ADD COLUMN position_pnl_usd REAL",
+    "ALTER TABLE eod_pnl ADD COLUMN interest_usd REAL",
+    "ALTER TABLE eod_pnl ADD COLUMN dividend_usd REAL",
+    "ALTER TABLE eod_pnl ADD COLUMN unattributed_usd REAL",
+    "ALTER TABLE eod_pnl ADD COLUMN unattributed_residual_pct REAL",
 ]
 
 CREATE_SHADOW_BOOK_TABLE = """
@@ -413,7 +426,15 @@ def log_risk_event(conn: sqlite3.Connection, event: dict) -> str:
 
 
 def log_eod(conn: sqlite3.Connection, eod: dict) -> None:
-    """Insert or replace an EOD P&L record."""
+    """Insert or replace an EOD P&L record.
+
+    Phase 2 transparency-inventory adds 6 attribution fields:
+      - nav_change_usd, position_pnl_usd, interest_usd, dividend_usd
+      - unattributed_usd  (the residual after attribution)
+      - unattributed_residual_pct  (residual / NAV × 100, the inventory's
+                                    headline metric — gate is ≤1%)
+    All optional for back-compat with legacy callers.
+    """
     import json
     conn.execute(
         """
@@ -421,8 +442,10 @@ def log_eod(conn: sqlite3.Connection, eod: dict) -> None:
             (date, portfolio_nav, daily_return_pct, spy_return_pct,
              daily_alpha_pct, positions_snapshot, spy_close,
              total_cash, accrued_interest, unrealized_pnl, realized_pnl,
+             nav_change_usd, position_pnl_usd, interest_usd, dividend_usd,
+             unattributed_usd, unattributed_residual_pct,
              created_at)
-        VALUES (?,?,?,?,?,?,?,?,?,?,?,?)
+        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             eod["date"],
@@ -436,6 +459,12 @@ def log_eod(conn: sqlite3.Connection, eod: dict) -> None:
             eod.get("accrued_interest"),
             eod.get("unrealized_pnl"),
             eod.get("realized_pnl"),
+            eod.get("nav_change_usd"),
+            eod.get("position_pnl_usd"),
+            eod.get("interest_usd"),
+            eod.get("dividend_usd"),
+            eod.get("unattributed_usd"),
+            eod.get("unattributed_residual_pct"),
             datetime.now(timezone.utc).isoformat(),
         ),
     )

--- a/tests/test_eod_pnl_attribution_columns.py
+++ b/tests/test_eod_pnl_attribution_columns.py
@@ -1,0 +1,187 @@
+"""Tests for the per-day P&L attribution columns on eod_pnl.
+
+Phase 2 transparency-inventory: closes the *P&L attribution* row in the
+gate checklist by publishing the previously log-only NAV-reconciliation
+breakdown as named columns.
+
+The headline metric is `unattributed_residual_pct` = `unattributed_usd /
+portfolio_nav × 100`. The inventory gate is ≤1%.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+from executor.trade_logger import init_db, log_eod
+
+
+@pytest.fixture
+def conn():
+    db_path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+    c = init_db(db_path)
+    yield c
+    c.close()
+    os.unlink(db_path)
+
+
+# ── Schema ───────────────────────────────────────────────────────────────────
+
+
+class TestSchema:
+    def test_attribution_columns_present(self, conn):
+        cols = {
+            row[1] for row in conn.execute("PRAGMA table_info(eod_pnl)").fetchall()
+        }
+        expected = {
+            "nav_change_usd", "position_pnl_usd", "interest_usd",
+            "dividend_usd", "unattributed_usd", "unattributed_residual_pct",
+        }
+        missing = expected - cols
+        assert not missing, f"missing attribution columns: {missing}"
+
+    def test_init_db_idempotent(self):
+        db_path = tempfile.NamedTemporaryFile(suffix=".db", delete=False).name
+        try:
+            c1 = init_db(db_path)
+            c1.close()
+            c2 = init_db(db_path)
+            c2.close()
+            # After two init_db runs, the columns still exist exactly once.
+            c3 = sqlite3.connect(db_path)
+            cols = [
+                row[1] for row in c3.execute("PRAGMA table_info(eod_pnl)").fetchall()
+            ]
+            c3.close()
+            # Each name appears exactly once.
+            assert cols.count("unattributed_residual_pct") == 1
+            assert cols.count("unattributed_usd") == 1
+        finally:
+            os.unlink(db_path)
+
+
+# ── log_eod plumbing ─────────────────────────────────────────────────────────
+
+
+class TestLogEodAttribution:
+    def test_attribution_fields_persisted(self, conn):
+        log_eod(conn, {
+            "date": "2026-05-06",
+            "portfolio_nav": 100_000.0,
+            "daily_return_pct": 0.5,
+            "spy_return_pct": 0.3,
+            "daily_alpha_pct": 0.2,
+            "nav_change_usd": 500.0,
+            "position_pnl_usd": 480.0,
+            "interest_usd": 5.0,
+            "dividend_usd": 12.0,
+            "unattributed_usd": 15.0,
+            "unattributed_residual_pct": 0.015,
+        })
+        row = conn.execute(
+            "SELECT nav_change_usd, position_pnl_usd, interest_usd, "
+            "dividend_usd, unattributed_usd, unattributed_residual_pct "
+            "FROM eod_pnl WHERE date=?", ("2026-05-06",),
+        ).fetchone()
+        assert row == (500.0, 480.0, 5.0, 12.0, 15.0, 0.015)
+
+    def test_legacy_caller_gets_null_attribution(self, conn):
+        """A pre-PR caller that doesn't pass the new fields persists
+        NULLs — the new columns are nullable per the additive-only
+        schema policy. The row otherwise inserts cleanly."""
+        log_eod(conn, {
+            "date": "2026-05-06",
+            "portfolio_nav": 100_000.0,
+            "daily_return_pct": 0.5,
+        })
+        row = conn.execute(
+            "SELECT nav_change_usd, position_pnl_usd, interest_usd, "
+            "dividend_usd, unattributed_usd, unattributed_residual_pct "
+            "FROM eod_pnl WHERE date=?", ("2026-05-06",),
+        ).fetchone()
+        assert row == (None, None, None, None, None, None)
+
+    def test_csv_export_includes_attribution_columns(self, conn):
+        """eod_reconcile re-exports `eod_pnl.csv` via SELECT *, so any
+        new column flows automatically. Locks that contract — if a
+        future schema change breaks SELECT * propagation, this fails."""
+        import pandas as pd
+        log_eod(conn, {
+            "date": "2026-05-06",
+            "portfolio_nav": 100_000.0,
+            "unattributed_usd": 15.0,
+            "unattributed_residual_pct": 0.015,
+        })
+        df = pd.read_sql("SELECT * FROM eod_pnl ORDER BY date", conn)
+        assert "unattributed_residual_pct" in df.columns
+        assert "unattributed_usd" in df.columns
+        assert "nav_change_usd" in df.columns
+        assert df.iloc[0]["unattributed_residual_pct"] == pytest.approx(0.015)
+
+    def test_replace_preserves_attribution_overwrite(self, conn):
+        """INSERT OR REPLACE on the same date overwrites all fields,
+        not just the ones supplied — confirms the new attribution
+        columns aren't accidentally treated as append-only."""
+        log_eod(conn, {
+            "date": "2026-05-06", "portfolio_nav": 100_000.0,
+            "unattributed_residual_pct": 0.015,
+        })
+        log_eod(conn, {
+            "date": "2026-05-06", "portfolio_nav": 100_500.0,
+            "unattributed_residual_pct": 0.005,
+        })
+        row = conn.execute(
+            "SELECT portfolio_nav, unattributed_residual_pct FROM eod_pnl "
+            "WHERE date=?", ("2026-05-06",),
+        ).fetchone()
+        assert row == (100_500.0, 0.005)
+
+
+# ── Residual % semantic locks ───────────────────────────────────────────────
+
+
+class TestResidualPctSemantic:
+    """The inventory gate is unattributed_residual_pct ≤ 1%. These
+    tests document the values that the eod_reconcile producer is
+    expected to write — they don't exercise the producer itself
+    (which has its own logic tests in test_eod_reconcile_logic.py)
+    but lock the meaning of the column."""
+
+    def test_zero_residual_is_perfectly_attributed(self, conn):
+        log_eod(conn, {"date": "2026-05-06", "portfolio_nav": 100_000.0,
+                       "nav_change_usd": 500.0, "position_pnl_usd": 500.0,
+                       "interest_usd": 0.0, "unattributed_usd": 0.0,
+                       "unattributed_residual_pct": 0.0})
+        row = conn.execute(
+            "SELECT unattributed_residual_pct FROM eod_pnl WHERE date=?",
+            ("2026-05-06",),
+        ).fetchone()
+        assert row[0] == 0.0
+
+    def test_residual_pct_can_be_negative(self, conn):
+        """Negative residual = position-pnl + interest exceeded the
+        actual NAV change (e.g. an unaccounted fee). The column is
+        signed; consumers should compare on absolute value."""
+        log_eod(conn, {"date": "2026-05-06", "portfolio_nav": 100_000.0,
+                       "nav_change_usd": 100.0, "position_pnl_usd": 200.0,
+                       "interest_usd": 5.0, "unattributed_usd": -105.0,
+                       "unattributed_residual_pct": -0.105})
+        row = conn.execute(
+            "SELECT unattributed_residual_pct FROM eod_pnl WHERE date=?",
+            ("2026-05-06",),
+        ).fetchone()
+        assert row[0] == pytest.approx(-0.105)
+
+    def test_above_1pct_breaches_inventory_gate(self, conn):
+        """Sanity: a value > 1% is the alarm condition. The column
+        captures it; alarm wiring is downstream (out of scope here)."""
+        log_eod(conn, {"date": "2026-05-06", "portfolio_nav": 100_000.0,
+                       "unattributed_usd": 1500.0,
+                       "unattributed_residual_pct": 1.5})
+        row = conn.execute(
+            "SELECT unattributed_residual_pct FROM eod_pnl WHERE date=?",
+            ("2026-05-06",),
+        ).fetchone()
+        assert row[0] > 1.0  # breach

--- a/tests/test_eod_reconcile_logic.py
+++ b/tests/test_eod_reconcile_logic.py
@@ -8,10 +8,46 @@ import pytest
 
 from executor.eod_reconcile import (
     _apply_dividend_delta,
+    _compute_unattributed_residual_pct,
     _load_constituents_sector_map,
     _resolve_prior_price,
     _synthesize_rationales,
 )
+
+
+class TestComputeUnattributedResidualPct:
+    """Phase 2 transparency-inventory headline metric: residual P&L
+    not attributable to position MTM, interest, or dividends, expressed
+    as % of NAV. Inventory gate is ≤1%."""
+
+    def test_typical_small_residual(self):
+        # $50 unattributed on $100,000 NAV → 0.05%
+        assert _compute_unattributed_residual_pct(50.0, 100_000.0) == pytest.approx(0.05)
+
+    def test_breaches_one_percent_gate(self):
+        # $1,500 unattributed on $100,000 NAV → 1.5% > 1% gate
+        result = _compute_unattributed_residual_pct(1_500.0, 100_000.0)
+        assert result == pytest.approx(1.5)
+        assert abs(result) > 1.0  # the alarm condition
+
+    def test_zero_residual_returns_zero(self):
+        assert _compute_unattributed_residual_pct(0.0, 100_000.0) == 0.0
+
+    def test_negative_residual_preserves_sign(self):
+        # Position pnl + interest exceeded actual NAV change (unaccounted fee)
+        assert _compute_unattributed_residual_pct(-105.0, 100_000.0) == pytest.approx(-0.105)
+
+    def test_none_unattributed_returns_none(self):
+        """First-ever EOD run has no prior_nav → nav_reconciliation is {}
+        → unattributed_usd is None. Persist NULL, not 0 — they mean
+        different things."""
+        assert _compute_unattributed_residual_pct(None, 100_000.0) is None
+
+    def test_zero_nav_returns_none_not_div_by_zero(self):
+        assert _compute_unattributed_residual_pct(50.0, 0.0) is None
+
+    def test_none_nav_returns_none(self):
+        assert _compute_unattributed_residual_pct(50.0, None) is None
 
 
 class TestResolvePriorPrice:


### PR DESCRIPTION
## Summary

Phase 2 transparency-inventory P1 — closes the **P&L attribution** row in the gate checklist. **Fourth and final ⚠️ row of the inventory now closeable** (alongside #138 trade execution, #139 risk decisions, backtester #146 agent decisions).

`eod_reconcile.py` already computes the NAV-reconciliation waterfall — total_nav_change, position_pnl, interest, dividend, unattributed — but the values landed only in server logs + the email's data_warnings (and only when the warning threshold was crossed). Now they're queryable from `eod_pnl.csv` as named columns, and the inventory's "unattributed residual ≤ 1%" gate is verifiable.

## What lands here

Six new nullable columns on `eod_pnl`:

| Column | Meaning |
|---|---|
| \`nav_change_usd\` | Total NAV delta day-over-day |
| \`position_pnl_usd\` | Sum of per-position P&L |
| \`interest_usd\` | Accrued-interest delta |
| \`dividend_usd\` | Positive accrual deltas (informational) |
| \`unattributed_usd\` | Residual after attribution |
| **\`unattributed_residual_pct\`** | **= unattributed_usd / portfolio_nav × 100 — inventory's headline metric; gate is ≤1%** |

\`eod_pnl.csv\` re-exports via \`SELECT *\`, so all new columns flow to the dashboard automatically — the new \`test_csv_export_includes_attribution_columns\` test locks that contract.

## Helper extraction

Pulled the \`unattributed / nav × 100\` calc out of the inline log_eod call site into \`_compute_unattributed_residual_pct\` so the formula's edge cases are testable directly:

- None unattributed (first-ever EOD run, prior_nav unknown) → None
- 0 / None nav → None (divide-by-zero protection)
- Negative residual sign preserved (consumers compare on absolute value)

## Distinct from existing data_warnings

Today's reconcile already raises a \`data_warnings\` entry when \`abs(unattributed_usd) > max($100, 0.05% NAV)\`. That path is unchanged — but now the underlying value is also persisted as a queryable field, so:

| | data_warnings (existing) | unattributed_residual_pct (new) |
|---|---|---|
| Trigger | Threshold-only | Always populated |
| Surface | EOD email body | \`eod_pnl.csv\` column |
| Consumers | Brian | Dashboard + future CW alarm |
| Gate | \>$100 OR \>0.05% NAV | ≤1% per inventory checklist |

Complementary, not competing.

## Files

| File | Change |
|---|---|
| \`executor/trade_logger.py\` | 6 new ALTER TABLE migrations (\`_EOD_MIGRATIONS\`); INSERT statement extended; new fields plumbed via \`eod.get()\` with NULL default |
| \`executor/eod_reconcile.py\` | New \`_compute_unattributed_residual_pct\` helper; log_eod call site populates the 6 new fields from the existing nav_reconciliation dict |
| \`tests/test_eod_reconcile_logic.py\` | +7 tests on the helper — typical small residual, breach above 1%, zero, negative-sign preserved, None inputs, zero NAV divide-by-zero protection |
| \`tests/test_eod_pnl_attribution_columns.py\` | NEW — 9 tests: schema columns present, init_db idempotent, log_eod plumbing round-trip, legacy callers get NULL, CSV SELECT * propagation, INSERT OR REPLACE overwrites, residual-% semantic locks |

## Tests (16 new, 478/478 total)

All 462 pre-existing executor tests + 16 new pass.

## Test plan

- [x] All 478 executor tests pass (was 462; +16 new)
- [x] Schema migration idempotent (re-run \`init_db\` doesn't raise)
- [x] Smoke: log_eod round-trip persists and recovers all 6 fields
- [x] Existing eod_reconcile tests still pass
- [ ] Live verification — first EOD reconcile after merge populates all 6 columns:
  \`\`\`
  ae-trading "sqlite3 ~/alpha-engine/trades.db 'SELECT date, nav_change_usd, position_pnl_usd, interest_usd, dividend_usd, unattributed_usd, unattributed_residual_pct FROM eod_pnl ORDER BY date DESC LIMIT 1;'"
  \`\`\`
- [ ] CSV export — confirm next \`eod_pnl.csv\` upload includes the new columns:
  \`\`\`
  aws s3 cp s3://alpha-engine-research/trades/eod_pnl.csv - | head -1 | tr ',' '\n' | grep -E 'unattributed|nav_change|position_pnl|interest_usd|dividend'
  \`\`\`

## Coverage gate semantics

The inventory gate is \`abs(unattributed_residual_pct) ≤ 1.0\`. Above 1%, the dashboard renders ⚠️/🔴 status; downstream CW alarm wiring (single line on the column) is a follow-up.

## What's NOT in this PR

- **CloudWatch metric emission** for \`unattributed_residual_pct\`: deferred. Today's path is the persisted column + EOD email warning. CW emission is the next step if alarming on the residual is wanted independent of the email.
- **Backfill of historical residuals**: not applicable — going-forward coverage is the inventory's gate framing. Historical rows have NULL in the new columns.
- **Dashboard surfacing at \`console.nousergon.ai/Metrics\`**: queryable today; rendering next to the existing transparency-inventory metrics is the natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)