### PR TITLE
feat(executor): emit decision artifacts for position sizer (L2308 PR 2)

### DIFF
--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -41,6 +41,11 @@ import logging
 from dataclasses import dataclass, field
 from datetime import date
 
+from executor.decision_capture import (
+    DecisionCaptureWriteError,
+    capture_position_sizer,
+    is_decision_capture_enabled,
+)
 from executor.position_sizer import compute_position_size
 from executor.risk_guard import (
     check_order,
@@ -708,6 +713,57 @@ def decide_entries(
             feature_coverage=coverage_map.get(ticker),
             stance=pred_data.get("stance"),
         )
+
+        # Emit executor:position_sizer DecisionArtifact (L2308 PR 2).
+        # Captured BEFORE any downstream filtering (shares==0, GBM veto,
+        # risk_guard veto) so grading analytics can measure "sizing
+        # decisions that got refused" (precision of refusal) alongside
+        # "sized → ordered" decisions. Risk-guard + GBM veto captures
+        # land in PR 3 (executor:risk_guard).
+        # Best-effort: capture failure must never kill planning flow.
+        if is_decision_capture_enabled():
+            sized_outcome = (
+                "shares_zero" if sizing.get("shares", 0) == 0 else "approved"
+            )
+            sized_outcome_reason = (
+                f"shares round to 0 (${sizing['dollar_size']:.0f} / "
+                f"${current_price:.2f})"
+                if sized_outcome == "shares_zero"
+                else None
+            )
+            try:
+                capture_position_sizer(
+                    run_date=run_date,
+                    ticker=ticker,
+                    signal=sig,
+                    sector_rating=sector_rating_str,
+                    current_price=current_price,
+                    portfolio_nav=portfolio_nav,
+                    n_enter_signals=len(enter_signals),
+                    drawdown_multiplier=dd_multiplier,
+                    atr_pct=atr_pct,
+                    prediction_confidence=pred_confidence,
+                    p_up=pred_data.get("p_up"),
+                    signal_age_days=signal_age_days,
+                    days_to_earnings=earnings_by_ticker.get(ticker),
+                    feature_coverage=coverage_map.get(ticker),
+                    stance=pred_data.get("stance"),
+                    sizing_result=sizing,
+                    sized_outcome=sized_outcome,
+                    sized_outcome_reason=sized_outcome_reason,
+                )
+            except DecisionCaptureWriteError as _cap_exc:
+                logger.warning(
+                    "decision_capture S3 write failed for SIZE %s — "
+                    "continuing planning (capture is observability, not "
+                    "load-bearing): %s",
+                    ticker, _cap_exc,
+                )
+            except Exception:  # noqa: BLE001 — capture must never kill planning
+                logger.exception(
+                    "decision_capture raised unexpected exception for "
+                    "SIZE %s — continuing planning", ticker,
+                )
 
         if sizing["shares"] == 0:
             logger.info(

--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -68,8 +68,14 @@ def is_decision_capture_enabled() -> bool:
 
 _AGENT_ID_ENTRY_TRIGGERS = "executor:entry_triggers"
 _PRODUCER_NAME_ENTRY_TRIGGERS = "alpha-engine.executor.entry_triggers"
+
+_AGENT_ID_POSITION_SIZER = "executor:position_sizer"
+_PRODUCER_NAME_POSITION_SIZER = "alpha-engine.executor.position_sizer"
+
 # Bump when the snapshot/output shape changes; readers can filter on this
-# rather than guessing from S3 timestamps.
+# rather than guessing from S3 timestamps. Per-component versioning so a
+# bump in one producer (e.g. entry_triggers) doesn't force a re-tag of
+# every other deterministic-decision producer.
 _PRODUCER_VERSION = "1.0.0"
 
 
@@ -263,9 +269,191 @@ def capture_entry_trigger(
     return s3_key
 
 
+# ── Position sizer payload + capture ─────────────────────────────────────
+
+
+def build_position_sizer_payload(
+    *,
+    ticker: str,
+    signal: dict,
+    sector_rating: str,
+    current_price: float,
+    portfolio_nav: float,
+    n_enter_signals: int,
+    drawdown_multiplier: float,
+    atr_pct: float | None,
+    prediction_confidence: float | None,
+    p_up: float | None,
+    signal_age_days: int | None,
+    days_to_earnings: int | None,
+    feature_coverage: float | None,
+    stance: str | None,
+    sizing_result: dict,
+    sized_outcome: str,
+    sized_outcome_reason: str | None,
+) -> tuple[dict, dict, str]:
+    """Build ``(input_data_snapshot, agent_output, input_data_summary)``
+    for one ``compute_position_size`` invocation.
+
+    Snapshot mirrors every argument passed into the sizer plus the
+    portfolio context (NAV, n_entries today) so a replay can re-derive
+    the sizing decision from inputs without hitting S3 again.
+
+    ``agent_output`` records the sized result (shares + dollars + pct NAV)
+    plus the per-multiplier breakdown (sector_adj, conviction_adj,
+    upside_adj, drawdown_multiplier, atr_adj, confidence_adj,
+    staleness_adj, earnings_adj, coverage_adj, stance_adj). Joining
+    against ``trades.csv`` by ``ticker + date`` lets the backtester
+    grading analytics (PR 5) measure sizing-skill — e.g. did high-
+    multiplier sizes systematically outperform low-multiplier ones over
+    5d.
+
+    ``sized_outcome`` is one of ``{"approved", "shares_zero"}`` — captured
+    at the call site so downstream consumers know whether the sized
+    quantity became an order or got filtered. (Risk-guard vetoes and
+    GBM vetoes that happen AFTER sizing are captured by PR 3
+    ``executor:risk_guard``, not here.)
+    """
+    snapshot = {
+        "_producer": _PRODUCER_NAME_POSITION_SIZER,
+        "_producer_version": _PRODUCER_VERSION,
+        # Inputs passed into compute_position_size
+        "ticker": ticker,
+        "signal": {
+            "score": signal.get("score"),
+            "conviction": signal.get("conviction"),
+            "rating": signal.get("rating"),
+            "price_target_upside": signal.get("price_target_upside"),
+            "sector": signal.get("sector"),
+        },
+        "sector_rating": sector_rating,
+        "current_price": current_price,
+        "portfolio_nav": portfolio_nav,
+        "n_enter_signals": n_enter_signals,
+        "drawdown_multiplier": drawdown_multiplier,
+        "atr_pct": atr_pct,
+        "prediction_confidence": prediction_confidence,
+        "p_up": p_up,
+        "signal_age_days": signal_age_days,
+        "days_to_earnings": days_to_earnings,
+        "feature_coverage": feature_coverage,
+        "stance": stance,
+    }
+
+    # The sizer return dict carries the full multiplier breakdown — copy
+    # it through so grading analytics can decompose any subsequent
+    # under/over-performance against any single multiplier.
+    agent_output = {
+        "shares": sizing_result.get("shares"),
+        "dollar_size": sizing_result.get("dollar_size"),
+        "position_pct": sizing_result.get("position_pct"),
+        "sector_adj": sizing_result.get("sector_adj"),
+        "conviction_adj": sizing_result.get("conviction_adj"),
+        "upside_adj": sizing_result.get("upside_adj"),
+        "dd_multiplier": sizing_result.get("dd_multiplier"),
+        "atr_adj": sizing_result.get("atr_adj"),
+        "confidence_adj": sizing_result.get("confidence_adj"),
+        "staleness_adj": sizing_result.get("staleness_adj"),
+        "earnings_adj": sizing_result.get("earnings_adj"),
+        "coverage_adj": sizing_result.get("coverage_adj"),
+        "stance_adj": sizing_result.get("stance_adj"),
+        "sized_outcome": sized_outcome,
+        "sized_outcome_reason": sized_outcome_reason,
+    }
+
+    summary = (
+        f"{ticker} sizing: shares={sizing_result.get('shares')} "
+        f"dollars=${sizing_result.get('dollar_size'):.0f} "
+        f"pct={sizing_result.get('position_pct'):.4f} "
+        f"outcome={sized_outcome}"
+        if sizing_result.get("dollar_size") is not None
+        and sizing_result.get("position_pct") is not None
+        else f"{ticker} sizing: outcome={sized_outcome}"
+    )
+    return snapshot, agent_output, summary
+
+
+def capture_position_sizer(
+    *,
+    run_date: str,
+    ticker: str,
+    signal: dict,
+    sector_rating: str,
+    current_price: float,
+    portfolio_nav: float,
+    n_enter_signals: int,
+    drawdown_multiplier: float,
+    atr_pct: float | None,
+    prediction_confidence: float | None,
+    p_up: float | None,
+    signal_age_days: int | None,
+    days_to_earnings: int | None,
+    feature_coverage: float | None,
+    stance: str | None,
+    sizing_result: dict,
+    sized_outcome: str,
+    sized_outcome_reason: str | None = None,
+    s3_client: Any | None = None,
+    s3_bucket: str = "alpha-engine-research",
+) -> str | None:
+    """Emit one ``executor:position_sizer`` artifact for a single
+    ``compute_position_size`` invocation.
+
+    No-op when the env-flag feature gate is off. Raises
+    ``DecisionCaptureWriteError`` on S3 failure per
+    ``feedback_no_silent_fails`` — caller is responsible for the
+    best-effort try/except.
+
+    ``run_id`` is ``{run_date}_{ticker}_{uuid8}`` (per the plan doc Q1
+    anchor — multiple sizing calls per ticker per day don't overwrite
+    at the S3 leaf; in practice the morning planner sizes each ticker
+    at most once, but the uniqueness invariant is preserved for
+    correctness rather than relying on assumed call frequency).
+    """
+    if not is_decision_capture_enabled():
+        return None
+
+    snapshot, agent_output, summary = build_position_sizer_payload(
+        ticker=ticker,
+        signal=signal,
+        sector_rating=sector_rating,
+        current_price=current_price,
+        portfolio_nav=portfolio_nav,
+        n_enter_signals=n_enter_signals,
+        drawdown_multiplier=drawdown_multiplier,
+        atr_pct=atr_pct,
+        prediction_confidence=prediction_confidence,
+        p_up=p_up,
+        signal_age_days=signal_age_days,
+        days_to_earnings=days_to_earnings,
+        feature_coverage=feature_coverage,
+        stance=stance,
+        sizing_result=sizing_result,
+        sized_outcome=sized_outcome,
+        sized_outcome_reason=sized_outcome_reason,
+    )
+
+    run_id = f"{run_date}_{ticker}_{uuid.uuid4().hex[:8]}"
+
+    s3_key = capture_decision(
+        run_id=run_id,
+        agent_id=_AGENT_ID_POSITION_SIZER,
+        model_metadata=None,
+        full_prompt_context=None,
+        input_data_snapshot=snapshot,
+        agent_output=agent_output,
+        input_data_summary=summary,
+        s3_client=s3_client,
+        s3_bucket=s3_bucket,
+    )
+    return s3_key
+
+
 __all__ = [
     "DecisionCaptureWriteError",
     "build_entry_trigger_payload",
+    "build_position_sizer_payload",
     "capture_entry_trigger",
+    "capture_position_sizer",
     "is_decision_capture_enabled",
 ]

--- a/tests/test_decision_capture.py
+++ b/tests/test_decision_capture.py
@@ -24,7 +24,9 @@ from executor.decision_capture import (
     DecisionCaptureWriteError,
     _classify_trigger_kind,
     build_entry_trigger_payload,
+    build_position_sizer_payload,
     capture_entry_trigger,
+    capture_position_sizer,
     is_decision_capture_enabled,
 )
 
@@ -370,5 +372,302 @@ class TestHardFail:
                 strategy_config=_make_strategy_config(),
                 disabled_triggers=[],
                 now_et_iso="t",
+                s3_client=s3,
+            )
+
+
+# ── Position sizer (PR 2) ────────────────────────────────────────────────
+
+
+def _make_signal() -> dict:
+    """Research signal dict shape as it lands in deciders.decide_entries."""
+    return {
+        "ticker": "AAPL",
+        "score": 78.5,
+        "conviction": "rising",
+        "rating": "BUY",
+        "price_target_upside": 0.18,
+        "sector": "technology",
+    }
+
+
+def _make_sizing_result(shares: int = 150) -> dict:
+    """compute_position_size return dict shape."""
+    return {
+        "shares": shares,
+        "dollar_size": 26287.50 if shares else 0.0,
+        "position_pct": 0.0263 if shares else 0.0,
+        "sector_adj": 1.05,
+        "conviction_adj": 1.00,
+        "upside_adj": 1.00,
+        "dd_multiplier": 1.0,
+        "atr_adj": 0.95,
+        "confidence_adj": 1.10,
+        "staleness_adj": 1.0,
+        "earnings_adj": 1.0,
+        "coverage_adj": 1.0,
+        "stance_adj": 1.0,
+    }
+
+
+class TestPositionSizerPayloadShape:
+    """Snapshot + agent_output shape match the plan-doc + sizer return dict."""
+
+    def test_snapshot_carries_producer_provenance(self):
+        snapshot, _, _ = build_position_sizer_payload(
+            ticker="AAPL",
+            signal=_make_signal(),
+            sector_rating="overweight",
+            current_price=175.25,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=10,
+            drawdown_multiplier=1.0,
+            atr_pct=0.018,
+            prediction_confidence=0.72,
+            p_up=0.61,
+            signal_age_days=2,
+            days_to_earnings=18,
+            feature_coverage=0.97,
+            stance="momentum",
+            sizing_result=_make_sizing_result(),
+            sized_outcome="approved",
+            sized_outcome_reason=None,
+        )
+        assert snapshot["_producer"] == "alpha-engine.executor.position_sizer"
+        assert snapshot["_producer_version"] == "1.0.0"
+
+    def test_snapshot_carries_full_sizer_inputs(self):
+        snapshot, _, _ = build_position_sizer_payload(
+            ticker="AAPL",
+            signal=_make_signal(),
+            sector_rating="overweight",
+            current_price=175.25,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=10,
+            drawdown_multiplier=0.50,
+            atr_pct=0.018,
+            prediction_confidence=0.72,
+            p_up=0.61,
+            signal_age_days=2,
+            days_to_earnings=18,
+            feature_coverage=0.97,
+            stance="momentum",
+            sizing_result=_make_sizing_result(),
+            sized_outcome="approved",
+            sized_outcome_reason=None,
+        )
+        assert snapshot["ticker"] == "AAPL"
+        assert snapshot["sector_rating"] == "overweight"
+        assert snapshot["current_price"] == 175.25
+        assert snapshot["portfolio_nav"] == 1_000_000.0
+        assert snapshot["n_enter_signals"] == 10
+        assert snapshot["drawdown_multiplier"] == 0.50
+        assert snapshot["atr_pct"] == 0.018
+        assert snapshot["prediction_confidence"] == 0.72
+        assert snapshot["p_up"] == 0.61
+        assert snapshot["signal_age_days"] == 2
+        assert snapshot["days_to_earnings"] == 18
+        assert snapshot["feature_coverage"] == 0.97
+        assert snapshot["stance"] == "momentum"
+        # Signal sub-dict carries the research-decision context.
+        assert snapshot["signal"]["score"] == 78.5
+        assert snapshot["signal"]["conviction"] == "rising"
+        assert snapshot["signal"]["price_target_upside"] == 0.18
+
+    def test_agent_output_carries_full_sizer_breakdown(self):
+        """Per-multiplier breakdown lets grading analytics decompose
+        under/over-performance against any single adjustment factor."""
+        _, output, _ = build_position_sizer_payload(
+            ticker="AAPL",
+            signal=_make_signal(),
+            sector_rating="overweight",
+            current_price=175.25,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=10,
+            drawdown_multiplier=1.0,
+            atr_pct=0.018,
+            prediction_confidence=0.72,
+            p_up=0.61,
+            signal_age_days=2,
+            days_to_earnings=18,
+            feature_coverage=0.97,
+            stance="momentum",
+            sizing_result=_make_sizing_result(),
+            sized_outcome="approved",
+            sized_outcome_reason=None,
+        )
+        assert output["shares"] == 150
+        assert output["dollar_size"] == 26287.50
+        assert output["position_pct"] == 0.0263
+        # All 10 multiplier fields present + carried through.
+        assert output["sector_adj"] == 1.05
+        assert output["conviction_adj"] == 1.00
+        assert output["upside_adj"] == 1.00
+        assert output["dd_multiplier"] == 1.0
+        assert output["atr_adj"] == 0.95
+        assert output["confidence_adj"] == 1.10
+        assert output["staleness_adj"] == 1.0
+        assert output["earnings_adj"] == 1.0
+        assert output["coverage_adj"] == 1.0
+        assert output["stance_adj"] == 1.0
+        assert output["sized_outcome"] == "approved"
+        assert output["sized_outcome_reason"] is None
+
+    def test_shares_zero_outcome_captured(self):
+        _, output, summary = build_position_sizer_payload(
+            ticker="ABNB",
+            signal=_make_signal(),
+            sector_rating="market_weight",
+            current_price=120.0,
+            portfolio_nav=10_000.0,  # tiny NAV → shares rounds to 0
+            n_enter_signals=50,
+            drawdown_multiplier=1.0,
+            atr_pct=None,
+            prediction_confidence=None,
+            p_up=None,
+            signal_age_days=None,
+            days_to_earnings=None,
+            feature_coverage=None,
+            stance=None,
+            sizing_result=_make_sizing_result(shares=0),
+            sized_outcome="shares_zero",
+            sized_outcome_reason="shares round to 0 ($0 / $120.00)",
+        )
+        assert output["shares"] == 0
+        assert output["sized_outcome"] == "shares_zero"
+        assert "$0 / $120.00" in output["sized_outcome_reason"]
+        assert "outcome=shares_zero" in summary
+
+
+class TestPositionSizerCapture:
+    """End-to-end: env-flag on + S3 stub → put_object lands at canonical
+    executor:position_sizer key with v2 deterministic body."""
+
+    def test_writes_v2_artifact_to_canonical_key(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3_key = capture_position_sizer(
+            run_date="2026-05-15",
+            ticker="AAPL",
+            signal=_make_signal(),
+            sector_rating="overweight",
+            current_price=175.25,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=10,
+            drawdown_multiplier=1.0,
+            atr_pct=0.018,
+            prediction_confidence=0.72,
+            p_up=0.61,
+            signal_age_days=2,
+            days_to_earnings=18,
+            feature_coverage=0.97,
+            stance="momentum",
+            sizing_result=_make_sizing_result(),
+            sized_outcome="approved",
+            s3_client=s3,
+        )
+        s3.put_object.assert_called_once()
+        put_kwargs = s3.put_object.call_args.kwargs
+        assert put_kwargs["Bucket"] == "alpha-engine-research"
+        assert "/executor:position_sizer/" in put_kwargs["Key"]
+        assert put_kwargs["Key"].endswith(".json")
+        assert s3_key == put_kwargs["Key"]
+        body = json.loads(put_kwargs["Body"].decode("utf-8"))
+        # v2 + deterministic shape per lib v0.10.0 contract.
+        assert body["schema_version"] == 2
+        assert body["agent_id"] == "executor:position_sizer"
+        assert body["model_metadata"] is None
+        assert body["full_prompt_context"] is None
+        assert body["input_data_snapshot"]["ticker"] == "AAPL"
+        assert body["agent_output"]["shares"] == 150
+
+    def test_disabled_when_env_off(self, monkeypatch):
+        monkeypatch.delenv(
+            "ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", raising=False,
+        )
+        s3 = _make_s3_stub()
+        result = capture_position_sizer(
+            run_date="2026-05-15",
+            ticker="AAPL",
+            signal=_make_signal(),
+            sector_rating="overweight",
+            current_price=175.25,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=10,
+            drawdown_multiplier=1.0,
+            atr_pct=0.018,
+            prediction_confidence=0.72,
+            p_up=0.61,
+            signal_age_days=2,
+            days_to_earnings=18,
+            feature_coverage=0.97,
+            stance="momentum",
+            sizing_result=_make_sizing_result(),
+            sized_outcome="approved",
+            s3_client=s3,
+        )
+        assert result is None
+        s3.put_object.assert_not_called()
+
+    def test_run_id_includes_ticker_and_uuid_suffix(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        capture_position_sizer(
+            run_date="2026-05-15",
+            ticker="MSFT",
+            signal=_make_signal(),
+            sector_rating="market_weight",
+            current_price=410.00,
+            portfolio_nav=1_000_000.0,
+            n_enter_signals=5,
+            drawdown_multiplier=1.0,
+            atr_pct=None,
+            prediction_confidence=None,
+            p_up=None,
+            signal_age_days=None,
+            days_to_earnings=None,
+            feature_coverage=None,
+            stance=None,
+            sizing_result=_make_sizing_result(shares=100),
+            sized_outcome="approved",
+            s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        run_id = body["run_id"]
+        assert run_id.startswith("2026-05-15_MSFT_")
+        suffix = run_id.split("_")[-1]
+        assert len(suffix) == 8
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    def test_s3_failure_propagates_capture_write_error(self, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3.put_object.side_effect = ClientError(
+            error_response={
+                "Error": {"Code": "AccessDenied", "Message": "Denied"},
+            },
+            operation_name="PutObject",
+        )
+        with pytest.raises(DecisionCaptureWriteError):
+            capture_position_sizer(
+                run_date="2026-05-15",
+                ticker="AAPL",
+                signal=_make_signal(),
+                sector_rating="overweight",
+                current_price=175.25,
+                portfolio_nav=1_000_000.0,
+                n_enter_signals=10,
+                drawdown_multiplier=1.0,
+                atr_pct=0.018,
+                prediction_confidence=0.72,
+                p_up=0.61,
+                signal_age_days=2,
+                days_to_earnings=18,
+                feature_coverage=0.97,
+                stance="momentum",
+                sizing_result=_make_sizing_result(),
+                sized_outcome="approved",
                 s3_client=s3,
             )


### PR DESCRIPTION
## Summary

**PR 2 of 6** in the executor decision-capture arc (ROADMAP L2308). Closes the \"Position Sizing — N/A insufficient data\" gap in the Saturday evaluator email's Executor Components section. Per-sized-ticker \`DecisionArtifact\` rows land at:

\`\`\`
s3://alpha-engine-research/decision_artifacts/{Y}/{M}/{D}/executor:position_sizer/{run_id}.json
\`\`\`

Plan doc: \`~/Development/alpha-engine-docs/private/executor-decision-capture-260511.md\`.

## Capture point

In \`executor/deciders.py::decide_entries\`, right after the \`compute_position_size(...)\` return, **BEFORE** the downstream branches:

1. \`shares_zero\` check (filtered → \`plan.blocked\`)
2. GBM veto (predictor overrides research's ENTER)
3. \`risk_guard.check_order\` (sector / equity / drawdown gates)
4. Append to \`plan.orders\` (successful path)

This way grading analytics (PR 5) can measure \"sized decisions that got refused\" (precision-of-refusal) alongside \"sized → ordered\" — both inputs to the sizing-skill grade. Risk-guard + GBM veto captures land separately in PR 3 (\`executor:risk_guard\`).

## Changes

**\`executor/decision_capture.py\`:**
- New constants \`_AGENT_ID_POSITION_SIZER = \"executor:position_sizer\"\` + \`_PRODUCER_NAME_POSITION_SIZER\` (per-component versioning)
- \`build_position_sizer_payload()\` — (snapshot, output, summary); snapshot mirrors every sizer input + portfolio context (NAV, n_enter_signals, drawdown_multiplier, atr_pct, prediction_confidence, p_up, signal_age_days, days_to_earnings, feature_coverage, stance, sector_rating, current_price); agent_output records sized result + the **10-field per-multiplier breakdown** (sector_adj, conviction_adj, upside_adj, dd_multiplier, atr_adj, confidence_adj, staleness_adj, earnings_adj, coverage_adj, stance_adj) so grading can decompose any sizing skew against any single multiplier
- \`capture_position_sizer()\` — wraps lib's \`capture_decision\` with \`model_metadata=None\` + \`full_prompt_context=None\`; same \`{run_date}_{ticker}_{uuid8}\` run_id convention as PR 1

**\`executor/deciders.py\`:**
- New import block for \`capture_position_sizer\`, \`is_decision_capture_enabled\`, \`DecisionCaptureWriteError\`
- Capture call in \`decide_entries\` with try/except (WARN on \`DecisionCaptureWriteError\`, ERROR + traceback on any other exception). Capture failure must never kill planning flow.
- Records \`sized_outcome\` ∈ {\`approved\`, \`shares_zero\`} + a human-readable reason on the shares_zero path

## Test plan

- [x] **+8 new tests** in \`tests/test_decision_capture.py\`:
  - \`TestPositionSizerPayloadShape\` (4): producer provenance; full sizer inputs (13 fields); full multiplier breakdown (10 multipliers); shares_zero outcome captured with reason
  - \`TestPositionSizerCapture\` (4): canonical S3 key + v2 body shape; env-flag disabled no-op; run_id format pinned; ClientError → \`DecisionCaptureWriteError\` per \`feedback_no_silent_fails\`
- [x] Full alpha-engine suite: 605 → 613 (+8 new, all pass)
- [x] Pre-push executor dry-run gate: passed
- [ ] **Production exercise:** next weekday SF morning planner run with the env flag enabled. ~5-10 artifacts/day under \`executor:position_sizer/\` (one per ENTER candidate reaching the sizing step).

## Operator-side invariant

The \`ALPHA_ENGINE_DECISION_CAPTURE_ENABLED=true\` env var enables BOTH PR 1's entry_triggers AND PR 2's position_sizer capture at once — operator only flips it once. Future PRs 3 + 4 keep the same convention so the activation surface remains a single env var.

## Out of scope

- PR 3: \`executor:risk_guard\` capture + counterfactual (\"non-vetoed\" path)
- PR 4: \`executor:exit_rules\` capture in \`intraday_exit_manager\` + \`strategies/exit_manager\`
- PR 5: \`alpha-engine-backtester\` per-component grading analytics consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)