### PR TITLE
docs(email): note α in EOD GBM rows is log-domain post 2026-05-09

### DIFF
--- a/executor/eod_emailer.py
+++ b/executor/eod_emailer.py
@@ -286,6 +286,18 @@ def build_eod_email(
             )
             plain_parts.append(f"  {ticker}: {narrative}")
         html_parts.append("</table>")
+        html_parts.append(
+            '<p style="font-size:11px; color:#888; margin-top:4px;">'
+            'ⓘ α in <b>GBM:</b> rows is log-domain decimal at the 21d horizon '
+            '(post 2026-05-09 canonical-alpha cutover). Top-of-email Daily Alpha '
+            'is unchanged: arithmetic portfolio return − SPY return.'
+            '</p>'
+        )
+        plain_parts.append(
+            "  Note: α in GBM: rows is log-domain decimal at 21d horizon "
+            "(post 2026-05-09 cutover). Top-of-email Daily Alpha is "
+            "unchanged arithmetic portfolio − SPY."
+        )
         plain_parts.append("")
 
     # ── Sector Attribution ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds a one-line footnote (HTML + plain) at the end of the EOD email's Position Rationale section explaining that the per-position GBM `α=…%` rendered there is log-domain decimal at the 21d horizon post the 2026-05-09 canonical-alpha cutover, displayed as `%` for readability.
- Explicitly distinguishes it from the top-of-email Daily Alpha (portfolio return − SPY return), which remains arithmetic and is computed independently of the predictor.
- No behavior change — the underlying `predicted_alpha` value rendered into the narrative was already log-domain after the cutover; this just makes the displayed semantics explicit so the two α numbers in the same email aren't conflated on tail tickers.

## Why
Composes with the predictor email PR (`alpha-engine-predictor#128`) and the backtester rolling-analytics PR (`alpha-engine-backtester#178`) — together they make every user-facing α field self-documenting through the ~4-week observation window. The cosmetic divergence between log and arithmetic is negligible at small magnitudes (log(1+r) ≈ r) but visible at tail values (e.g. -10% log ≈ -9.5% arithmetic; asymmetric on the downside), which is exactly when a reader would cross-check the email field against realized P&L.

## Test plan
- [x] `pytest -q -k eod` passes (86 passed)
- [ ] Next EOD email renders the new footnote and confirms the existing top-of-email α subject + summary table is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)