### PR TITLE
fix(deps): bump alpha-engine-lib v0.2.2 → v0.2.4 to unblock daemon flow-doctor init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,10 @@ requests~=2.32
 # Gateway noise (10197 = iOS app steals live-data session, 10349 = TIF
 # coerced to DAY per order preset — order still placed). See daemon.py /
 # main.py / eod_reconcile.py.
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.2
+#
+# v0.2.4 is the minimum that bundles flow-doctor>=0.4.0, which adds the
+# `s3` notifier type required by `flow-doctor.yaml`. v0.2.2 + flow-doctor
+# 0.3.0 crashed the daemon at `setup_logging` with
+# `ConfigError: notify[2] (type=s3): unknown notifier type 's3'`
+# (2026-05-11 incident — 205 systemd restarts before stop).
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.4


### PR DESCRIPTION
## Summary

- Bump `alpha-engine-lib[flow_doctor] @ v0.2.2` → `@v0.2.4` in `requirements.txt`.
- The bumped version transitively pulls `flow-doctor[diagnosis,s3]>=0.4.0,<0.5.0` (alpha-engine-lib PR #14), which adds the `s3` notifier type required by the shared `flow-doctor.yaml` config.

## Why

The daemon has been **crash-looping 205+ times** as of today (2026-05-11). systemd journal shows `Main process exited, code=exited, status=1/FAILURE` every 38s. `/var/log/daemon.log` reveals the cause at `setup_logging`:

```
flow_doctor.core.errors.ConfigError: notify[2] (type=s3):
  unknown notifier type 's3'. Supported types: slack, email, github.
```

Root cause: alpha-engine has been pinned at `alpha-engine-lib@v0.2.2` which transitively pulls flow-doctor 0.3.0 (no `s3` notifier). The shared `flow-doctor.yaml` declares an `s3` notifier for the system-wide changelog corpus. Other repos (data, predictor, research, backtester, dashboard) all use lib `v0.5.6+` which pins `flow-doctor>=0.4.0` — only alpha-engine drifted behind.

## Why this matters for memory

The daemon crash-loop was the **load-bearing trigger** for today's MorningEnrich OOM cascade. Every 38s the daemon spins up a fresh python process (loading pandas/numpy/IB libs → ~200-300MB transient) before flow-doctor init crashes it. Stacked with daily_append's ~1GB working set on a 2GB t3.small + SSM agent + IB Gateway, peak memory blew past available + swap.

After this PR ships + EC2 venv is upgraded, the daemon will reach its actual application logic instead of dying at import time, freeing ~200-300MB of constant transient churn.

## Why v0.2.4, not v0.5.6+ or v0.8.0

Minimum-surface fix. v0.2.4's only behavioral delta from v0.2.2:
- `chore: bump flow-doctor pin to >=0.4.0,<0.5.0` (PR #14) — load-bearing
- `feat(cost): cost-telemetry pricing primitive` (PR #13) — additive, executor doesn't import
- `feat(ci): emit system-wide deploy changelog entry` (PR #12) — CI-side, no runtime effect

Larger lib jump to align with peers (v0.5.6/v0.6.2/v0.7.0/v0.8.0) deferred to a follow-up PR — keeping the immediate fix minimum-surface so the daemon stops crash-looping today without dragging in unrelated lib feature additions.

## Operational follow-ups (separate from this PR)

- Trading EC2 daemon currently stopped manually (`systemctl stop alpha-engine-daemon.timer && systemctl stop alpha-engine-daemon.service`) to halt the crash-loop while this PR ships
- After merge: EC2 boot-pull will pick up new requirements; venv needs `pip install -r requirements.txt --upgrade --upgrade-strategy eager` to actually pull the new lib + flow-doctor versions (a clean reinstall or explicit upgrade)
- Once verified, re-enable daemon timer + service

## Test plan

- [ ] CI passes
- [ ] Post-merge on EC2: `pip install -r requirements.txt --upgrade` resolves to flow-doctor>=0.4.0
- [ ] `python -m executor.daemon` no longer crashes at setup_logging
- [ ] Re-enable + start systemd service, confirm no crash-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)