### PR TITLE
feat(executor): backfill Unknown sectors from constituents at signal-read

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -347,6 +347,19 @@ def _read_signals(
                 logger.error("Admission gate failed on ArcticDB read: %s", exc)
                 raise
 
+    if not simulate:
+        from executor.signal_reader import patch_unknown_sectors_with_constituents
+        try:
+            n_patched = patch_unknown_sectors_with_constituents(signals_raw, signals_bucket)
+            if n_patched:
+                logger.warning(
+                    "[sector_fallback] Backfilled %d sectors from constituents.json "
+                    "(research signals.json escape from alpha-engine-research#126)",
+                    n_patched,
+                )
+        except Exception as e:
+            logger.warning("Sector backfill skipped: %s", e)
+
     signals = get_actionable_signals(signals_raw)
 
     # Alert if signals are stale (research didn't run recently)

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -395,6 +395,59 @@ def assert_predictions_cover_buy_candidates(
         )
 
 
+def patch_unknown_sectors_with_constituents(signals_raw: dict, s3_bucket: str) -> int:
+    """Backfill sector="Unknown" or missing on ENTER signals using
+    constituents.json sector_map as the authoritative GICS source.
+
+    Defense-in-depth against an escape from research's signals.json
+    preflight (alpha-engine-research#126). The 2026-05-04 EOG/NVT
+    incident wrote "Unknown" into trades.db because the planner consumed
+    research's first-pass file before sector_map had loaded. The research
+    preflight is the primary gate; this is the executor-side catch.
+
+    Mutates ``signals_raw["buy_candidates"]`` and ``signals_raw["universe"]``
+    in place. Returns count of patches applied for caller logging.
+    Lazy-loads the constituents map only when at least one ENTER signal
+    needs patching, so the typical clean path pays no S3 round-trip.
+    """
+    needs_patch = False
+    for key in ("buy_candidates", "universe"):
+        for s in signals_raw.get(key) or []:
+            if not isinstance(s, dict) or s.get("signal") != "ENTER":
+                continue
+            cur = s.get("sector")
+            if not cur or cur == "Unknown":
+                needs_patch = True
+                break
+        if needs_patch:
+            break
+
+    if not needs_patch:
+        return 0
+
+    from executor.eod_reconcile import _load_constituents_sector_map
+    constituents_map = _load_constituents_sector_map(s3_bucket)
+    if not constituents_map:
+        return 0
+
+    patched = 0
+    for key in ("buy_candidates", "universe"):
+        for s in signals_raw.get(key) or []:
+            if not isinstance(s, dict):
+                continue
+            cur = s.get("sector")
+            if cur and cur != "Unknown":
+                continue
+            ticker = s.get("ticker")
+            if not ticker:
+                continue
+            mapped = constituents_map.get(ticker)
+            if mapped:
+                s["sector"] = mapped
+                patched += 1
+    return patched
+
+
 def get_actionable_signals(signals: dict) -> dict:
     """
     Filter signals to actionable entries by signal type.

--- a/tests/test_signal_reader_sector_patch.py
+++ b/tests/test_signal_reader_sector_patch.py
@@ -1,0 +1,143 @@
+"""Tests for signal_reader.patch_unknown_sectors_with_constituents.
+
+Defense-in-depth complement to research's signals.json sector preflight
+(alpha-engine-research#126). The 2026-05-04 EOG/NVT incident: research
+wrote signals.json with sector="Unknown" because constituents data hadn't
+loaded yet, the morning planner consumed v1, and the daemon's intraday
+fills wrote "Unknown" into trades.db. The research preflight blocks the
+emission; this patch catches the escape if it ever happens.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def signals_raw_unknown_eog_nvt():
+    return {
+        "buy_candidates": [
+            {"ticker": "EOG", "signal": "ENTER", "sector": "Unknown"},
+            {"ticker": "NVT", "signal": "ENTER", "sector": "Unknown"},
+            {"ticker": "CTAS", "signal": "ENTER", "sector": "Industrials"},
+        ],
+        "universe": [
+            {"ticker": "EOG", "signal": "ENTER", "sector": "Unknown"},
+            {"ticker": "NVT", "signal": "ENTER", "sector": "Unknown"},
+            {"ticker": "CTAS", "signal": "ENTER", "sector": "Industrials"},
+            {"ticker": "META", "signal": "HOLD", "sector": "Unknown"},
+        ],
+    }
+
+
+def test_patches_unknown_with_constituents_map(signals_raw_unknown_eog_nvt):
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    constituents = {"EOG": "Energy", "NVT": "Industrials"}
+
+    with patch(
+        "executor.eod_reconcile._load_constituents_sector_map",
+        return_value=constituents,
+    ):
+        n = patch_unknown_sectors_with_constituents(signals_raw_unknown_eog_nvt, "bucket")
+
+    assert n == 4
+
+    bc_by_t = {s["ticker"]: s for s in signals_raw_unknown_eog_nvt["buy_candidates"]}
+    uni_by_t = {s["ticker"]: s for s in signals_raw_unknown_eog_nvt["universe"]}
+
+    assert bc_by_t["EOG"]["sector"] == "Energy"
+    assert bc_by_t["NVT"]["sector"] == "Industrials"
+    assert bc_by_t["CTAS"]["sector"] == "Industrials"
+    assert uni_by_t["EOG"]["sector"] == "Energy"
+    assert uni_by_t["NVT"]["sector"] == "Industrials"
+    assert uni_by_t["META"]["sector"] == "Unknown"
+
+
+def test_no_patch_when_all_sectors_resolved():
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    signals_raw = {
+        "buy_candidates": [{"ticker": "EOG", "signal": "ENTER", "sector": "Energy"}],
+        "universe": [{"ticker": "EOG", "signal": "ENTER", "sector": "Energy"}],
+    }
+
+    with patch(
+        "executor.eod_reconcile._load_constituents_sector_map",
+        side_effect=AssertionError("should not load constituents on clean path"),
+    ):
+        n = patch_unknown_sectors_with_constituents(signals_raw, "bucket")
+
+    assert n == 0
+
+
+def test_constituents_miss_leaves_unknown_in_place():
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    signals_raw = {
+        "buy_candidates": [{"ticker": "RARE", "signal": "ENTER", "sector": "Unknown"}],
+        "universe": [{"ticker": "RARE", "signal": "ENTER", "sector": "Unknown"}],
+    }
+
+    with patch(
+        "executor.eod_reconcile._load_constituents_sector_map",
+        return_value={"OTHER": "Healthcare"},
+    ):
+        n = patch_unknown_sectors_with_constituents(signals_raw, "bucket")
+
+    assert n == 0
+    assert signals_raw["buy_candidates"][0]["sector"] == "Unknown"
+
+
+def test_empty_constituents_map_is_safe():
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    signals_raw = {
+        "buy_candidates": [{"ticker": "EOG", "signal": "ENTER", "sector": "Unknown"}],
+        "universe": [{"ticker": "EOG", "signal": "ENTER", "sector": "Unknown"}],
+    }
+
+    with patch("executor.eod_reconcile._load_constituents_sector_map", return_value={}):
+        n = patch_unknown_sectors_with_constituents(signals_raw, "bucket")
+
+    assert n == 0
+    assert signals_raw["buy_candidates"][0]["sector"] == "Unknown"
+
+
+def test_missing_or_none_sector_is_treated_as_unknown():
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    signals_raw = {
+        "buy_candidates": [
+            {"ticker": "A", "signal": "ENTER"},
+            {"ticker": "B", "signal": "ENTER", "sector": None},
+            {"ticker": "C", "signal": "ENTER", "sector": ""},
+        ],
+        "universe": [],
+    }
+
+    with patch(
+        "executor.eod_reconcile._load_constituents_sector_map",
+        return_value={"A": "Healthcare", "B": "Energy", "C": "Industrials"},
+    ):
+        n = patch_unknown_sectors_with_constituents(signals_raw, "bucket")
+
+    assert n == 3
+    assert signals_raw["buy_candidates"][0]["sector"] == "Healthcare"
+    assert signals_raw["buy_candidates"][1]["sector"] == "Energy"
+    assert signals_raw["buy_candidates"][2]["sector"] == "Industrials"
+
+
+def test_empty_signals_raw_is_safe():
+    from executor.signal_reader import patch_unknown_sectors_with_constituents
+
+    with patch(
+        "executor.eod_reconcile._load_constituents_sector_map",
+        side_effect=AssertionError("should not load constituents on empty path"),
+    ):
+        assert patch_unknown_sectors_with_constituents({}, "bucket") == 0
+        assert patch_unknown_sectors_with_constituents(
+            {"buy_candidates": [], "universe": []}, "bucket"
+        ) == 0


### PR DESCRIPTION
## Summary
- Add `patch_unknown_sectors_with_constituents` to `executor/signal_reader.py`. Walks `signals_raw.buy_candidates + signals_raw.universe`, finds entries with `sector` missing or `"Unknown"`, and backfills from constituents.json sector_map (reusing `eod_reconcile._load_constituents_sector_map`).
- Wire it in `_read_signals` between the admission gate and `get_actionable_signals` — the filtered `enter`/`exit`/`reduce`/`hold` lists hold dict references back into `buy_candidates + universe`, so patches flow through transparently.
- Lazy-load: clean signals.json files pay no S3 round-trip.
- 6 new tests pinning patch/no-patch/miss/empty/None behavior. Suite: 478 → 484.

## Surface
Defense-in-depth complement to **alpha-engine-research#126** (signals.json sector preflight). The 2026-05-04 EOG/NVT incident wrote `sector="Unknown"` into trades.db because the morning planner consumed research's first-pass signals.json before constituents data had loaded. The bad rows survived because no UPDATE path overwrites `trades.sector` — `eod_reconcile` only enriches the in-memory positions snapshot.

Research's preflight is the primary gate. This PR is the catch-net for any future escape (new bug class, manual override, etc.).

## Test plan
- [x] `pytest tests/test_signal_reader_sector_patch.py -v` — 6/6 pass
- [x] `pytest tests/ -q` — 484/484 pass
- [ ] Validate on next weekday SF: monitor for `[sector_fallback] Backfilled N sectors from constituents.json` warnings — should be silent on the clean path. Non-zero N indicates research's preflight let something through and is worth investigating upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)