### PR TITLE
fix(scripts): resolve executor.* imports in backfill_trades_sector.py

### DIFF
--- a/scripts/backfill_trades_sector.py
+++ b/scripts/backfill_trades_sector.py
@@ -33,8 +33,14 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import sqlite3
 import sys
+
+# Resolve `executor.*` imports when invoked as `python scripts/...` from the
+# repo root — same pattern as executor/main.py:34. Lets the script be run
+# directly without setting PYTHONPATH.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
One-line sys.path prepend so `python scripts/backfill_trades_sector.py` resolves `from executor.eod_reconcile import ...` when run from the repo root. Same pattern as `executor/main.py:34`.

## Surface
ae-trading dry-run after PR #142 hit `ModuleNotFoundError: No module named 'executor'` — script depends on `_load_constituents_sector_map` from the executor module but didn't manipulate sys.path.

## Side observation
Dry-run on ae-trading reported **226 candidate rows** (not the 2 I scoped in PR #142). PR #122 (sector column add, 2026-04-30) only populates sector on rows added *after* its deploy; all pre-deploy historical trades have NULL sector. The backfill will resolve them all via constituents.json — better historical attribution than originally scoped.

## Test plan
- [x] `pytest tests/test_backfill_trades_sector.py -v` — 8/8 pass (sys.path prepend doesn't affect tests, which inject their own paths)
- [x] `python scripts/backfill_trades_sector.py --help` — runs cleanly locally
- [ ] Re-run on ae-trading after merge: `ae-trading "cd ~/alpha-engine && git pull && source .venv/bin/activate && python scripts/backfill_trades_sector.py --db-path ~/alpha-engine/trades.db --dry-run"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)