### PR TITLE
feat(iam): grant CloudWatch read + SNS publish for substrate health check

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
@@ -11,6 +11,16 @@
                     "cloudwatch:namespace": "AlphaEngine/*"
                 }
             }
+        },
+        {
+            "Sid": "ReadMetricsForSubstrateCheck",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:ListMetrics"
+            ],
+            "Resource": "*"
         }
     ]
 }

--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-sns-publish.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-sns-publish.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PublishAlphaEngineAlerts",
+            "Effect": "Allow",
+            "Action": "sns:Publish",
+            "Resource": "arn:aws:sns:us-east-1:711398986525:alpha-engine-alerts"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Two IAM grants on \`alpha-engine-executor-role\` surfaced by the 2026-05-06 first-end-to-end exercise of the substrate health checker on the dashboard EC2 (substrate-arc PRs #175 + #176 from yesterday).

1. **alpha-engine-cloudwatch-metrics** — adds \`cloudwatch:GetMetricStatistics\` + \`cloudwatch:GetMetricData\` + \`cloudwatch:ListMetrics\` to the existing policy. Resource \`*\` since CloudWatch read APIs don't support resource-level scoping. Unblocks pipeline_execution + agent_quality substrate rows.
2. **alpha-engine-sns-publish** — new inline policy granting \`sns:Publish\` scoped to the alpha-engine-alerts topic ARN only. Unblocks the substrate checker's \`--alert\` SNS path.

## Why
The 2026-05-06 17:00 PT substrate-check log on the dashboard EC2 showed:
\`\`\`
[FAIL] pipeline_execution    AccessDenied: cloudwatch:GetMetricStatistics
[FAIL] agent_quality          AccessDenied: cloudwatch:GetMetricStatistics
WARNING:__main__:SNS publish failed: AuthorizationError: SNS:Publish on alpha-engine-alerts
\`\`\`

The dashboard EC2 (\`i-09b539c844515d549\`) runs as \`alpha-engine-executor-role\`; the substrate checker (lib \`alpha_engine_lib.transparency\`) calls \`cloudwatch:GetMetricStatistics\` on \`AWS/States\` (pipeline_execution row checks SF success rate) and \`AlphaEngine/Eval\` (agent_quality row checks rolling-mean datapoints). The role had \`PutMetricData\` (write) but no read grants. SNS\\:Publish was never granted at all.

## Apply state (live IAM)
Already applied via \`./infrastructure/iam/apply.sh --role alpha-engine-executor-role --policy <name>\` for both policies. \`check-drift.py\` reports clean across all codified roles. Live verification: re-ran \`python -m alpha_engine_lib.transparency --cadence weekly\` on dashboard EC2 — AccessDenied errors gone (pipeline_execution + agent_quality now error on a separate lib bug \`InvalidParameterValue: Period must be a multiple of 60\` addressed in alpha-engine-lib PR #26).

## Test plan
- [x] \`apply.sh --role alpha-engine-executor-role --policy alpha-engine-cloudwatch-metrics\` — applied OK.
- [x] \`apply.sh --role alpha-engine-executor-role --policy alpha-engine-sns-publish\` — applied OK.
- [x] \`check-drift.py\` — clean across all codified roles.
- [x] Substrate check re-run on dashboard EC2 — IAM-AccessDenied gone; surfaces lib period bug instead.
- [ ] After lib PR #26 merges + dashboard pin bumps to v0.5.3 + redeploys: confirm pipeline_execution + agent_quality flip OK on next substrate run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)