### PR TITLE
feat(daemon): pass ec2_instance_id to EOD SF for daily substrate check

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -832,10 +832,16 @@ def run_daemon(dry_run: bool = False) -> None:
 def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
     """Start the EOD Step Function pipeline after daemon shutdown.
 
-    Input shape matches the SF's expectations: trading_instance_id (array
-    for SSM sendCommand) + sns_topic_arn for HandleFailure publish.
-    Extra fields (run_date, triggered_by) are harmless — the SF ignores
-    them but they're useful for audit / debugging in execution history.
+    Input shape matches the SF's expectations:
+    - ``trading_instance_id`` (array for SSM sendCommand) — PostMarketData,
+      CaptureSnapshot, EODReconcile, StopTradingInstance all target this.
+    - ``ec2_instance_id`` (array) — DailySubstrateHealthCheck targets the
+      dashboard EC2 (where alpha-engine-dashboard + lib pin are installed).
+    - ``sns_topic_arn`` — HandleFailure publish.
+
+    Extra fields (``run_date``, ``triggered_by``) are harmless — the SF
+    ignores them but they're useful for audit / debugging in execution
+    history.
 
     Failures are non-fatal so a transient SF / IAM hiccup doesn't crash
     the daemon mid-shutdown. SF failure surfaces via the SNS HandleFailure
@@ -847,6 +853,7 @@ def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
         sfn = _b3_sf.client("stepfunctions", region_name="us-east-1")
         state_machine_arn = "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline"
         trading_instance_id = "i-018eb3307a21329bf"
+        dashboard_instance_id = "i-09b539c844515d549"
         sns_topic_arn = config.get(
             "sns_topic_arn",
             "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts",
@@ -857,6 +864,7 @@ def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
             name=f"eod-{run_date}-{int(__import__('time').time())}",
             input=_json_sf.dumps({
                 "trading_instance_id": [trading_instance_id],
+                "ec2_instance_id": [dashboard_instance_id],
                 "sns_topic_arn": sns_topic_arn,
                 "run_date": run_date,
                 "triggered_by": "daemon_shutdown",

--- a/tests/test_daemon_phase0.py
+++ b/tests/test_daemon_phase0.py
@@ -274,8 +274,10 @@ class TestTriggerEodPipeline:
             assert kwargs["name"].startswith("eod-2026-04-29-")
 
     def test_input_payload_shape(self):
-        """Input must include trading_instance_id (array — SF SSM step expects
-        it) + sns_topic_arn (HandleFailure publish target)."""
+        """Input must include trading_instance_id (array — PostMarketData,
+        CaptureSnapshot, EODReconcile, StopTradingInstance target it),
+        ec2_instance_id (array — DailySubstrateHealthCheck targets the
+        dashboard EC2), and sns_topic_arn (HandleFailure publish target)."""
         import json
 
         from executor.daemon import _trigger_eod_pipeline
@@ -290,6 +292,11 @@ class TestTriggerEodPipeline:
             payload = json.loads(sfn.start_execution.call_args.kwargs["input"])
             assert isinstance(payload["trading_instance_id"], list)
             assert payload["trading_instance_id"][0].startswith("i-")
+            assert isinstance(payload["ec2_instance_id"], list)
+            assert payload["ec2_instance_id"][0].startswith("i-")
+            assert payload["ec2_instance_id"][0] != payload["trading_instance_id"][0], (
+                "trading EC2 and dashboard EC2 must be distinct instances"
+            )
             assert payload["sns_topic_arn"].startswith("arn:aws:sns:")
             assert payload["run_date"] == "2026-04-29"
             assert payload["triggered_by"] == "daemon_shutdown"


### PR DESCRIPTION
## Summary
- Adds `ec2_instance_id` (dashboard EC2 `i-09b539c844515d549`) to the daemon's EOD SF input, mirroring the existing `trading_instance_id` field.
- The companion alpha-engine-data PR adds a `DailySubstrateHealthCheck` state to the weekday EOD SF that targets `$.ec2_instance_id`. Without this change the new SF state would error at the SSM step with `States.Runtime` on the missing JSONPath.
- Updates `test_input_payload_shape` to pin the new field. Adds an explicit assertion that the trading and dashboard instance ids are distinct (regression protection).

## Why
PR #175 in alpha-engine-data shipped the Saturday-SF `WeeklySubstrateHealthCheck` which runs the row-driven `alpha_engine_lib.transparency` checker on the dashboard EC2. The companion PR (alpha-engine-data #178) extends the same pattern to the weekday EOD SF with `--cadence daily`, closing the Phase 2 → 3 gap where daily-cadence rows (lineage, risk_events, residual_pct) only got checked once per week.

The new SF state needs the dashboard EC2 instance id (where alpha-engine-dashboard + lib pin are installed). The existing `trading_instance_id` cannot satisfy this — the trading EC2 doesn't have the dashboard repo or lib installed.

## Failure mode without this change
The SF's `DailySubstrateHealthCheck` Catch is non-blocking, routing to `StopTradingInstance`. So if the field were missing, the trading EC2 would still stop (cost-guard preserved) — but the substrate check would silently never run. The new test assertion makes this regression visible at the daemon-test level.

## Test plan
- [x] `pytest tests/test_daemon_phase0.py` — all 27 daemon tests pass, including updated `test_input_payload_shape`.
- [x] Full alpha-engine suite — 492 passed.
- [ ] After merge: confirm next daemon-shutdown EOD SF execution input contains `ec2_instance_id` (visible in Step Functions execution history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)