### PR TITLE
feat(trades): add entry_trigger column for substrate inventory contract

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -1109,6 +1109,12 @@ def _execute_entry(
         "signal_price": _signal_price,
         "trigger_price": _trigger_price,
         "trigger_type": trigger_reason,
+        # entry_trigger duplicates trigger_reason here intentionally —
+        # see _TRADES_MIGRATIONS for the canonical-name rationale (the
+        # substrate inventory expects entry_trigger; trigger_type is
+        # also populated on exits with the exit reason, so the two
+        # cannot be merged).
+        "entry_trigger": trigger_reason,
         "spy_price_at_order": _spy_now,
         "slippage_vs_signal": _slippage,
         # Date-convention dual-tracking. trading_day is the last completed

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -91,6 +91,14 @@ _TRADES_MIGRATIONS = [
     # Both nullable for back-compat with rows logged before this PR.
     "ALTER TABLE trades ADD COLUMN signal_date TEXT",
     "ALTER TABLE trades ADD COLUMN prediction_date TEXT",
+    # ── Phase 2 transparency-inventory: entry-trigger lineage (2026-05-07) ──
+    # entry_trigger is the canonical name in the substrate inventory
+    # (alpha_engine_lib/transparency_inventory.yaml row trade_execution_lineage).
+    # The existing trigger_type column overlaps but is also populated on exits
+    # (with the exit reason); separating entry_trigger keeps the
+    # entry-trigger-only contract clean. Populated only on ENTER rows; NULL
+    # elsewhere.
+    "ALTER TABLE trades ADD COLUMN entry_trigger TEXT",
 ]
 
 _EOD_MIGRATIONS = [
@@ -268,8 +276,8 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             spy_price_at_order, realized_pnl, realized_return_pct,
             spy_return_during_hold, realized_alpha_pct, days_held,
             slippage_vs_signal, trading_day, signal_trading_day,
-            signal_date, prediction_date, created_at
-        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+            signal_date, prediction_date, entry_trigger, created_at
+        ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
         """,
         (
             trade_id,
@@ -314,6 +322,7 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
             trade.get("signal_trading_day"),
             trade.get("signal_date"),
             trade.get("prediction_date"),
+            trade.get("entry_trigger"),
             datetime.now(timezone.utc).isoformat(),
         ),
     )

--- a/tests/test_trades_entry_trigger.py
+++ b/tests/test_trades_entry_trigger.py
@@ -1,0 +1,134 @@
+"""
+Tests for the `entry_trigger` column on the trades table.
+
+Phase 2 transparency-inventory item — closes the *trade execution lineage*
+row in alpha_engine_lib/transparency_inventory.yaml. The substrate health
+check asserts the column is present in trades_full.csv; the daemon's
+ENTER fill site is the only writer that populates it (mirrors the
+trigger_reason returned by EntryTriggerEngine.should_enter).
+
+Distinct from `trigger_type`: trigger_type is also populated on exits
+with the exit reason, so the entry-only contract requires a separate
+column rather than a rename.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from executor.trade_logger import init_db, log_trade
+
+
+def _columns(db_path: Path) -> set[str]:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.execute("PRAGMA table_info(trades)")
+    cols = {row[1] for row in cur.fetchall()}
+    conn.close()
+    return cols
+
+
+def test_init_db_creates_entry_trigger_column(tmp_path):
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    assert "entry_trigger" in _columns(db_path)
+
+
+def test_init_db_idempotent_for_entry_trigger(tmp_path):
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    conn.close()
+    conn = init_db(str(db_path))
+    conn.close()
+    assert "entry_trigger" in _columns(db_path)
+
+
+def test_log_trade_persists_entry_trigger(tmp_path):
+    """The daemon ENTER fill site populates entry_trigger from the
+    EntryTriggerEngine return string (e.g. 'pullback 2.3% from high $182.10').
+    """
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-09",
+        "ticker": "NVDA",
+        "action": "ENTER",
+        "shares": 50,
+        "entry_trigger": "pullback 2.3% from high $182.10",
+    })
+    row = conn.execute(
+        "SELECT entry_trigger FROM trades WHERE ticker='NVDA'"
+    ).fetchone()
+    conn.close()
+    assert row == ("pullback 2.3% from high $182.10",)
+
+
+def test_log_trade_entry_trigger_defaults_to_null(tmp_path):
+    """Legacy callers that don't pass entry_trigger get NULL — back-compat
+    with rows logged before this column shipped, and intended NULL state
+    on exit rows (entry-trigger-only contract)."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-09",
+        "ticker": "AAPL",
+        "action": "ENTER",
+        "shares": 100,
+    })
+    row = conn.execute(
+        "SELECT entry_trigger FROM trades WHERE ticker='AAPL'"
+    ).fetchone()
+    conn.close()
+    assert row == (None,)
+
+
+def test_entry_trigger_independent_of_trigger_type_on_exits(tmp_path):
+    """Exit rows write trigger_type with the exit reason but leave
+    entry_trigger NULL. Keeps the entry-only contract clean."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    log_trade(conn, {
+        "date": "2026-05-09",
+        "ticker": "MSFT",
+        "action": "EXIT",
+        "shares": 50,
+        "exit_reason": "intraday_atr_stop",
+        "trigger_type": "intraday_atr_stop",
+        # entry_trigger intentionally omitted
+    })
+    row = conn.execute(
+        "SELECT entry_trigger, trigger_type FROM trades WHERE ticker='MSFT'"
+    ).fetchone()
+    conn.close()
+    assert row == (None, "intraday_atr_stop")
+
+
+def test_entry_trigger_canonical_engine_strings(tmp_path):
+    """Smoke-test all 5 trigger_reason strings produced by
+    EntryTriggerEngine.should_enter (executor/entry_triggers.py) round-trip
+    cleanly through the column. Catches any future encoding regression."""
+    db_path = tmp_path / "trades.db"
+    conn = init_db(str(db_path))
+    canonical = [
+        ("AAA", "pullback 1.5% from high $50.10"),
+        ("BBB", "VWAP discount 0.8% (VWAP=$22.15)"),
+        ("CCC", "near support $98.20 (dist 0.4%)"),
+        ("DDD", "time_expiry"),
+        ("EEE", "graduated_entry (+1.2% vs morning $44.80, 3.5h)"),
+    ]
+    for ticker, trigger in canonical:
+        log_trade(conn, {
+            "date": "2026-05-09",
+            "ticker": ticker,
+            "action": "ENTER",
+            "shares": 10,
+            "entry_trigger": trigger,
+        })
+    rows = conn.execute(
+        "SELECT ticker, entry_trigger FROM trades ORDER BY ticker"
+    ).fetchall()
+    conn.close()
+    assert rows == canonical


### PR DESCRIPTION
## Summary
Closes the `trade_execution_lineage` row of the transparency inventory (alpha_engine_lib `transparency_inventory.yaml`). Substrate Health email at 6:11 AM 2026-05-07 reported `[FAIL] trade_execution_lineage missing column 'entry_trigger'`.

The existing `trigger_type` column overlaps but is also written on exits with the exit reason (e.g. `intraday_atr_stop`), so the entry-only contract requires a separate column rather than a rename — preserves the non-breaking ADD posture per CLAUDE.md S3 contract safety.

- New column `entry_trigger TEXT` added via `_TRADES_MIGRATIONS` (idempotent on re-run).
- Populated only at the daemon's ENTER fill site (`executor/daemon.py:1117`) from the `trigger_reason` string returned by `EntryTriggerEngine.should_enter` (pullback / VWAP / support / time_expiry / graduated_entry).
- NULL on exit rows and legacy rows — matches back-compat policy on every other additive column.

## Test plan
- [x] `tests/test_trades_entry_trigger.py` — 6 new tests: column creation, idempotent migration, populated on ENTER, NULL default, NULL on exit rows when only trigger_type is set, all 5 canonical engine strings round-trip.
- [x] All 52 tests pass across the 7 test files that import `trade_logger`.
- [ ] First daemon ENTER fill on the next live trading day will populate the column; substrate health email next firing should show `[OK] trade_execution_lineage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)