### PR TITLE
fix(flow-doctor): wire S3Notifier — funnel executor alerts to changelog corpus

### DIFF
--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -11,6 +11,9 @@ notify:
   - type: github
     repo: cipher813/alpha-engine
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+  - type: s3
+    bucket: alpha-engine-research
+    subsystem: executor
 store:
   type: sqlite
   path: /tmp/flow_doctor.db


### PR DESCRIPTION
## Summary

Closes the changelog event-mining coverage gap surfaced by 2026-05-07 audit. ROADMAP claimed Gap 1 closed 2026-05-01 with "5 PRs across 5 repos: ... -type: s3 yaml blocks" but only \`alpha-engine-data\` actually has the block live. Today's 100 corpus entries split: 72 ci-deploy + 20 sns-mirror + 8 cloudwatch-mirror — **zero source=flow-doctor**.

Three-line yaml addition adding the S3 notify channel. Per-repo subsystem mapping per vocab.yaml: executor → \`executor\`.

Pure config — no code, no tests, no new deps. \`alpha-engine-lib[flow_doctor]\` already pulls \`flow-doctor[diagnosis,s3]>=0.4.0\`. IAM already covered: \`alpha-engine-executor-role\`'s \`alpha-engine-research-bucket-write\` policy grants \`s3:PutObject\` on \`alpha-engine-research/*\` (wildcard includes \`changelog/entries/*\`).

After deploy + next \`flow-doctor.report()\` call, entries will land at \`s3://alpha-engine-research/changelog/entries/{date}/{event_id}.json\` with \`source=flow-doctor\`, \`subsystem=executor\`, severity mapped from flow_doctor's critical/error/warning, plus the nested \`flow_doctor\` provenance block.

## Companion PRs in same arc

- alpha-engine-research (subsystem: research)
- alpha-engine-predictor (subsystem: predictor)
- alpha-engine-dashboard (subsystem: dashboard)

## Test plan

- [x] Yaml syntactically valid
- [ ] Live verification: next flow-doctor alert from executor lands in changelog/entries/ with \`source=flow-doctor\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)