### PR TITLE
feat(optimizer): MVO portfolio optimizer kernel — PR 1 of cash-management arc

### DIFF
--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -1,0 +1,312 @@
+"""
+Constrained mean-variance portfolio optimizer — PR 1 of the portfolio-optimizer
+arc (plan: `alpha-engine-docs/private/portfolio-optimizer-260511.md`).
+
+The institutional benchmark-as-null pattern: SPY (the benchmark) is the
+no-conviction fill, cash is a pinned operational sleeve, conviction picks
+express deviation from SPY within sector + position + vol-target constraints.
+
+Math:
+    maximize   wᵀα̂  −  λ · wᵀΣw  −  τ · ‖w − w_prev‖₁
+    s.t.       Σwᵢ = 1                                    (budget)
+               w[CASH] = cash_sleeve                       (sleeve pin)
+               0 ≤ wᵢ ≤ stance_capᵢ                       (per-name cap)
+               Σ_{i∈sector S} wᵢ ≤ max_sector_pct          (sector cap)
+               wᵢ = 0 for i with eligibility=False         (gate mask)
+               wᵀΣw ≤ σ²_target_daily                      (vol-target SOC)
+
+This module is a pure function over numpy inputs. It does no I/O, no logging
+config side effects, no S3 calls — easy to unit-test (PR 1) and easy to wire
+into shadow mode (PR 2).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_CLARABEL = "CLARABEL"
+_FALLBACK_SOLVERS = ("SCS", "OSQP")
+
+
+@dataclass(frozen=True)
+class OptimizerResult:
+    weights: np.ndarray
+    diagnostics: dict
+
+
+def solve_target_weights(
+    tickers: list[str],
+    alpha_hat: np.ndarray,
+    returns_panel: np.ndarray,
+    w_prev: np.ndarray,
+    sectors: list[str],
+    stance_caps: np.ndarray,
+    eligibility: np.ndarray,
+    spy_idx: int,
+    cash_idx: int,
+    cfg: dict,
+) -> OptimizerResult:
+    """
+    Solve the constrained MVO and return target weights + diagnostics.
+
+    Args:
+        tickers: length-N universe. Must contain SPY (benchmark fill) and a
+            CASH sentinel ticker.
+        alpha_hat: shape (N,) predicted alpha vector. Convention: SPY entry is
+            0.0 (benchmark = null hypothesis), CASH entry is a small negative
+            number so the optimizer prefers SPY over cash when ε-indifferent.
+        returns_panel: shape (T, N) daily returns history for covariance
+            estimation. Rows with NaN are dropped pre-shrinkage. Caller is
+            responsible for ensuring CASH column is ~0 (no return) and SPY
+            column has real history.
+        w_prev: shape (N,) current portfolio weights (positions / NAV). Used
+            for the L1 turnover penalty.
+        sectors: length-N sector labels. Use a stable string like "tech",
+            "healthcare". SPY and CASH should have unique sentinel sectors
+            (e.g., "__benchmark__", "__cash__") so they're not summed into
+            real sector caps.
+        stance_caps: shape (N,) per-name upper bound on weight. The caller
+            composes this from base max_pos × stance multiplier × drawdown
+            tier × earnings × coverage. For SPY use a high cap (e.g., 1.0);
+            for CASH the cap is overridden by the equality pin.
+        eligibility: shape (N,) bool. Names with eligibility=False are pinned
+            to w_i = 0. SPY and CASH must be eligibility=True.
+        spy_idx, cash_idx: positions in tickers list.
+        cfg: dict with optimizer parameters. See OPTIMIZER_CONFIG_DEFAULTS.
+
+    Returns:
+        OptimizerResult with weights (length N, sums to 1, sleeve pinned) and
+        diagnostics dict including solver status, portfolio vol, active share
+        vs SPY, and n_active.
+
+    On infeasibility, returns the fallback weights (current weights with cash
+    absorbing the residual) and diagnostics["status"] = "infeasible_fallback".
+    """
+    cfg = {**OPTIMIZER_CONFIG_DEFAULTS, **cfg}
+    _validate_inputs(
+        tickers, alpha_hat, returns_panel, w_prev,
+        sectors, stance_caps, eligibility, spy_idx, cash_idx,
+    )
+
+    N = len(tickers)
+    sigma = _estimate_covariance(returns_panel, cfg)
+
+    try:
+        import cvxpy as cp
+    except ImportError as e:
+        raise ImportError(
+            "cvxpy is required for portfolio_optimizer. Install via "
+            "`pip install 'cvxpy>=1.4,<1.8'`. See requirements.txt."
+        ) from e
+
+    sigma_psd = cp.psd_wrap(sigma)
+    w = cp.Variable(N)
+
+    objective = cp.Maximize(
+        alpha_hat @ w
+        - cfg["risk_aversion"] * cp.quad_form(w, sigma_psd)
+        - (cfg["tcost_bps"] / 1e4) * cp.norm(w - w_prev, 1)
+    )
+
+    eligibility_idx = np.where(~eligibility)[0]
+    effective_caps = np.where(eligibility, stance_caps, 0.0)
+
+    constraints = [
+        cp.sum(w) == 1.0,
+        w >= 0,
+        w <= effective_caps,
+        w[cash_idx] == cfg["cash_sleeve_pct"],
+    ]
+    if cfg.get("vol_target_annual") is not None:
+        sigma_target_daily = cfg["vol_target_annual"] / np.sqrt(252)
+        constraints.append(cp.quad_form(w, sigma_psd) <= sigma_target_daily ** 2)
+    if eligibility_idx.size > 0:
+        constraints.append(w[eligibility_idx] == 0)
+
+    for sector_label in _real_sectors(sectors):
+        idx = [i for i, s in enumerate(sectors) if s == sector_label]
+        constraints.append(cp.sum(w[idx]) <= cfg["max_sector_pct"])
+
+    problem = cp.Problem(objective, constraints)
+    weights, status = _solve_with_fallback(problem, w, cfg)
+
+    if weights is None:
+        weights = _fallback_weights(w_prev, cash_idx, cfg["cash_sleeve_pct"])
+        diagnostics = _build_diagnostics(
+            weights, w_prev, sigma, alpha_hat, spy_idx, "infeasible_fallback", cfg,
+        )
+        return OptimizerResult(weights=weights, diagnostics=diagnostics)
+
+    weights = _clip_and_renormalize(weights, effective_caps, cash_idx, cfg)
+    diagnostics = _build_diagnostics(
+        weights, w_prev, sigma, alpha_hat, spy_idx, status, cfg,
+    )
+    return OptimizerResult(weights=weights, diagnostics=diagnostics)
+
+
+_VOL_TARGET_COMMENT = """
+vol_target_annual default is None (no SOC constraint). For a long-only
+benchmark-aware portfolio that uses SPY as the no-conviction fill, the
+portfolio's natural volatility is bounded below by SPY's vol (≈16% annual),
+since SPY absorbs ~89% of the book on conviction-light days. Setting
+vol_target_annual below SPY vol is structurally infeasible without bonds.
+Set explicitly (e.g., 0.25) to enable a stress-regime cap that only binds
+during high-vol periods. Reserved for v2 multi-asset / risk-parity layer.
+""".strip()
+
+
+OPTIMIZER_CONFIG_DEFAULTS: dict = {
+    "vol_target_annual": None,
+    "risk_aversion": 5.0,
+    "tcost_bps": 5.0,
+    "cash_sleeve_pct": 0.03,
+    "max_sector_pct": 0.25,
+    "covariance_shrinkage": "ledoit_wolf",
+    "min_position_pct": 0.005,
+}
+
+
+def _validate_inputs(
+    tickers: list[str],
+    alpha_hat: np.ndarray,
+    returns_panel: np.ndarray,
+    w_prev: np.ndarray,
+    sectors: list[str],
+    stance_caps: np.ndarray,
+    eligibility: np.ndarray,
+    spy_idx: int,
+    cash_idx: int,
+) -> None:
+    N = len(tickers)
+    if N == 0:
+        raise ValueError("Empty universe — cannot optimize")
+    for name, arr in (
+        ("alpha_hat", alpha_hat),
+        ("w_prev", w_prev),
+        ("stance_caps", stance_caps),
+        ("eligibility", eligibility),
+    ):
+        if arr.shape != (N,):
+            raise ValueError(f"{name} shape {arr.shape} != ({N},)")
+    if returns_panel.ndim != 2 or returns_panel.shape[1] != N:
+        raise ValueError(
+            f"returns_panel shape {returns_panel.shape} incompatible with N={N}"
+        )
+    if len(sectors) != N:
+        raise ValueError(f"sectors length {len(sectors)} != N={N}")
+    if not (0 <= spy_idx < N) or not (0 <= cash_idx < N):
+        raise ValueError(f"spy_idx={spy_idx} cash_idx={cash_idx} out of range [0,{N})")
+    if not eligibility[spy_idx]:
+        raise ValueError("SPY must be eligible (benchmark fill)")
+    if not eligibility[cash_idx]:
+        raise ValueError("CASH must be eligible (sleeve pin)")
+
+
+def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
+    clean = returns_panel[~np.isnan(returns_panel).any(axis=1)]
+    if clean.shape[0] < 20:
+        raise ValueError(
+            f"Need ≥20 clean return rows for covariance; got {clean.shape[0]}"
+        )
+    if cfg["covariance_shrinkage"] == "ledoit_wolf":
+        try:
+            from sklearn.covariance import LedoitWolf
+        except ImportError as e:
+            raise ImportError(
+                "scikit-learn is required for Ledoit-Wolf shrinkage. Install "
+                "via `pip install 'scikit-learn>=1.3,<1.6'`."
+            ) from e
+        return LedoitWolf().fit(clean).covariance_
+    if cfg["covariance_shrinkage"] == "sample":
+        return np.cov(clean, rowvar=False)
+    raise ValueError(f"Unknown covariance_shrinkage: {cfg['covariance_shrinkage']}")
+
+
+def _real_sectors(sectors: list[str]) -> set[str]:
+    return {s for s in sectors if not (s.startswith("__") and s.endswith("__"))}
+
+
+def _solve_with_fallback(problem, w, cfg: dict):
+    import cvxpy as cp
+    for solver in (_CLARABEL, *_FALLBACK_SOLVERS):
+        if solver not in cp.installed_solvers():
+            continue
+        try:
+            problem.solve(solver=solver)
+        except (cp.error.SolverError, ValueError) as e:
+            logger.warning(f"Solver {solver} raised {e!r}, trying next")
+            continue
+        if problem.status in ("optimal", "optimal_inaccurate"):
+            return np.asarray(w.value, dtype=float), problem.status
+        logger.warning(
+            f"Solver {solver} returned status={problem.status}, trying next"
+        )
+    return None, problem.status if problem.status else "no_solver_available"
+
+
+def _fallback_weights(
+    w_prev: np.ndarray, cash_idx: int, cash_sleeve_pct: float,
+) -> np.ndarray:
+    weights = np.maximum(w_prev.copy(), 0.0)
+    weights[cash_idx] = 0.0
+    equity_sum = weights.sum()
+    target_equity = 1.0 - cash_sleeve_pct
+    if equity_sum > 0:
+        weights *= target_equity / equity_sum
+    weights[cash_idx] = cash_sleeve_pct
+    return weights
+
+
+def _clip_and_renormalize(
+    weights: np.ndarray,
+    effective_caps: np.ndarray,
+    cash_idx: int,
+    cfg: dict,
+) -> np.ndarray:
+    weights = np.maximum(weights, 0.0)
+    weights = np.minimum(weights, effective_caps + 1e-8)
+    small = (weights < cfg["min_position_pct"]) & (np.arange(len(weights)) != cash_idx)
+    weights = np.where(small, 0.0, weights)
+    total = weights.sum()
+    if total > 0:
+        weights = weights / total
+    return weights
+
+
+def _build_diagnostics(
+    weights: np.ndarray,
+    w_prev: np.ndarray,
+    sigma: np.ndarray,
+    alpha_hat: np.ndarray,
+    spy_idx: int,
+    status: str,
+    cfg: dict,
+) -> dict:
+    daily_var = float(weights @ sigma @ weights)
+    daily_var = max(daily_var, 0.0)
+    vol_ann = float(np.sqrt(252 * daily_var))
+    spy_only = np.zeros_like(weights)
+    spy_only[spy_idx] = 1.0 - cfg["cash_sleeve_pct"]
+    active_share = float(np.sum(np.abs(weights - spy_only)) / 2)
+    n_active = int(np.sum(weights > cfg["min_position_pct"]))
+    turnover = float(np.sum(np.abs(weights - w_prev)) / 2)
+    return {
+        "status": status,
+        "portfolio_vol_ann": vol_ann,
+        "active_share_vs_spy": active_share,
+        "n_active_positions": n_active,
+        "turnover_one_way": turnover,
+        "expected_alpha": float(weights @ alpha_hat),
+        "weight_sum": float(weights.sum()),
+    }
+
+
+def make_cash_sentinel_returns(n_rows: int) -> np.ndarray:
+    """Helper for callers: cash has zero return (treated as risk-free at sleeve)."""
+    return np.zeros(n_rows)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,16 @@ requests~=2.32
 # `ConfigError: notify[2] (type=s3): unknown notifier type 's3'`
 # (2026-05-11 incident — 205 systemd restarts before stop).
 alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.9.1
+# portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
+# constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
+# scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at
+# import time — executor/portfolio_optimizer.py raises a clear ImportError if
+# missing, so the legacy 1/n sizing path runs unaffected on environments that
+# haven't pulled these in yet.
+# cvxpy + scikit-learn pins are upper-bounded to stay compatible with numpy<2
+# (line 5). cvxpy 1.8+ uses numpy.lib.array_utils (numpy 2.x only); sklearn 1.6+
+# shipped wheels built against numpy 2.x. Both conflict with the arcticdb /
+# pyarrow / pandas stack already pinned in this repo. Drop the upper bounds
+# only when the rest of the requirements graph moves to numpy 2.
+cvxpy>=1.4,<1.8
+scikit-learn>=1.3,<1.6

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -1,0 +1,246 @@
+"""
+Unit tests for executor/portfolio_optimizer.py — PR 1 of portfolio-optimizer arc.
+
+The kernel is pure-numpy in/out; tests exercise the math directly with
+synthetic inputs to confirm:
+  1. Single-asset known-answer (positive α̂ → max_pos in asset, rest in SPY)
+  2. Two-asset symmetric known-answer (equal α̂ + Σ → equal weights)
+  3. Vol-target SOC constraint binds when assets are high-vol
+  4. L1 turnover penalty discourages large rebalances from w_prev
+  5. Eligibility mask pins disallowed names to 0
+  6. Cash sleeve equality constraint cannot be violated
+  7. Sector cap binds when many names in one sector have positive α̂
+  8. Infeasibility falls back to current-weights + cash residual
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from executor.portfolio_optimizer import (
+    OPTIMIZER_CONFIG_DEFAULTS,
+    OptimizerResult,
+    solve_target_weights,
+)
+
+
+def _synthetic_returns(N: int, T: int = 250, vol: float = 0.01, seed: int = 0) -> np.ndarray:
+    """Generate (T, N) iid normal returns with given daily vol."""
+    rng = np.random.default_rng(seed)
+    return rng.normal(0.0, vol, size=(T, N))
+
+
+def _baseline_universe(
+    n_active: int = 2,
+    sector_labels: list[str] | None = None,
+    daily_vol: float = 0.01,
+) -> dict:
+    """
+    Build a baseline universe with N = n_active + 2 (SPY + CASH).
+    Returns a dict of all kwargs needed for solve_target_weights.
+    """
+    if sector_labels is None:
+        sector_labels = ["tech"] * n_active
+    assert len(sector_labels) == n_active
+
+    tickers = [f"T{i}" for i in range(n_active)] + ["SPY", "CASH"]
+    N = len(tickers)
+    spy_idx = N - 2
+    cash_idx = N - 1
+
+    returns = _synthetic_returns(N, vol=daily_vol)
+    returns[:, cash_idx] = 0.0
+
+    return {
+        "tickers": tickers,
+        "alpha_hat": np.zeros(N),
+        "returns_panel": returns,
+        "w_prev": np.zeros(N),
+        "sectors": sector_labels + ["__benchmark__", "__cash__"],
+        "stance_caps": np.full(N, 0.08),
+        "eligibility": np.ones(N, dtype=bool),
+        "spy_idx": spy_idx,
+        "cash_idx": cash_idx,
+        "cfg": {},
+    }
+
+
+def _solve(u: dict) -> OptimizerResult:
+    u["stance_caps"][u["spy_idx"]] = 1.0
+    u["stance_caps"][u["cash_idx"]] = 1.0
+    return solve_target_weights(**u)
+
+
+def test_single_asset_positive_alpha_maxes_position_and_fills_spy():
+    """One asset with positive α̂ → optimizer allocates max_pos to it, SPY absorbs the rest."""
+    u = _baseline_universe(n_active=1)
+    u["alpha_hat"][0] = 0.05
+
+    result = _solve(u)
+    w = result.weights
+
+    assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate")
+    assert w[0] == pytest.approx(0.08, abs=1e-3), \
+        f"Active asset should fill its 0.08 cap; got {w[0]:.4f}"
+    assert w[u["cash_idx"]] == pytest.approx(0.03, abs=1e-6), \
+        "Cash sleeve must be pinned at 0.03"
+    assert w[u["spy_idx"]] == pytest.approx(1 - 0.08 - 0.03, abs=1e-3), \
+        f"SPY should absorb residual ~0.89; got {w[u['spy_idx']]:.4f}"
+    assert w.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_two_asset_symmetric_alpha_yields_equal_weights():
+    """Two assets, identical α̂ + identical covariance → optimizer assigns equal weight."""
+    u = _baseline_universe(n_active=2)
+    u["alpha_hat"][0] = 0.05
+    u["alpha_hat"][1] = 0.05
+    u["returns_panel"][:, 0] = u["returns_panel"][:, 1]
+
+    result = _solve(u)
+    w = result.weights
+
+    assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate")
+    assert abs(w[0] - w[1]) < 1e-3, \
+        f"Symmetric inputs must give symmetric weights; got w[0]={w[0]:.4f} w[1]={w[1]:.4f}"
+    assert w[0] == pytest.approx(0.08, abs=1e-3), \
+        "Both should hit their 0.08 cap given strong α̂"
+
+
+def test_vol_target_constraint_binds_with_high_vol_universe():
+    """High-vol actives + a vol_target below the cap-filling vol → optimizer backs off caps.
+
+    Uses sample (not Ledoit-Wolf) covariance because LW's trace/N × I shrinkage
+    target is sensitive to synthetic vol heterogeneity. Production uses LW with
+    real stock returns where vols are more homogeneous (1-3% daily). The
+    synthetic setup uses long T (5000 rows) to drive sample cov noise low so
+    feasibility math is predictable.
+    """
+    N = 6
+    T = 5000
+    rng = np.random.default_rng(7)
+    active_vol = 0.05
+    spy_vol = 0.005
+    returns = np.column_stack([
+        rng.normal(0, active_vol, T),
+        rng.normal(0, active_vol, T),
+        rng.normal(0, active_vol, T),
+        rng.normal(0, active_vol, T),
+        rng.normal(0, spy_vol, T),
+        np.zeros(T),
+    ])
+    u = {
+        "tickers": ["T0", "T1", "T2", "T3", "SPY", "CASH"],
+        "alpha_hat": np.array([0.10, 0.10, 0.10, 0.10, 0.0, -1e-6]),
+        "returns_panel": returns,
+        "w_prev": np.zeros(N),
+        "sectors": ["tech", "tech", "tech", "tech", "__benchmark__", "__cash__"],
+        "stance_caps": np.array([0.08, 0.08, 0.08, 0.08, 1.0, 1.0]),
+        "eligibility": np.ones(N, dtype=bool),
+        "spy_idx": 4,
+        "cash_idx": 5,
+        "cfg": {"vol_target_annual": 0.10, "covariance_shrinkage": "sample"},
+    }
+
+    result = solve_target_weights(**u)
+    w = result.weights
+
+    assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate"), \
+        f"Setup must be feasible; got {result.diagnostics['status']}"
+    assert result.diagnostics["portfolio_vol_ann"] <= 0.10 + 5e-3, \
+        f"Vol target 0.10 violated; got {result.diagnostics['portfolio_vol_ann']:.4f}"
+    active_total = w[:4].sum()
+    assert active_total < 4 * 0.08 - 1e-3, \
+        f"Vol-target should prevent filling all 4 caps (would be 0.32); got {active_total:.4f}"
+
+
+def test_l1_turnover_penalty_reduces_rebalance_when_tcost_high():
+    """Large tcost_bps + w_prev close to optimum → optimizer stays near w_prev."""
+    u_low = _baseline_universe(n_active=2)
+    u_low["alpha_hat"][:2] = 0.01
+    u_low["w_prev"][0] = 0.07
+    u_low["w_prev"][1] = 0.07
+    u_low["w_prev"][u_low["spy_idx"]] = 1 - 0.07 - 0.07 - 0.03
+    u_low["w_prev"][u_low["cash_idx"]] = 0.03
+    u_low["cfg"] = {"tcost_bps": 0.0}
+    result_low = _solve(u_low)
+
+    u_high = _baseline_universe(n_active=2)
+    u_high["alpha_hat"][:2] = 0.01
+    u_high["w_prev"][0] = 0.07
+    u_high["w_prev"][1] = 0.07
+    u_high["w_prev"][u_high["spy_idx"]] = 1 - 0.07 - 0.07 - 0.03
+    u_high["w_prev"][u_high["cash_idx"]] = 0.03
+    u_high["cfg"] = {"tcost_bps": 5000.0}
+    result_high = _solve(u_high)
+
+    assert result_high.diagnostics["turnover_one_way"] < \
+           result_low.diagnostics["turnover_one_way"] + 1e-6, (
+        f"High tcost ({result_high.diagnostics['turnover_one_way']:.4f}) should not "
+        f"trade more than low tcost ({result_low.diagnostics['turnover_one_way']:.4f})"
+    )
+
+
+def test_eligibility_mask_pins_disallowed_to_zero():
+    """An ineligible ticker with very positive α̂ must still get w=0."""
+    u = _baseline_universe(n_active=2)
+    u["alpha_hat"][0] = 0.10
+    u["alpha_hat"][1] = 0.05
+    u["eligibility"][0] = False
+
+    result = _solve(u)
+    w = result.weights
+
+    assert w[0] == pytest.approx(0.0, abs=1e-6), \
+        f"Ineligible asset must be pinned to 0; got {w[0]:.4f}"
+    assert w[1] == pytest.approx(0.08, abs=1e-3), \
+        "Eligible competitor should still hit its cap"
+
+
+def test_cash_sleeve_equality_constraint_is_inviolable():
+    """Cash sleeve pin must hold even when α̂ strongly favors equities."""
+    u = _baseline_universe(n_active=4)
+    u["alpha_hat"][:4] = 0.20
+    u["cfg"] = {"cash_sleeve_pct": 0.05}
+
+    result = _solve(u)
+
+    assert result.weights[u["cash_idx"]] == pytest.approx(0.05, abs=1e-6), \
+        f"Cash sleeve 0.05 violated; got {result.weights[u['cash_idx']]:.6f}"
+
+
+def test_sector_cap_binds_when_many_names_in_one_sector():
+    """5 names in one sector, all positive α̂ → sector total capped at max_sector_pct."""
+    u = _baseline_universe(n_active=5, sector_labels=["tech"] * 5)
+    u["alpha_hat"][:5] = 0.05
+    u["cfg"] = {"max_sector_pct": 0.20}
+
+    result = _solve(u)
+    w = result.weights
+
+    tech_total = w[:5].sum()
+    assert tech_total <= 0.20 + 1e-4, \
+        f"Sector cap 0.20 violated; got {tech_total:.4f}"
+    assert tech_total >= 0.20 - 1e-3, \
+        f"Sector cap should be binding given strong α̂; got {tech_total:.4f}"
+
+
+def test_infeasibility_falls_back_to_current_weights_plus_cash():
+    """Conflicting hard constraints → solver returns infeasible → fallback weights returned."""
+    u = _baseline_universe(n_active=1)
+    u["alpha_hat"][0] = 0.05
+    u["stance_caps"][:] = 0.001
+    u["w_prev"][0] = 0.50
+    u["w_prev"][u["spy_idx"]] = 0.47
+    u["w_prev"][u["cash_idx"]] = 0.03
+    u["cfg"] = {"cash_sleeve_pct": 0.03}
+
+    result = solve_target_weights(**u)
+
+    assert result.weights.sum() == pytest.approx(1.0, abs=1e-6)
+    assert result.weights[u["cash_idx"]] == pytest.approx(0.03, abs=1e-6)
+    if result.diagnostics["status"] == "infeasible_fallback":
+        assert result.weights[0] > result.weights[u["spy_idx"]] * 0.8, (
+            "Fallback should preserve the rough current allocation profile "
+            "(asset 0 was 0.50, SPY was 0.47)"
+        )


### PR DESCRIPTION
## Summary

First PR of the portfolio-optimizer / cash-management arc. Adds the constrained mean-variance optimizer kernel as a pure-numpy in/out module. **No integration into main.py / signal_reader / risk_guard yet — module is fully isolated.** Legacy 1/n sizing path unaffected.

Plan: [`alpha-engine-docs/private/portfolio-optimizer-260511.md`](https://github.com/cipher813/alpha-engine-docs/blob/main/private/portfolio-optimizer-260511.md) (gitignored, in private repo).

Origin: 2026-05-11 EOD email showed 92.2% cash ($950k of $1.03M NAV) with only 4 sub-3% positions deployed. Diagnosed as structural: `1/n_enter_signals × max_pos_pct` makes cash a residual, not a managed variable. Daily α = −0.21% is dominated by missing SPY exposure.

## Math

```
maximize   wᵀα̂  −  λ · wᵀΣw  −  τ · ‖w − w_prev‖₁
s.t.       Σwᵢ = 1                                    (budget)
           w[CASH] = cash_sleeve                       (sleeve pin)
           0 ≤ wᵢ ≤ stance_capᵢ · eligibilityᵢ        (per-name + mask)
           Σ_{i∈sector S} wᵢ ≤ max_sector_pct          (sector cap)
           wᵀΣw ≤ σ²_target_daily                      (optional SOC vol-target)
```

Institutional benchmark-as-null pattern: SPY (α̂=0) is the no-conviction fill; cash is a pinned operational sleeve (default 3%); conviction picks express deviation from SPY within sector + position + (optional) vol-target constraints.

## Vol-target default flipped to None during PR 1

Plan doc originally proposed `vol_target_annual=0.12`. Test-design surfaced that this is **structurally infeasible** for the long-only enhanced-index pattern — a SPY-heavy portfolio has portfolio vol bounded below by SPY's vol (~16% annual), since SPY absorbs ~89% of the book on conviction-light days. Default is now None (no SOC constraint); an explicit value (e.g., 0.25) can be set as a stress-regime cap. Sub-SPY vol targeting reserved for v2 multi-asset / risk-parity layer.

## How existing modules will compose (PR 2+)

| Module | Before | After |
|---|---|---|
| `position_sizer.py` | Computes weight = 1/n × adjustments | Computes **upper-bound caps** per ticker (stance × dd × earnings × coverage); optimizer chooses actual weight inside the cap |
| `risk_guard.py` | Pre-construction filter | Splits into (a) **eligibility mask** that pins disallowed names to `w_i=0` pre-solve, (b) **post-solve sanity check** |
| EXIT handling | Independent path, leaks to cash | Sets `eligibility[i]=False`; optimizer redistributes freed capital to SPY + next-best names same-solve |

## What's NOT in this PR

- No `main.py` changes — the legacy `_plan_entries` / `_legacy_plan_entries` path is unchanged
- No risk_guard integration
- No live config / risk.yaml changes
- No S3 wiring

Those land in PR 2 (shadow mode), PR 3 (backtester mode), PR 4 (cutover gate), PR 5 (cutover).

## Test plan

- [x] 8 new unit tests in `tests/test_portfolio_optimizer.py` cover: single-asset known-answer, two-asset symmetric, vol-target SOC binding, L1 turnover, eligibility mask, cash sleeve inviolability, sector cap, infeasibility → current-weights fallback
- [x] Full alpha-engine test suite green: **576 passed** (568 pre-existing + 8 new) in 2.80s
- [x] Module imports cleanly with no side effects
- [x] Solver fallback chain (CLARABEL → SCS → OSQP) exercised by the infeasibility test

## Risks

- **cvxpy / scikit-learn are new dependencies.** Both pinned with upper bounds (`<1.8` / `<1.6` respectively) to stay numpy<2 compatible. Install size adds ~100-150MB to the venv — only matters on EC2 if/when PR 2 ships shadow mode. PR 1 itself doesn't import either module unless `solve_target_weights()` is called.
- **Module is not yet wired** — zero impact on production behavior. The kernel is dead code until PR 2 calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)