### PR TITLE
feat(stance): stance-conditional position sizing (follow-up A)

### DIFF
--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -706,6 +706,7 @@ def decide_entries(
             signal_age_days=signal_age_days,
             days_to_earnings=earnings_by_ticker.get(ticker),
             feature_coverage=coverage_map.get(ticker),
+            stance=pred_data.get("stance"),
         )
 
         if sizing["shares"] == 0:

--- a/executor/position_sizer.py
+++ b/executor/position_sizer.py
@@ -39,6 +39,7 @@ def compute_position_size(
     signal_age_days: int | None = None,
     days_to_earnings: int | None = None,
     feature_coverage: float | None = None,
+    stance: str | None = None,
 ) -> dict:
     """
     Compute position size for a new ENTER order.
@@ -131,6 +132,35 @@ def compute_position_size(
     # fraction of non-NaN features, floored at ``coverage_derate_floor``
     # so we never size below a meaningful threshold. Continuous (no cliff)
     # so an 87%-covered ticker gets 87% of a 100%-covered ticker's size.
+    # Stance-conditional sizing (stance taxonomy arc PR 4 follow-up).
+    # Per-stance multipliers reflect the asymmetry between stance theses:
+    #   momentum (1.0×) — trend-following, the baseline thesis
+    #   value (0.7×)    — contrarian thesis carries higher uncertainty
+    #                     (catching a falling knife is structurally riskier
+    #                     than riding a trend), so smaller stake
+    #   quality (0.8×)  — defensive names accept smaller positions in
+    #                     exchange for longer hold + tighter exit gates
+    #   catalyst (0.6×) — event-driven = higher variance + binary outcome,
+    #                     smallest stake size
+    #
+    # Multipliers backtester-tunable from day 1 — once 4+ weeks of
+    # stance-tagged history exists, the optimizer can move them based
+    # on per-stance Sharpe / alpha attribution from
+    # backtester#182's ``by_stance`` table.
+    #
+    # Falls through to 1.0× (no adjustment) when stance is None
+    # (pre-stance-arc artifacts) — preserves legacy behavior.
+    if config.get("stance_sizing_enabled", True) and stance is not None:
+        stance_multipliers = {
+            "momentum": config.get("stance_size_momentum", 1.0),
+            "value":    config.get("stance_size_value",    0.7),
+            "quality":  config.get("stance_size_quality",  0.8),
+            "catalyst": config.get("stance_size_catalyst", 0.6),
+        }
+        stance_adj = stance_multipliers.get(stance, 1.0)
+    else:
+        stance_adj = 1.0
+
     if (
         config.get("coverage_sizing_enabled", True)
         and feature_coverage is not None
@@ -144,7 +174,8 @@ def compute_position_size(
     max_pct = config.get("max_position_pct", 0.05)
     raw_weight = (base_weight * sector_adj * conviction_adj * upside_adj
                   * drawdown_multiplier * atr_adj * confidence_adj
-                  * staleness_adj * earnings_adj * coverage_adj)
+                  * staleness_adj * earnings_adj * coverage_adj
+                  * stance_adj)
     position_weight = min(raw_weight, max_pct)
 
     # ATR volatility cap: ensure ATR constraint is not overridden by other
@@ -167,6 +198,7 @@ def compute_position_size(
         f"dd_mult={drawdown_multiplier} atr_adj={atr_adj} "
         f"confidence_adj={confidence_adj} staleness_adj={staleness_adj} "
         f"earnings_adj={earnings_adj} coverage_adj={coverage_adj} "
+        f"stance_adj={stance_adj} "
         f"→ {position_weight:.3f} NAV = ${dollar_size:.0f} = {shares} shares"
     )
 
@@ -183,4 +215,5 @@ def compute_position_size(
         "staleness_adj": staleness_adj,
         "earnings_adj": earnings_adj,
         "coverage_adj": coverage_adj,
+        "stance_adj": stance_adj,
     }

--- a/tests/test_position_sizer.py
+++ b/tests/test_position_sizer.py
@@ -481,3 +481,101 @@ class TestComputePositionSize:
         # base=0.04, sector=0.85, dd=0.25 → 0.04*0.85*0.25=0.0085
         # dollar = 5000 * 0.0085 = 42.50 < 500 min
         assert result["shares"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Stance-conditional sizing (stance taxonomy arc PR 4 follow-up, 2026-05-11)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestStanceConditionalSizing:
+    """Per-stance position-size multipliers.
+
+    Defaults (executor falls back to these if config doesn't override):
+      momentum 1.0× — baseline thesis (trend-following)
+      value    0.7× — contrarian thesis carries higher uncertainty
+      quality  0.8× — defensive names: smaller stake, longer hold
+      catalyst 0.6× — event-driven: highest variance, smallest stake
+
+    Backtester-tunable from day 1 — multipliers in
+    config/executor_params.json. Auto-tuned weekly once 4+ weeks of
+    stance-tagged history accumulates.
+    """
+
+    def _sizing(self, stance, **cfg_overrides):
+        """Single-entry helper — returns the full sizing dict."""
+        cfg_kwargs = {
+            "max_position_pct": 1.0,        # disable cap so the multiplier shows through
+            "stance_sizing_enabled": True,
+        }
+        cfg_kwargs.update(cfg_overrides)
+        cfg = _base_config(**cfg_kwargs)
+        return compute_position_size(
+            ticker="X",
+            portfolio_nav=1_000_000,
+            enter_signals=[{"ticker": "X"}],
+            signal=_base_signal(),
+            sector_rating="market_weight",
+            current_price=100.0,
+            config=cfg,
+            stance=stance,
+        )
+
+    def test_momentum_stance_default_multiplier_is_1_0(self):
+        r = self._sizing("momentum")
+        assert r["stance_adj"] == pytest.approx(1.0)
+
+    def test_value_stance_default_multiplier_is_0_7(self):
+        r = self._sizing("value")
+        assert r["stance_adj"] == pytest.approx(0.7)
+
+    def test_quality_stance_default_multiplier_is_0_8(self):
+        r = self._sizing("quality")
+        assert r["stance_adj"] == pytest.approx(0.8)
+
+    def test_catalyst_stance_default_multiplier_is_0_6(self):
+        r = self._sizing("catalyst")
+        assert r["stance_adj"] == pytest.approx(0.6)
+
+    def test_unknown_stance_falls_back_to_1_0(self):
+        """A stance label not in the canonical set falls back to 1.0×
+        (no adjustment). Defensive — protects against a future
+        vocabulary change that ships before this PR is updated."""
+        r = self._sizing("growth")  # not in canonical 4
+        assert r["stance_adj"] == pytest.approx(1.0)
+
+    def test_stance_none_no_adjustment(self):
+        """stance=None (pre-stance-arc artifacts) → no multiplier
+        applied. Legacy behavior preserved."""
+        r = self._sizing(None)
+        assert r["stance_adj"] == pytest.approx(1.0)
+
+    def test_stance_sizing_disabled_via_config_flag(self):
+        """``stance_sizing_enabled=False`` break-glass flag disables
+        the multiplier even when stance is provided. Used for A/B
+        comparison during the rollout window."""
+        r = self._sizing("catalyst", stance_sizing_enabled=False)
+        assert r["stance_adj"] == pytest.approx(1.0)
+
+    def test_stance_multipliers_overridable_via_config(self):
+        """Backtester-tunable: each multiplier reads from config first,
+        falls back to the canonical default. Pinned so the
+        executor_optimizer auto-tune path can move them."""
+        r = self._sizing("value", stance_size_value=0.5)
+        assert r["stance_adj"] == pytest.approx(0.5)
+
+    def test_stance_multiplier_propagates_through_to_position_pct(self):
+        """End-to-end: a catalyst pick should size at 0.6× of a momentum
+        pick with otherwise-identical inputs."""
+        r_momentum = self._sizing("momentum")
+        r_catalyst = self._sizing("catalyst")
+        ratio = r_catalyst["position_pct"] / r_momentum["position_pct"]
+        assert ratio == pytest.approx(0.6, rel=1e-3)
+
+    def test_value_stance_smaller_dollar_size_than_momentum(self):
+        """A value pick gets ~70% of a momentum pick's dollars on the
+        same setup — the institutional contrarian-stance discipline."""
+        r_momentum = self._sizing("momentum")
+        r_value = self._sizing("value")
+        assert r_value["dollar_size"] < r_momentum["dollar_size"]
+        assert r_value["dollar_size"] / r_momentum["dollar_size"] == pytest.approx(0.7, rel=1e-3)


### PR DESCRIPTION
## Summary

Stance taxonomy arc follow-up **A**. Threads the predictor's stance label into ``compute_position_size`` and applies per-stance multipliers to the raw_weight chain.

- New ``stance: str | None`` parameter on ``compute_position_size``
- Default multipliers: momentum 1.0× / value 0.7× / quality 0.8× / catalyst 0.6×
- New config keys: ``stance_sizing_enabled`` (default True) + ``stance_size_{momentum,value,quality,catalyst}``
- Wired in ``deciders.py`` call site — reads ``pred_data.get("stance")``
- 10 new tests in ``TestStanceConditionalSizing``
- Full executor suite: 551 passed

## Why these multipliers

Institutional discipline: higher-uncertainty theses get smaller stakes.

| Stance | Multiplier | Rationale |
|---|---|---|
| momentum | 1.0× | Baseline — trend-following is the most-historically-validated thesis |
| quality | 0.8× | Defensive: smaller stake in exchange for longer hold + tighter exit gates |
| value | 0.7× | Contrarian thesis carries higher uncertainty (catching a falling knife is structurally riskier) |
| catalyst | 0.6× | Event-driven = binary outcome + highest variance |

Thesis-uncertainty ordering (`momentum > quality > value > catalyst`) is pinned by `test_stance_size_factory_defaults_obey_thesis_order` in the backtester PR so a future hand-edit can't accidentally flip the discount direction.

## Backtester-tunable

Each multiplier reads from config first, falls back to the canonical default. The companion backtester PR adds all 4 to ``SAFE_PARAMS`` + ``EXTENDED_GRID`` with bracketed sweep ranges so the optimizer can move them in either direction once 4+ weeks of stance-tagged history accumulates.

## V1 simple consumer path

This PR reads the discrete ``stance`` (argmax of loadings) and applies a single multiplier. The continuous ``stance_loadings`` field is available for a future weighted-sizing v2 — read each loading and apply a blended multiplier `(0.65 * 1.0 + 0.20 * 0.8 + 0.10 * 0.7 + 0.05 * 0.6)` = 0.86×. Defer until v1 proves the architecture.

## Composes with

- alpha-engine-lib#38 (merged) — StanceLiteral vocabulary
- alpha-engine-lib#39 — StanceLoadings continuous
- alpha-engine-predictor#137 — heuristic classifier emits stance
- alpha-engine#153 — stance-conditional momentum gate
- alpha-engine-backtester#NNN (parallel) — adds the 4 multipliers to SAFE_PARAMS + sweep grid

## Test plan

- [x] `pytest tests/test_position_sizer.py::TestStanceConditionalSizing` — 10/10 new pass
- [x] Full executor suite: 551 passed
- [ ] Post-deploy: confirm sizing dict includes ``stance_adj`` field on each entry's log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)