### PR TITLE
feat(executor): batch-confidence-aware min_score tightening (audit Phase 1, 2/2)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -20,6 +20,15 @@ drawdown_circuit_breaker: 0.06   # halt new entries if portfolio drawdown exceed
 
 # ── Entry gates ──────────────────────────────────────────────────────────────
 min_score_to_enter: 30           # backstop only — predictor veto is primary gate
+
+# Tighten min_score_to_enter when the predictor batch's mean prediction_confidence
+# is broadly low (degenerate-predictor backstop, per 2026-05-07 audit Phase 1).
+# Today's incident: 16 of 27 tickers clamped to p_up=0.458 (mean batch conf ~0.60),
+# 5 saturated at conf=0.99 — the per-ticker signal looked fine but the batch
+# distribution was degenerate. Default off; opt in only after shadow validation.
+batch_confidence_tightening_enabled: false
+batch_confidence_threshold: 0.65    # if mean batch confidence < this, tighten
+batch_confidence_min_score_bump: 10 # bump min_score_to_enter by this when triggered
 momentum_gate_enabled: false      # disabled — predictor mean-reversion conflicts with this
 min_conviction_to_enter:         # only these conviction levels allow new entries
   - rising

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -250,6 +250,82 @@ class ExitPlan:
     urgent_exits_with_meta: list[dict] = field(default_factory=list)
 
 
+def _batch_confidence_mean(predictions_by_ticker: dict) -> float | None:
+    """Mean of ``prediction_confidence`` across all valid predictions in the batch.
+
+    Returns ``None`` when the batch has no usable confidence values — caller
+    interprets None as "skip the tightening gate" rather than "tightening
+    triggered." Skips entries with missing or non-numeric confidence so a
+    sparse predictions file (e.g. early-cutover days) doesn't drag the mean
+    toward zero artificially.
+    """
+    if not predictions_by_ticker:
+        return None
+    confs: list[float] = []
+    for pred in predictions_by_ticker.values():
+        if not isinstance(pred, dict):
+            continue
+        c = pred.get("prediction_confidence")
+        if isinstance(c, (int, float)) and c is not None:
+            confs.append(float(c))
+    if not confs:
+        return None
+    return sum(confs) / len(confs)
+
+
+def _apply_batch_confidence_tightening(
+    config: dict,
+    predictions_by_ticker: dict,
+    run_date: str,
+) -> dict:
+    """Return a derived config with ``min_score_to_enter`` tightened when the
+    predictor batch's mean confidence is broadly low.
+
+    Per the 2026-05-07 predictor audit's Phase 1: today's predictor produced
+    16 of 27 tickers clamped to ``p_up=0.458`` (mean batch confidence ~0.60),
+    5 saturated at ``conf=0.99``. Mean across the batch was ~0.60 — broadly
+    low and a meaningful signal that the day's predictor output is degenerate
+    even when individual confidences look high. Bumping ``min_score_to_enter``
+    by a configurable step under that condition is a backstop tightening
+    that doesn't depend on per-ticker confidence (which is already noisy in
+    the degenerate case).
+
+    Feature-flagged off by default (``batch_confidence_tightening_enabled:
+    false``). Opt in via risk.yaml; validate in shadow before relying on it.
+
+    Returns the original config object unchanged when the gate is disabled
+    or the trigger doesn't fire — no copy is made in those cases. When the
+    trigger fires, returns a shallow copy with the bumped ``min_score_to_enter``
+    so the caller's config dict is never mutated.
+    """
+    if not config.get("batch_confidence_tightening_enabled", False):
+        return config
+
+    threshold = config.get("batch_confidence_threshold", 0.65)
+    bump = config.get("batch_confidence_min_score_bump", 10)
+    base_min_score = config.get("min_score_to_enter", 70)
+
+    mean_conf = _batch_confidence_mean(predictions_by_ticker)
+    if mean_conf is None or mean_conf >= threshold:
+        return config
+
+    tightened_min_score = base_min_score + bump
+    logger.warning(
+        "Batch confidence tightening triggered: mean_confidence=%.3f < %.3f; "
+        "min_score_to_enter %d → %d for run_date=%s",
+        mean_conf, threshold, base_min_score, tightened_min_score, run_date,
+    )
+    derived = dict(config)
+    derived["min_score_to_enter"] = tightened_min_score
+    derived["_batch_confidence_tightening_applied"] = {
+        "mean_confidence": mean_conf,
+        "threshold": threshold,
+        "base_min_score": base_min_score,
+        "tightened_min_score": tightened_min_score,
+    }
+    return derived
+
+
 def _entry_priority_key(sig: dict, predictions_by_ticker: dict) -> tuple[float, float]:
     """Sort key controlling the order in which ENTER candidates are processed.
 
@@ -347,6 +423,11 @@ def decide_entries(
     # payload). Both stamped on every structured risk event for artifact
     # lineage parity with PR #138's trades.signal_date column.
     signals_date = signals_raw.get("date", run_date) if signals_raw else run_date
+
+    # Tighten min_score_to_enter when batch-mean prediction_confidence is
+    # broadly low (degenerate-predictor backstop). Returns the original
+    # config when the feature flag is off or the trigger doesn't fire.
+    config = _apply_batch_confidence_tightening(config, predictions_by_ticker, run_date)
 
     # Process candidates in priority order: research composite score first,
     # predicted_alpha as the tie-break. The risk_guard's max_total_equity

--- a/tests/test_batch_confidence_tightening.py
+++ b/tests/test_batch_confidence_tightening.py
@@ -1,0 +1,379 @@
+"""Tests for batch-confidence-aware min_score tightening.
+
+Per the 2026-05-07 predictor audit's Phase 1: when the predictor batch's
+mean prediction_confidence is broadly low (degenerate output pattern),
+tighten min_score_to_enter as a backstop. Feature-flagged off by default;
+these tests validate the helpers and the integration with decide_entries.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from executor.deciders import (
+    _apply_batch_confidence_tightening,
+    _batch_confidence_mean,
+)
+
+
+# ── _batch_confidence_mean ────────────────────────────────────────────────
+
+class TestBatchConfidenceMean:
+
+    def test_simple_mean(self):
+        preds = {
+            "A": {"prediction_confidence": 0.5},
+            "B": {"prediction_confidence": 0.7},
+            "C": {"prediction_confidence": 0.9},
+        }
+        assert _batch_confidence_mean(preds) == pytest.approx(0.7)
+
+    def test_skips_missing_confidence_field(self):
+        preds = {
+            "A": {"prediction_confidence": 0.6},
+            "B": {},  # no confidence — skipped
+            "C": {"prediction_confidence": 0.8},
+        }
+        assert _batch_confidence_mean(preds) == pytest.approx(0.7)
+
+    def test_skips_none_confidence(self):
+        preds = {
+            "A": {"prediction_confidence": 0.6},
+            "B": {"prediction_confidence": None},
+            "C": {"prediction_confidence": 0.8},
+        }
+        assert _batch_confidence_mean(preds) == pytest.approx(0.7)
+
+    def test_returns_none_on_empty_dict(self):
+        assert _batch_confidence_mean({}) is None
+
+    def test_returns_none_on_none(self):
+        assert _batch_confidence_mean(None) is None
+
+    def test_returns_none_when_no_valid_confidences(self):
+        preds = {
+            "A": {},
+            "B": {"prediction_confidence": None},
+        }
+        assert _batch_confidence_mean(preds) is None
+
+    def test_skips_non_dict_values(self):
+        preds = {
+            "A": {"prediction_confidence": 0.7},
+            "B": "garbage",  # not a dict — skipped
+        }
+        assert _batch_confidence_mean(preds) == pytest.approx(0.7)
+
+
+# ── _apply_batch_confidence_tightening ────────────────────────────────────
+
+class TestApplyBatchConfidenceTightening:
+
+    def test_returns_unchanged_when_disabled(self):
+        config = {
+            "batch_confidence_tightening_enabled": False,
+            "min_score_to_enter": 30,
+        }
+        preds = {"A": {"prediction_confidence": 0.20}}  # very low
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result is config  # same object, no copy
+        assert result["min_score_to_enter"] == 30
+
+    def test_returns_unchanged_when_flag_missing(self):
+        # Default behavior when the key isn't set in risk.yaml at all.
+        config = {"min_score_to_enter": 30}
+        preds = {"A": {"prediction_confidence": 0.20}}
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result is config
+
+    def test_does_not_trigger_when_confidence_above_threshold(self):
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        preds = {
+            "A": {"prediction_confidence": 0.80},
+            "B": {"prediction_confidence": 0.90},
+        }
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result is config  # threshold not crossed → no copy
+
+    def test_triggers_when_confidence_below_threshold(self):
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        preds = {
+            "A": {"prediction_confidence": 0.55},
+            "B": {"prediction_confidence": 0.60},
+        }
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result is not config  # different object — copy was made
+        assert result["min_score_to_enter"] == 40  # 30 + 10 bump
+        # Original unchanged.
+        assert config["min_score_to_enter"] == 30
+
+    def test_triggers_at_exact_threshold_boundary(self):
+        # Threshold is "< threshold" (strict), so equal does NOT trigger.
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.60,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        preds = {"A": {"prediction_confidence": 0.60}}
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result is config  # no trigger at exact boundary
+
+    def test_records_diagnostic_metadata_on_trigger(self):
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        preds = {"A": {"prediction_confidence": 0.50}}
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        meta = result.get("_batch_confidence_tightening_applied")
+        assert meta is not None
+        assert meta["mean_confidence"] == 0.50
+        assert meta["threshold"] == 0.65
+        assert meta["base_min_score"] == 30
+        assert meta["tightened_min_score"] == 40
+
+    def test_no_trigger_when_predictions_empty(self):
+        # Empty predictions dict → can't compute mean → don't trigger.
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        result = _apply_batch_confidence_tightening(config, {}, "2026-05-07")
+        assert result is config
+
+    def test_no_trigger_when_predictions_none(self):
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+            "min_score_to_enter": 30,
+        }
+        result = _apply_batch_confidence_tightening(config, None, "2026-05-07")
+        assert result is config
+
+    def test_uses_yaml_default_min_score_when_unset(self):
+        # When config doesn't explicitly set min_score_to_enter, the helper
+        # uses the same default the risk_guard does (70).
+        config = {
+            "batch_confidence_tightening_enabled": True,
+            "batch_confidence_threshold": 0.65,
+            "batch_confidence_min_score_bump": 10,
+        }
+        preds = {"A": {"prediction_confidence": 0.50}}
+        result = _apply_batch_confidence_tightening(config, preds, "2026-05-07")
+        assert result["min_score_to_enter"] == 80  # 70 default + 10 bump
+
+
+# ── Integration with decide_entries ──────────────────────────────────────
+
+import pandas as pd
+from executor.deciders import decide_entries
+
+
+def _df_history(base: float = 100.0):
+    closes = [base * (1 + 0.001 * i) for i in range(40)]
+    return pd.DataFrame(
+        {"close": closes, "high": [c * 1.01 for c in closes],
+         "low": [c * 0.99 for c in closes], "volume": [1_000_000] * 40},
+        index=pd.date_range("2026-03-01", periods=40, freq="B"),
+    )
+
+
+def _base_config():
+    return {
+        "min_score_to_enter": 50,
+        "max_position_pct": 0.05,
+        "max_sector_pct": 0.30,
+        "max_total_equity_pct": 0.95,
+        "drawdown_halt_pct": 0.20,
+        "atr_sizing_enabled": False,
+        "momentum_gate_enabled": False,
+        "earnings_proximity_warning_days": 0,
+    }
+
+
+def _signal(ticker: str, score: int):
+    return {
+        "ticker": ticker,
+        "signal": "ENTER",
+        "score": score,
+        "conviction": "rising",
+        "sector": "Technology",
+        "rating": "BUY",
+        "price_target_upside": 0.15,
+        "thesis_summary": "test",
+    }
+
+
+class TestDecideEntriesAppliesTightening:
+
+    def test_low_batch_confidence_blocks_marginal_score_when_enabled(self):
+        # Setup: signal with score=55 (clears base min_score=50), low batch
+        # confidence (0.50), tightening flag on, bump=10 → tightened to 60 →
+        # signal now blocked.
+        config = _base_config()
+        config["batch_confidence_tightening_enabled"] = True
+        config["batch_confidence_threshold"] = 0.65
+        config["batch_confidence_min_score_bump"] = 10
+
+        sig = _signal("MARG", 55)
+        preds = {"MARG": {"prediction_confidence": 0.50, "predicted_alpha": 0.001,
+                          "gbm_veto": False}}
+
+        signals_raw = {
+            "date": "2026-05-07",
+            "market_regime": "neutral",
+            "sector_ratings": {"Technology": {"rating": "market_weight"}},
+            "enter": [sig],
+            "exit": [],
+            "reduce": [],
+            "hold": [],
+            "universe": [sig],
+            "buy_candidates": [sig],
+        }
+        all_tickers = ["MARG"]
+        plan = decide_entries(
+            enter_signals=[sig],
+            signals_raw=signals_raw,
+            predictions_by_ticker=preds,
+            config=config,
+            strategy_config={"vwap_threshold_pct": 1.0,
+                             "intraday_support_lookback_days": 20,
+                             "drawdown_forced_exit_enabled": False},
+            market_regime="neutral",
+            sector_ratings=signals_raw["sector_ratings"],
+            portfolio_nav=1_000_000.0,
+            peak_nav=1_000_000.0,
+            current_positions={},
+            prices_now={"MARG": 100.0},
+            price_histories={"MARG": _df_history()},
+            atr_map={"MARG": 0.02},
+            vwap_map={"MARG": 100.0},
+            coverage_map={"MARG": 1.0},
+            dd_multiplier=1.0,
+            signal_age_days=0,
+            earnings_by_ticker={},
+            run_date="2026-05-07",
+            predictions_date="2026-05-07",
+        )
+
+        # Tightening should have raised min_score 50 → 60; score=55 now fails.
+        assert plan.n_entered == 0
+        # Block reason should reference the new tightened min_score (60), not 50.
+        assert any("60" in (b.get("block_reason") or "") for b in plan.blocked)
+
+    def test_low_batch_confidence_does_nothing_when_disabled(self):
+        # Same input as above but with the flag off — signal should clear.
+        config = _base_config()
+        # Tightening explicitly disabled (mirrors current production default).
+        config["batch_confidence_tightening_enabled"] = False
+
+        sig = _signal("MARG", 55)
+        preds = {"MARG": {"prediction_confidence": 0.50, "predicted_alpha": 0.001,
+                          "gbm_veto": False}}
+
+        signals_raw = {
+            "date": "2026-05-07",
+            "market_regime": "neutral",
+            "sector_ratings": {"Technology": {"rating": "market_weight"}},
+            "enter": [sig],
+            "exit": [],
+            "reduce": [],
+            "hold": [],
+            "universe": [sig],
+            "buy_candidates": [sig],
+        }
+        plan = decide_entries(
+            enter_signals=[sig],
+            signals_raw=signals_raw,
+            predictions_by_ticker=preds,
+            config=config,
+            strategy_config={"vwap_threshold_pct": 1.0,
+                             "intraday_support_lookback_days": 20,
+                             "drawdown_forced_exit_enabled": False},
+            market_regime="neutral",
+            sector_ratings=signals_raw["sector_ratings"],
+            portfolio_nav=1_000_000.0,
+            peak_nav=1_000_000.0,
+            current_positions={},
+            prices_now={"MARG": 100.0},
+            price_histories={"MARG": _df_history()},
+            atr_map={"MARG": 0.02},
+            vwap_map={"MARG": 100.0},
+            coverage_map={"MARG": 1.0},
+            dd_multiplier=1.0,
+            signal_age_days=0,
+            earnings_by_ticker={},
+            run_date="2026-05-07",
+            predictions_date="2026-05-07",
+        )
+
+        # With flag off, score=55 clears base min_score=50 — entry approved.
+        assert plan.n_entered == 1
+
+    def test_does_not_mutate_caller_config(self):
+        # Verify the helper makes a copy when triggered, never mutating input.
+        config = _base_config()
+        config["batch_confidence_tightening_enabled"] = True
+        config["batch_confidence_threshold"] = 0.65
+        config["batch_confidence_min_score_bump"] = 10
+
+        sig = _signal("MARG", 90)  # well above either threshold
+        preds = {"MARG": {"prediction_confidence": 0.50, "predicted_alpha": 0.001,
+                          "gbm_veto": False}}
+
+        signals_raw = {
+            "date": "2026-05-07",
+            "market_regime": "neutral",
+            "sector_ratings": {"Technology": {"rating": "market_weight"}},
+            "enter": [sig],
+            "exit": [], "reduce": [], "hold": [],
+            "universe": [sig], "buy_candidates": [sig],
+        }
+        decide_entries(
+            enter_signals=[sig],
+            signals_raw=signals_raw,
+            predictions_by_ticker=preds,
+            config=config,
+            strategy_config={"vwap_threshold_pct": 1.0,
+                             "intraday_support_lookback_days": 20,
+                             "drawdown_forced_exit_enabled": False},
+            market_regime="neutral",
+            sector_ratings=signals_raw["sector_ratings"],
+            portfolio_nav=1_000_000.0,
+            peak_nav=1_000_000.0,
+            current_positions={},
+            prices_now={"MARG": 100.0},
+            price_histories={"MARG": _df_history()},
+            atr_map={"MARG": 0.02},
+            vwap_map={"MARG": 100.0},
+            coverage_map={"MARG": 1.0},
+            dd_multiplier=1.0,
+            signal_age_days=0,
+            earnings_by_ticker={},
+            run_date="2026-05-07",
+            predictions_date="2026-05-07",
+        )
+
+        # Caller's config must remain unchanged regardless of trigger outcome.
+        assert config["min_score_to_enter"] == 50
+        assert "_batch_confidence_tightening_applied" not in config


### PR DESCRIPTION
## Summary

Phase 1 deliverable 2/2 from the [2026-05-07 predictor audit](../../alpha-engine-docs/private/predictor-audit-260507.md). Adds a feature-flagged backstop gate that tightens `min_score_to_enter` when the predictor batch's mean `prediction_confidence` is broadly low.

## Why

Today's incident: 16 of 27 tickers clamped to `p_up=0.458` (mean batch conf ~0.60), 5 saturated at `conf=0.99`. **Per-ticker confidence looked fine** (each clamped ticker was ~0.54), but the batch distribution was degenerate. The existing per-ticker gates couldn't catch it as a systemic issue. A batch-level aggregate is the right abstraction.

The audit's framing (§9.1, §9.2): risk-management-driven, not sizing-driven. Tightens the entry gate; doesn't affect sizing.

## How it works

- **`_batch_confidence_mean(predictions_by_ticker)`** — mean of `prediction_confidence` across valid predictions; skips missing/None; returns None on empty.
- **`_apply_batch_confidence_tightening(config, predictions_by_ticker, run_date)`** — returns a derived config with `min_score_to_enter` bumped when mean < threshold. Returns the **original config object** unchanged when the flag is off or trigger doesn't fire (no copy made — caller's dict never mutated).
- **`decide_entries`** calls the helper once at the top; all downstream `check_order` calls see the tightened gate without further plumbing.

## Configuration surface

Three new keys, all defaulted off:

```yaml
batch_confidence_tightening_enabled: false   # opt-in default
batch_confidence_threshold: 0.65             # trigger when mean batch conf <
batch_confidence_min_score_bump: 10          # bump amount
```

**Production driver** is `alpha-engine-config/executor/risk.yaml` — keys added in [`alpha-engine-config#58`](https://github.com/cipher813/alpha-engine-config/pull/58). The `risk.yaml.example` in this repo carries the keys for documentation/template purposes only; it doesn't drive anything in production. Validate in shadow before flipping the master flag in alpha-engine-config.

## Diagnostic metadata

When the trigger fires, the derived config carries `_batch_confidence_tightening_applied` with `{mean_confidence, threshold, base_min_score, tightened_min_score}`. Risk_guard's veto reason already includes the (now derived) min_score, so vetoes triggered by the tightening are auditable in the standard risk_event log.

## Test plan

- [x] 19 new tests in `test_batch_confidence_tightening.py`:
  - `_batch_confidence_mean`: 7 tests covering simple mean, missing/None handling, empty/None dict, non-dict tolerance
  - `_apply_batch_confidence_tightening`: 9 tests covering flag-off no-op (same object returned, no copy), threshold-not-crossed no-op, exact-boundary check (strict `<`), diagnostic-metadata recording, default min_score=70 fallback
  - `decide_entries` integration: 3 tests covering trigger-blocks-marginal-score, flag-off-allows-marginal-score, caller-config-non-mutation
- [x] Full executor test suite: 524/524 pass (505 → 524, +19 net)
- [x] Pre-push dry-run gate passed
- [ ] After merge + alpha-engine-config#58 merge: enable in production risk.yaml after a quiet trading day; confirm the warning log fires when batch mean conf is below threshold; confirm the standard veto path (`min_score` reason) reflects the tightened threshold

## Audit context

- Companion to [#147](https://github.com/cipher813/alpha-engine/pull/147) (predicted_alpha tie-break ranking) which shipped earlier today.
- Production driver companion: [`alpha-engine-config#58`](https://github.com/cipher813/alpha-engine-config/pull/58).
- **Phase 1 executor track is now complete.** Remaining Phase 1 work is predictor-side: Track A (canonical-label shadow window — blocked on evaluator-revamp PR 6) and Track B (horizon measurement battery — actionable now, ~2-3 weeks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)