### PR TITLE
chore(lib): bump alpha-engine-lib v0.2.4 → v0.9.1 (align with predictor pin)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,4 @@ requests~=2.32
 # 0.3.0 crashed the daemon at `setup_logging` with
 # `ConfigError: notify[2] (type=s3): unknown notifier type 's3'`
 # (2026-05-11 incident — 205 systemd restarts before stop).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.2.4
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.9.1


### PR DESCRIPTION
## Summary
- Bump alpha-engine-lib pin v0.2.4 → v0.9.1 in `requirements.txt`
- Aligns executor with predictor (alpha-engine-predictor#138 just bumped v0.8.0 → v0.9.1)

## Why now
Established consumer-pin discipline: every consumer tracks the same lib tag so the active version is a single grep across the repos. Lagging consumers caused cascading lockstep failures in the past (memory: `feedback_lib_pin_bump_lockstep`, tag/sentinel skew on 2026-05-07 dashboard incident).

## Span covers
v0.2.4 → v0.9.1 spans ~7 minor releases — all additive:
- v0.3.0: RAG consolidation
- v0.4.0: deploy-drift preflight check
- v0.5.x: transparency substrate inventory + Pydantic agent schemas
- v0.6.x: collector error reporting helper
- v0.7.x: CIORawDecision.rule_tags
- v0.8.0: eval_artifacts canonical S3 layout
- v0.9.0 / v0.9.1: StanceLiteral + StanceLoadings

Executor consumes `dates` / `logging` / `trading_calendar` / `preflight.BasePreflight` — none break across this span.

## Test plan
- [x] Local `python -m pip install --upgrade alpha-engine-lib[...]@v0.9.1` succeeded (flow-doctor pinned to 0.4.0 per lib `[flow_doctor]` extras)
- [x] Full local `pytest tests/` — 568 passed
- [ ] CI green
- [ ] Boot-pull picks up new pin on next trading-instance boot (next weekday SF)

## F follow-up (deferred)
Executor does not currently import `StanceLiteral` (consumes `pred_data["stance"]` as raw string). This bump unlocks future type-hinting of stance-gate branches in `deciders.py` without another pin dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)