### PR TITLE
feat(optimizer): shadow-mode integration — PR 2 of cash-management arc

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -186,5 +186,41 @@ notifications:
 # Informational only — not a gate. The predictor features handle the signal.
 earnings_proximity_warning_days: 2
 
+# ── Portfolio optimizer (PR 2 of portfolio-optimizer-260511 arc) ────────────
+# Shadow-mode MVO optimizer runs alongside the legacy 1/n sizer and writes
+# target weights + diagnostics to S3 (predictor/optimizer_shadow/{date}.json)
+# without affecting order placement. Default OFF — enable per-environment.
+# Cutover to drive actual order placement lands in a later PR after 2-3 days
+# of shadow logs confirm plausible target weights.
+shadow_portfolio_optimizer: false
+
+portfolio_optimizer:
+  # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty.
+  risk_aversion: 5.0
+  # Transaction cost penalty (bps per dollar traded) used in the L1 turnover
+  # term. 5 bps is conservative for liquid US large-caps; backtester tunes.
+  tcost_bps: 5.0
+  # Cash sleeve (fraction of NAV) pinned via equality constraint. Operational
+  # liquidity in SGOV/BIL; the rest of NAV deploys to SPY + conviction picks.
+  cash_sleeve_pct: 0.03
+  # Sector cap (fraction of NAV). Mirrors the legacy max_sector_pct above.
+  max_sector_pct: 0.25
+  # Rebalance band — trades smaller than this weight delta are skipped to
+  # control turnover. Applies to the would_be_trades list in shadow logs.
+  rebalance_band_pct: 0.005
+  # Vol-target constraint. null = disabled (default). A long-only enhanced-
+  # index portfolio with SPY as no-conviction fill has portfolio vol bounded
+  # below by SPY's vol (~16% annual); sub-SPY targeting is structurally
+  # infeasible without bonds. Set to e.g. 0.25 to enable a stress-regime cap
+  # that only binds in high-vol periods. Sub-SPY targeting reserved for v2
+  # multi-asset / risk-parity layer.
+  vol_target_annual: null
+  # Covariance estimator. "ledoit_wolf" is the institutional default;
+  # "sample" disables shrinkage (useful only for synthetic-input tests).
+  covariance_shrinkage: ledoit_wolf
+  # Minimum position pct — weights below this are clipped to 0 (clean output;
+  # avoid tiny stub positions like today's UNP 0.1% NAV residual).
+  min_position_pct: 0.005
+
 # ── Paths (adjust to your deployment) ───────────────────────────────────────
 db_path: "/path/to/trades.db"

--- a/executor/main.py
+++ b/executor/main.py
@@ -1262,6 +1262,36 @@ def run(
         )
         orders.extend(exit_orders)
 
+        # ── 5b. Shadow portfolio optimizer (PR 2 of portfolio-optimizer-260511) ──
+        #
+        # Runs the constrained MVO optimizer on the same inputs the legacy
+        # planner just used, logs target weights + diagnostics to S3, and
+        # NEVER raises into the legacy path. Production behaviour is
+        # unchanged. The shadow log is the primary observability artifact
+        # for deciding when to cut over (PR 5).
+        if (
+            not simulate and not dry_run
+            and config.get("shadow_portfolio_optimizer", False)
+        ):
+            try:
+                from executor.optimizer_shadow import run_shadow_optimizer
+                run_shadow_optimizer(
+                    signals_raw=signals_raw,
+                    predictions_by_ticker=predictions_by_ticker,
+                    current_positions=current_positions,
+                    portfolio_nav=portfolio_nav,
+                    price_histories=price_histories or {},
+                    config=config,
+                    signals_bucket=signals_bucket,
+                    run_date=run_date,
+                    legacy_orders=orders,
+                )
+            except Exception as _shadow_err:
+                logger.warning(
+                    f"Shadow portfolio optimizer wrapper raised "
+                    f"(non-blocking): {_shadow_err}"
+                )
+
         # ── 6. Write stop records and save order book for daemon ────────────────
         if not simulate and not dry_run:
             try:

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -1,0 +1,419 @@
+"""
+Shadow-mode portfolio optimizer wrapper — PR 2 of the portfolio-optimizer arc.
+
+The optimizer kernel (PR 1, executor/portfolio_optimizer.py) is a pure-numpy
+in/out function. This module assembles optimizer inputs from the existing
+main.py state (signals, predictions, positions, price histories), calls the
+kernel, and logs the resulting target weights + diagnostics to S3.
+
+Production behaviour is unchanged — no orders are placed based on the
+optimizer's output. The shadow log is the primary observability artifact for
+deciding whether to cut over (PR 5 of the arc).
+
+S3 layout:
+    predictor/optimizer_shadow/{run_date}.json   ← per-day snapshot
+    predictor/optimizer_shadow/latest.json       ← convenience pointer
+
+This wrapper NEVER raises into the legacy planner path. All exceptions are
+caught, logged at WARNING, and a sentinel is written to S3 so the absence
+of a shadow log is itself flagged in the daily diagnostic surface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from datetime import datetime, timezone
+from typing import Any
+
+import boto3
+import numpy as np
+import pandas as pd
+
+from executor.portfolio_optimizer import (
+    OPTIMIZER_CONFIG_DEFAULTS,
+    solve_target_weights,
+)
+
+logger = logging.getLogger(__name__)
+
+_SPY = "SPY"
+_CASH = "CASH"
+_BENCH_SECTOR = "__benchmark__"
+_CASH_SECTOR = "__cash__"
+_CASH_ALPHA_HINT = -1e-6
+_RETURNS_LOOKBACK_DAYS = 252
+_MIN_RETURNS_FOR_COV = 60
+
+
+def run_shadow_optimizer(
+    signals_raw: dict,
+    predictions_by_ticker: dict[str, dict],
+    current_positions: dict[str, dict],
+    portfolio_nav: float,
+    price_histories: dict[str, pd.DataFrame],
+    config: dict,
+    signals_bucket: str,
+    run_date: str,
+    legacy_orders: list[dict] | None = None,
+    s3_client=None,
+) -> dict | None:
+    """
+    Run the optimizer in shadow mode and write the result to S3.
+
+    Returns the shadow log dict on success, or None on any failure. Never
+    raises — exceptions are caught + logged + a sentinel written to S3 so
+    the absence of a real shadow log is itself observable.
+    """
+    try:
+        log = _build_and_solve(
+            signals_raw=signals_raw,
+            predictions_by_ticker=predictions_by_ticker,
+            current_positions=current_positions,
+            portfolio_nav=portfolio_nav,
+            price_histories=price_histories,
+            config=config,
+            run_date=run_date,
+            legacy_orders=legacy_orders or [],
+        )
+        _write_shadow_log_to_s3(log, signals_bucket, run_date, s3_client)
+        logger.info(
+            f"Shadow optimizer OK: status={log['diagnostics']['status']} "
+            f"n_active={log['diagnostics']['n_active_positions']} "
+            f"vol_ann={log['diagnostics']['portfolio_vol_ann']:.3f} "
+            f"active_share={log['diagnostics']['active_share_vs_spy']:.3f}"
+        )
+        return log
+    except Exception as e:
+        logger.warning(f"Shadow optimizer failed (non-blocking): {e}", exc_info=True)
+        sentinel = {
+            "run_date": run_date,
+            "shadow_status": "failed",
+            "error": repr(e),
+            "written_at_utc": datetime.now(timezone.utc).isoformat(),
+        }
+        try:
+            _write_shadow_log_to_s3(sentinel, signals_bucket, run_date, s3_client)
+        except Exception as inner:
+            logger.warning(f"Shadow sentinel write also failed: {inner}")
+        return None
+
+
+def _build_and_solve(
+    signals_raw: dict,
+    predictions_by_ticker: dict[str, dict],
+    current_positions: dict[str, dict],
+    portfolio_nav: float,
+    price_histories: dict[str, pd.DataFrame],
+    config: dict,
+    run_date: str,
+    legacy_orders: list[dict],
+) -> dict:
+    optimizer_cfg = {
+        **OPTIMIZER_CONFIG_DEFAULTS,
+        **config.get("portfolio_optimizer", {}),
+    }
+    tickers = _build_universe(
+        signals_raw, predictions_by_ticker, current_positions, price_histories,
+    )
+    N = len(tickers)
+    spy_idx = tickers.index(_SPY)
+    cash_idx = tickers.index(_CASH)
+
+    signals_by_ticker = signals_raw.get("signals", {})
+    alpha_hat = _build_alpha_hat(tickers, predictions_by_ticker, spy_idx, cash_idx)
+    returns_panel = _build_returns_panel(tickers, price_histories, cash_idx)
+    w_prev = _build_w_prev(tickers, current_positions, portfolio_nav, cash_idx, optimizer_cfg)
+    sectors = _build_sectors(tickers, signals_by_ticker, spy_idx, cash_idx)
+    stance_caps = _build_stance_caps(
+        tickers, signals_by_ticker, predictions_by_ticker,
+        config, optimizer_cfg, spy_idx, cash_idx,
+    )
+    eligibility = _build_eligibility(
+        tickers, signals_by_ticker, predictions_by_ticker,
+        current_positions, config, spy_idx, cash_idx,
+    )
+
+    result = solve_target_weights(
+        tickers=tickers,
+        alpha_hat=alpha_hat,
+        returns_panel=returns_panel,
+        w_prev=w_prev,
+        sectors=sectors,
+        stance_caps=stance_caps,
+        eligibility=eligibility,
+        spy_idx=spy_idx,
+        cash_idx=cash_idx,
+        cfg=optimizer_cfg,
+    )
+
+    would_be_trades = _compute_trade_deltas(
+        tickers, result.weights, w_prev, portfolio_nav, optimizer_cfg,
+    )
+
+    return {
+        "run_date": run_date,
+        "written_at_utc": datetime.now(timezone.utc).isoformat(),
+        "shadow_status": "ok",
+        "portfolio_nav": float(portfolio_nav),
+        "n_tickers": N,
+        "tickers": tickers,
+        "target_weights": [float(x) for x in result.weights],
+        "current_weights": [float(x) for x in w_prev],
+        "alpha_hat": [float(x) for x in alpha_hat],
+        "eligibility": [bool(x) for x in eligibility],
+        "stance_caps": [float(x) for x in stance_caps],
+        "sectors": sectors,
+        "would_be_trades": would_be_trades,
+        "diagnostics": result.diagnostics,
+        "legacy_orders": [_redact_order(o) for o in legacy_orders],
+        "optimizer_cfg": optimizer_cfg,
+    }
+
+
+def _build_universe(
+    signals_raw: dict,
+    predictions_by_ticker: dict,
+    current_positions: dict,
+    price_histories: dict[str, pd.DataFrame],
+) -> list[str]:
+    candidates: set[str] = set()
+    candidates.update(predictions_by_ticker.keys())
+    candidates.update(current_positions.keys())
+    universe_list = signals_raw.get("universe", [])
+    if isinstance(universe_list, list):
+        candidates.update(universe_list)
+
+    candidates.discard(_SPY)
+    candidates.discard(_CASH)
+    eligible = sorted(t for t in candidates if _has_usable_history(t, price_histories))
+
+    if _SPY not in price_histories or not _has_usable_history(_SPY, price_histories):
+        raise RuntimeError(
+            "Shadow optimizer requires SPY price history; not found in price_histories. "
+            "Confirm executor's load_price_histories includes SPY (line ~1096 in main.py)."
+        )
+
+    return eligible + [_SPY, _CASH]
+
+
+def _has_usable_history(ticker: str, price_histories: dict[str, pd.DataFrame]) -> bool:
+    df = price_histories.get(ticker)
+    if df is None or len(df) < _MIN_RETURNS_FOR_COV + 1:
+        return False
+    if "close" not in df.columns:
+        return False
+    return True
+
+
+def _build_alpha_hat(
+    tickers: list[str],
+    predictions_by_ticker: dict[str, dict],
+    spy_idx: int,
+    cash_idx: int,
+) -> np.ndarray:
+    alpha = np.zeros(len(tickers))
+    for i, t in enumerate(tickers):
+        if i == spy_idx:
+            alpha[i] = 0.0
+            continue
+        if i == cash_idx:
+            alpha[i] = _CASH_ALPHA_HINT
+            continue
+        pred = predictions_by_ticker.get(t, {})
+        raw_alpha = pred.get("predicted_alpha") or pred.get("canonical_predicted_alpha") or 0.0
+        try:
+            alpha[i] = float(raw_alpha)
+        except (TypeError, ValueError):
+            alpha[i] = 0.0
+        if not math.isfinite(alpha[i]):
+            alpha[i] = 0.0
+    return alpha
+
+
+def _build_returns_panel(
+    tickers: list[str],
+    price_histories: dict[str, pd.DataFrame],
+    cash_idx: int,
+) -> np.ndarray:
+    series_by_ticker: dict[str, pd.Series] = {}
+    for i, t in enumerate(tickers):
+        if i == cash_idx:
+            continue
+        df = price_histories[t]
+        s = df["close"].tail(_RETURNS_LOOKBACK_DAYS + 1).pct_change().dropna()
+        series_by_ticker[t] = s
+
+    aligned = pd.DataFrame(series_by_ticker).dropna()
+    if aligned.shape[0] < _MIN_RETURNS_FOR_COV:
+        raise RuntimeError(
+            f"Aligned returns panel has only {aligned.shape[0]} rows; "
+            f"need ≥{_MIN_RETURNS_FOR_COV} for covariance estimation. "
+            "Universe likely has tickers with non-overlapping histories — "
+            "filter pre-call."
+        )
+
+    panel = np.zeros((aligned.shape[0], len(tickers)))
+    for i, t in enumerate(tickers):
+        if i == cash_idx:
+            panel[:, i] = 0.0
+        else:
+            panel[:, i] = aligned[t].values
+    return panel
+
+
+def _build_w_prev(
+    tickers: list[str],
+    current_positions: dict[str, dict],
+    portfolio_nav: float,
+    cash_idx: int,
+    optimizer_cfg: dict,
+) -> np.ndarray:
+    w = np.zeros(len(tickers))
+    if portfolio_nav <= 0:
+        w[cash_idx] = 1.0
+        return w
+    for i, t in enumerate(tickers):
+        if i == cash_idx:
+            continue
+        pos = current_positions.get(t, {})
+        mv = pos.get("market_value", 0.0) or 0.0
+        try:
+            w[i] = float(mv) / portfolio_nav
+        except (TypeError, ValueError, ZeroDivisionError):
+            w[i] = 0.0
+    deployed = w.sum()
+    w[cash_idx] = max(0.0, 1.0 - deployed)
+    return w
+
+
+def _build_sectors(
+    tickers: list[str],
+    signals_by_ticker: dict[str, dict],
+    spy_idx: int,
+    cash_idx: int,
+) -> list[str]:
+    out: list[str] = []
+    for i, t in enumerate(tickers):
+        if i == spy_idx:
+            out.append(_BENCH_SECTOR)
+        elif i == cash_idx:
+            out.append(_CASH_SECTOR)
+        else:
+            sector = signals_by_ticker.get(t, {}).get("sector", "Unknown")
+            out.append(str(sector) if sector else "Unknown")
+    return out
+
+
+def _build_stance_caps(
+    tickers: list[str],
+    signals_by_ticker: dict[str, dict],
+    predictions_by_ticker: dict[str, dict],
+    config: dict,
+    optimizer_cfg: dict,
+    spy_idx: int,
+    cash_idx: int,
+) -> np.ndarray:
+    base_cap = float(config.get("max_position_pct", 0.08))
+    stance_multipliers = {
+        "momentum": float(config.get("stance_size_momentum", 1.0)),
+        "value":    float(config.get("stance_size_value",    0.7)),
+        "quality":  float(config.get("stance_size_quality",  0.8)),
+        "catalyst": float(config.get("stance_size_catalyst", 0.6)),
+    }
+    caps = np.full(len(tickers), base_cap)
+    caps[spy_idx] = 1.0
+    caps[cash_idx] = 1.0
+    for i, t in enumerate(tickers):
+        if i in (spy_idx, cash_idx):
+            continue
+        pred = predictions_by_ticker.get(t, {})
+        stance = pred.get("stance") or signals_by_ticker.get(t, {}).get("stance")
+        if stance and stance in stance_multipliers:
+            caps[i] = base_cap * stance_multipliers[stance]
+    return caps
+
+
+def _build_eligibility(
+    tickers: list[str],
+    signals_by_ticker: dict[str, dict],
+    predictions_by_ticker: dict[str, dict],
+    current_positions: dict[str, dict],
+    config: dict,
+    spy_idx: int,
+    cash_idx: int,
+) -> np.ndarray:
+    min_score = float(config.get("min_score_to_enter", 57))
+    eligibility = np.ones(len(tickers), dtype=bool)
+    for i, t in enumerate(tickers):
+        if i in (spy_idx, cash_idx):
+            continue
+        sig = signals_by_ticker.get(t, {})
+        pred = predictions_by_ticker.get(t, {})
+        is_held = t in current_positions
+
+        if sig.get("signal") == "EXIT":
+            eligibility[i] = False
+            continue
+        if pred.get("gbm_veto") is True:
+            eligibility[i] = False
+            continue
+        if is_held:
+            continue
+        score = sig.get("score")
+        if score is None or float(score) < min_score:
+            eligibility[i] = False
+    return eligibility
+
+
+def _compute_trade_deltas(
+    tickers: list[str],
+    target_weights: np.ndarray,
+    current_weights: np.ndarray,
+    portfolio_nav: float,
+    optimizer_cfg: dict,
+) -> list[dict]:
+    band = float(optimizer_cfg.get("rebalance_band_pct", 0.005))
+    trades: list[dict] = []
+    for i, t in enumerate(tickers):
+        if t == _CASH:
+            continue
+        delta_pct = float(target_weights[i] - current_weights[i])
+        if abs(delta_pct) < band:
+            continue
+        delta_dollars = delta_pct * float(portfolio_nav)
+        trades.append({
+            "ticker": t,
+            "action": "BUY" if delta_pct > 0 else "SELL",
+            "delta_weight": round(delta_pct, 6),
+            "delta_dollars": round(delta_dollars, 2),
+            "target_weight": round(float(target_weights[i]), 6),
+            "current_weight": round(float(current_weights[i]), 6),
+        })
+    return trades
+
+
+def _redact_order(order: dict) -> dict:
+    keep = {"ticker", "action", "shares", "limit_price", "dollar_size",
+            "position_pct", "stance", "score", "signal_type"}
+    return {k: order.get(k) for k in keep if k in order}
+
+
+def _write_shadow_log_to_s3(
+    log: dict, bucket: str, run_date: str, s3_client=None,
+) -> None:
+    s3 = s3_client or boto3.client("s3")
+    body = json.dumps(log, default=str, indent=2).encode("utf-8")
+    s3.put_object(
+        Bucket=bucket,
+        Key=f"predictor/optimizer_shadow/{run_date}.json",
+        Body=body,
+        ContentType="application/json",
+    )
+    s3.put_object(
+        Bucket=bucket,
+        Key="predictor/optimizer_shadow/latest.json",
+        Body=body,
+        ContentType="application/json",
+    )

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -1,0 +1,229 @@
+"""
+Unit tests for executor/optimizer_shadow.py — PR 2 of portfolio-optimizer arc.
+
+The shadow wrapper assembles optimizer inputs from main.py's existing state
+(signals, predictions, positions, price histories), calls the kernel, and
+logs to S3. Tests use synthetic inputs + a stub S3 client to verify:
+  1. Happy path — universe assembly, alpha_hat, returns_panel, w_prev,
+     sectors, stance_caps, eligibility all populated correctly
+  2. EXIT signals → eligibility[ticker] = False
+  3. GBM veto → eligibility[ticker] = False
+  4. Held positions populate w_prev from market_value / NAV
+  5. Cash sleeve absorbs residual weight pre-solve
+  6. Universe includes SPY and CASH appended at the end
+  7. Failures don't raise — sentinel written, None returned
+  8. Stance multipliers apply to caps when stance is present
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from executor.optimizer_shadow import (
+    _build_alpha_hat,
+    _build_eligibility,
+    _build_sectors,
+    _build_stance_caps,
+    _build_universe,
+    _build_w_prev,
+    _compute_trade_deltas,
+    run_shadow_optimizer,
+)
+
+
+def _synthetic_price_df(n_rows: int = 260, seed: int = 0) -> pd.DataFrame:
+    """Build a price history DataFrame with a 'close' column."""
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(0.0005, 0.012, n_rows)
+    prices = 100 * np.exp(np.cumsum(returns))
+    idx = pd.date_range("2025-01-01", periods=n_rows, freq="D")
+    return pd.DataFrame({"close": prices}, index=idx)
+
+
+def _baseline_inputs():
+    """Construct a minimal set of shadow-optimizer inputs."""
+    tickers_with_pred = ["AAPL", "MSFT", "JNJ"]
+    price_histories = {t: _synthetic_price_df(seed=i) for i, t in enumerate(tickers_with_pred)}
+    price_histories["SPY"] = _synthetic_price_df(seed=99)
+    signals_raw = {
+        "universe": tickers_with_pred,
+        "signals": {
+            "AAPL": {"signal": "ENTER", "score": 72, "sector": "Technology"},
+            "MSFT": {"signal": "HOLD",  "score": 65, "sector": "Technology"},
+            "JNJ":  {"signal": "ENTER", "score": 60, "sector": "Healthcare"},
+        },
+    }
+    predictions_by_ticker = {
+        "AAPL": {"predicted_alpha":  0.04, "gbm_veto": False, "stance": "momentum"},
+        "MSFT": {"predicted_alpha":  0.02, "gbm_veto": False, "stance": "quality"},
+        "JNJ":  {"predicted_alpha": -0.01, "gbm_veto": False, "stance": "value"},
+    }
+    current_positions = {
+        "MSFT": {"market_value": 50_000.0, "sector": "Technology"},
+    }
+    return {
+        "signals_raw": signals_raw,
+        "predictions_by_ticker": predictions_by_ticker,
+        "current_positions": current_positions,
+        "portfolio_nav": 1_000_000.0,
+        "price_histories": price_histories,
+        "config": {
+            "max_position_pct": 0.08,
+            "min_score_to_enter": 57,
+        },
+        "signals_bucket": "test-bucket",
+        "run_date": "2026-05-11",
+    }
+
+
+def test_happy_path_assembles_inputs_and_writes_to_s3():
+    inputs = _baseline_inputs()
+    s3 = MagicMock()
+
+    log = run_shadow_optimizer(s3_client=s3, **inputs)
+
+    assert log is not None, "Shadow optimizer should succeed on the happy path"
+    assert log["shadow_status"] == "ok"
+    assert log["run_date"] == "2026-05-11"
+    assert log["portfolio_nav"] == 1_000_000.0
+    assert log["tickers"][-2:] == ["SPY", "CASH"], "SPY/CASH must be appended"
+    assert log["n_tickers"] == len(log["tickers"])
+    assert len(log["target_weights"]) == log["n_tickers"]
+    assert log["diagnostics"]["status"] in ("optimal", "optimal_inaccurate")
+
+    assert s3.put_object.call_count == 2, "Should write dated + latest keys"
+    dated_call = s3.put_object.call_args_list[0].kwargs
+    assert dated_call["Key"] == "predictor/optimizer_shadow/2026-05-11.json"
+    latest_call = s3.put_object.call_args_list[1].kwargs
+    assert latest_call["Key"] == "predictor/optimizer_shadow/latest.json"
+    body = json.loads(dated_call["Body"])
+    assert body["shadow_status"] == "ok"
+
+
+def test_universe_assembly_filters_tickers_without_history():
+    inputs = _baseline_inputs()
+    inputs["price_histories"]["AAPL"] = _synthetic_price_df(n_rows=30)
+
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+
+    assert "AAPL" not in tickers, "Tickers with <60 rows of history must be dropped"
+    assert tickers[-2:] == ["SPY", "CASH"]
+
+
+def test_universe_requires_spy_history():
+    inputs = _baseline_inputs()
+    del inputs["price_histories"]["SPY"]
+
+    with pytest.raises(RuntimeError, match="SPY price history"):
+        _build_universe(
+            inputs["signals_raw"], inputs["predictions_by_ticker"],
+            inputs["current_positions"], inputs["price_histories"],
+        )
+
+
+def test_exit_signal_makes_ticker_ineligible():
+    inputs = _baseline_inputs()
+    inputs["signals_raw"]["signals"]["AAPL"]["signal"] = "EXIT"
+
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+    spy_idx = tickers.index("SPY")
+    cash_idx = tickers.index("CASH")
+    aapl_idx = tickers.index("AAPL")
+
+    eligibility = _build_eligibility(
+        tickers, inputs["signals_raw"]["signals"],
+        inputs["predictions_by_ticker"], inputs["current_positions"],
+        inputs["config"], spy_idx, cash_idx,
+    )
+    assert eligibility[aapl_idx] == False, "EXIT signal must zero eligibility"
+    assert eligibility[spy_idx] == True
+    assert eligibility[cash_idx] == True
+
+
+def test_gbm_veto_makes_ticker_ineligible():
+    inputs = _baseline_inputs()
+    inputs["predictions_by_ticker"]["AAPL"]["gbm_veto"] = True
+
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+    aapl_idx = tickers.index("AAPL")
+    spy_idx = tickers.index("SPY")
+    cash_idx = tickers.index("CASH")
+
+    eligibility = _build_eligibility(
+        tickers, inputs["signals_raw"]["signals"],
+        inputs["predictions_by_ticker"], inputs["current_positions"],
+        inputs["config"], spy_idx, cash_idx,
+    )
+    assert eligibility[aapl_idx] == False
+
+
+def test_w_prev_reflects_current_positions():
+    inputs = _baseline_inputs()
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+    cash_idx = tickers.index("CASH")
+    msft_idx = tickers.index("MSFT")
+
+    w_prev = _build_w_prev(
+        tickers, inputs["current_positions"], inputs["portfolio_nav"],
+        cash_idx, {},
+    )
+    assert w_prev[msft_idx] == pytest.approx(0.05, abs=1e-6), \
+        "MSFT mkt_val=50k on 1M NAV → 5% weight"
+    assert w_prev[cash_idx] == pytest.approx(0.95, abs=1e-6), \
+        "Cash should absorb the residual pre-optimization"
+    assert w_prev.sum() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_stance_caps_apply_multiplier_when_stance_present():
+    inputs = _baseline_inputs()
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+    spy_idx = tickers.index("SPY")
+    cash_idx = tickers.index("CASH")
+    aapl_idx = tickers.index("AAPL")
+    msft_idx = tickers.index("MSFT")
+    jnj_idx = tickers.index("JNJ")
+
+    caps = _build_stance_caps(
+        tickers, inputs["signals_raw"]["signals"],
+        inputs["predictions_by_ticker"], inputs["config"], {},
+        spy_idx, cash_idx,
+    )
+    assert caps[aapl_idx] == pytest.approx(0.08 * 1.0), "momentum mult = 1.0"
+    assert caps[msft_idx] == pytest.approx(0.08 * 0.8), "quality mult = 0.8"
+    assert caps[jnj_idx]  == pytest.approx(0.08 * 0.7), "value mult = 0.7"
+    assert caps[spy_idx] == 1.0
+    assert caps[cash_idx] == 1.0
+
+
+def test_wrapper_never_raises_writes_sentinel_on_failure():
+    inputs = _baseline_inputs()
+    del inputs["price_histories"]["SPY"]
+    s3 = MagicMock()
+
+    result = run_shadow_optimizer(s3_client=s3, **inputs)
+
+    assert result is None, "Failures return None — never raise"
+    assert s3.put_object.call_count == 2, "Sentinel still written (dated + latest)"
+    body = json.loads(s3.put_object.call_args_list[0].kwargs["Body"])
+    assert body["shadow_status"] == "failed"
+    assert "SPY price history" in body["error"]


### PR DESCRIPTION
## Summary

Wires the MVO portfolio optimizer (kernel shipped in #157) into the morning planner in **shadow mode** behind a config flag. Both paths run; the legacy 1/n sizer continues to emit orders, the optimizer logs target weights + diagnostics to S3 without affecting trade decisions.

Plan: [`alpha-engine-docs/private/portfolio-optimizer-260511.md`](https://github.com/cipher813/alpha-engine-docs/blob/main/private/portfolio-optimizer-260511.md)

## What's in this PR

| File | Purpose |
|---|---|
| `executor/optimizer_shadow.py` | Input assembler + S3 logger. Builds universe, alpha_hat, returns_panel, w_prev, sectors, stance_caps, eligibility from existing main.py state. Wraps `solve_target_weights` and writes to `predictor/optimizer_shadow/{date}.json` + `latest.json`. **Never raises into the legacy path** — failures write a sentinel. |
| `executor/main.py` | Single try/except call after `exit_orders` are computed (line ~1265), gated on `config.shadow_portfolio_optimizer` (default False). |
| `config/risk.yaml.example` | `shadow_portfolio_optimizer` flag + `portfolio_optimizer` config block with all defaults |
| `tests/test_optimizer_shadow.py` | 8 unit tests with mocked S3 |

## Production behavior

**Unchanged when `shadow_portfolio_optimizer: false`** (the default). The shadow path is dead code until the config flag is flipped.

### To enable on the trading EC2

1. Ensure cvxpy + scikit-learn are installed in the executor venv (added to requirements.txt in #157):
   ```bash
   ae-trading "cd ~/alpha-engine && source .venv/bin/activate && pip install -r requirements.txt"
   ```
2. Flip the flag in the live config (NOT the .example):
   ```bash
   ae-trading "sudo sed -i 's/shadow_portfolio_optimizer: false/shadow_portfolio_optimizer: true/' /etc/alpha-engine-config/executor/risk.yaml"
   ```
   Or equivalent edit via the alpha-engine-config repo flow.
3. Next morning planner run (weekday SF `RunMorningPlanner` step) writes the first shadow log to `s3://alpha-engine-research/predictor/optimizer_shadow/{YYYY-MM-DD}.json`.

### Inspecting the shadow log

```bash
aws s3 cp s3://alpha-engine-research/predictor/optimizer_shadow/latest.json - | jq '.diagnostics, .would_be_trades[:5], .target_weights'
```

Plausibility checks for first shadow log:
- `diagnostics.status` = `"optimal"` (or `"optimal_inaccurate"`)
- `diagnostics.n_active_positions` in `[3, 25]`
- `diagnostics.active_share_vs_spy` in `[0.05, 0.40]`
- SPY weight (`target_weights[tickers.index("SPY")]`) in `[0.70, 0.93]`
- CASH weight ≈ `0.03` (sleeve floor)

## Inputs assembled

| Optimizer kwarg | Source in main.py |
|---|---|
| `alpha_hat` | `predictions_by_ticker[t].predicted_alpha` (21d log α post 2026-05-09 cutover); SPY = 0, CASH = −1e-6 |
| `returns_panel` | `price_histories[t].close.pct_change()` aligned over the last 252 days (Ledoit-Wolf shrinkage handled by kernel) |
| `w_prev` | `current_positions[t].market_value / portfolio_nav`; cash absorbs residual |
| `sectors` | `signals_raw.signals[t].sector` (GICS name); SPY = `"__benchmark__"`, CASH = `"__cash__"` |
| `stance_caps` | `max_position_pct × stance_multiplier[t]` (momentum 1.0 / quality 0.8 / value 0.7 / catalyst 0.6) |
| `eligibility` | False if EXIT signal OR `gbm_veto=True` OR (not held AND score < `min_score_to_enter`) |

## Test plan

- [x] 8 new unit tests in `tests/test_optimizer_shadow.py`:
  - happy-path S3 write schema (target_weights / current_weights / diagnostics / would_be_trades / legacy_orders)
  - universe filtering by history length
  - SPY-required guard
  - EXIT signal → ineligibility
  - gbm_veto → ineligibility
  - w_prev reflects positions/NAV
  - stance multipliers apply to caps
  - never-raises behavior with sentinel write on failure
- [x] Full alpha-engine test suite green: **584 passed** (576 pre-existing + 8 new) in 2.83s
- [x] Pre-push dry-run gate passed

## Next steps

After this merges, the arc proceeds with:
- **Manual shadow flag flip** on the trading EC2 + observe 2-3 shadow logs
- **PR 3** — backtester optimizer-mode (2y replay, side-by-side metrics vs legacy)
- **PR 4** — cutover gate validator
- **PR 5** — cutover (`use_portfolio_optimizer: true`)
- **PR 6** — legacy retirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)