### PR TITLE
feat(executor): emit decision artifacts for risk guard (L2308 PR 3)

### DIFF
--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -44,6 +44,7 @@ from datetime import date
 from executor.decision_capture import (
     DecisionCaptureWriteError,
     capture_position_sizer,
+    capture_risk_guard,
     is_decision_capture_enabled,
 )
 from executor.position_sizer import compute_position_size
@@ -846,6 +847,45 @@ def decide_entries(
             ev.setdefault("signal_date", signals_date)
             ev.setdefault("prediction_date", predictions_date)
             plan.risk_events.append(ev)
+
+        # Emit executor:risk_guard DecisionArtifact (L2308 PR 3).
+        # Captures BOTH the vetoed and approved paths (counterfactual
+        # coverage) so backtester grading can measure precision-of-
+        # refusal: vetoed entries that would have won → false-positive
+        # vetoes; approved entries that became drawdowns → false-
+        # negative approvals. Without both directions, only one half of
+        # the precision/recall surface is gradable.
+        # Best-effort: capture failure must never kill planning flow.
+        if is_decision_capture_enabled():
+            try:
+                capture_risk_guard(
+                    run_date=run_date,
+                    ticker=ticker,
+                    action="ENTER",
+                    dollar_size=sizing["dollar_size"],
+                    portfolio_nav=portfolio_nav,
+                    peak_nav=peak_nav,
+                    current_positions=current_positions,
+                    sector=sector,
+                    market_regime=market_regime,
+                    signal=sig_with_sector,
+                    config=config,
+                    approved=approved,
+                    reason=reason,
+                    events=check_events,
+                )
+            except DecisionCaptureWriteError as _cap_exc:
+                logger.warning(
+                    "decision_capture S3 write failed for RISK_GUARD %s — "
+                    "continuing planning (capture is observability, not "
+                    "load-bearing): %s",
+                    ticker, _cap_exc,
+                )
+            except Exception:  # noqa: BLE001 — capture must never kill planning
+                logger.exception(
+                    "decision_capture raised unexpected exception for "
+                    "RISK_GUARD %s — continuing planning", ticker,
+                )
 
         if not approved:
             logger.info(f"BLOCKED {ticker} — {reason}")

--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -72,6 +72,9 @@ _PRODUCER_NAME_ENTRY_TRIGGERS = "alpha-engine.executor.entry_triggers"
 _AGENT_ID_POSITION_SIZER = "executor:position_sizer"
 _PRODUCER_NAME_POSITION_SIZER = "alpha-engine.executor.position_sizer"
 
+_AGENT_ID_RISK_GUARD = "executor:risk_guard"
+_PRODUCER_NAME_RISK_GUARD = "alpha-engine.executor.risk_guard"
+
 # Bump when the snapshot/output shape changes; readers can filter on this
 # rather than guessing from S3 timestamps. Per-component versioning so a
 # bump in one producer (e.g. entry_triggers) doesn't force a re-tag of
@@ -449,11 +452,207 @@ def capture_position_sizer(
     return s3_key
 
 
+# ── Risk guard payload + capture ─────────────────────────────────────────
+
+
+def _compute_existing_sector_exposure(
+    current_positions: dict, sector: str | None,
+) -> float:
+    """Sum market_value across current positions in the same sector.
+
+    Mirrors the risk_guard internal computation so the capture snapshot
+    carries the same view risk_guard saw at gate-evaluation time —
+    important for grading the max_sector veto in particular (the
+    threshold check uses `(existing + new) / nav`).
+    """
+    if not sector:
+        return 0.0
+    return float(sum(
+        pos.get("market_value", 0.0) or 0.0
+        for pos in (current_positions or {}).values()
+        if pos.get("sector") == sector
+    ))
+
+
+def build_risk_guard_payload(
+    *,
+    ticker: str,
+    action: str,
+    dollar_size: float,
+    portfolio_nav: float,
+    peak_nav: float,
+    current_positions: dict,
+    sector: str | None,
+    market_regime: str,
+    signal: dict,
+    config: dict,
+    approved: bool,
+    reason: str,
+    events: list[dict] | None,
+) -> tuple[dict, dict, str]:
+    """Build ``(input_data_snapshot, agent_output, input_data_summary)``
+    for one ``risk_guard.check_order`` invocation.
+
+    Captures both the **vetoed** path (artifact mirrors the risk_events
+    table row with full input context) AND the **counterfactual** —
+    every approved ticker also gets one artifact recording the
+    "non-vetoed" path inputs so backtester grading (PR 5) can measure
+    precision-of-refusal: of the entries risk_guard approved, how many
+    became drawdowns? Of the ones it vetoed, how many would have been
+    winners? Without the counterfactual, only one direction is gradable.
+
+    Snapshot mirrors every variable risk_guard reads at decision time:
+    portfolio state (nav, peak_nav, drawdown fraction), per-ticker
+    proposal (dollar_size, sector, sector_rating), market regime, and
+    every gate threshold from config that's evaluated for ENTER.
+
+    ``agent_output.outcome`` is ``"approved"`` or ``"vetoed"``;
+    ``vetoed_rule`` carries the rule name (``"min_score"``, ``"max_position"``,
+    ``"bear_underweight"``, ``"max_sector"``, ``"max_equity"``,
+    ``"correlation_block"``, etc.) for grading-side filtering.
+    ``events`` is the raw list emitted by risk_guard for the per-rule
+    audit trail (one row per veto event — usually 0 or 1, never more
+    than 1 per ticker because the function short-circuits on first fail).
+    """
+    drawdown_frac = (
+        (peak_nav - portfolio_nav) / peak_nav
+        if peak_nav and peak_nav > 0 else 0.0
+    )
+    sector_rating = signal.get("sector_rating", "market_weight")
+    existing_sector_exposure = _compute_existing_sector_exposure(
+        current_positions, sector,
+    )
+    snapshot = {
+        "_producer": _PRODUCER_NAME_RISK_GUARD,
+        "_producer_version": _PRODUCER_VERSION,
+        # Per-ticker proposal
+        "ticker": ticker,
+        "action": action,
+        "dollar_size": dollar_size,
+        "sector": sector,
+        "sector_rating": sector_rating,
+        # Portfolio state at gate-evaluation time
+        "portfolio_nav": portfolio_nav,
+        "peak_nav": peak_nav,
+        "drawdown_fraction": drawdown_frac,
+        "n_open_positions": len(current_positions or {}),
+        "existing_sector_exposure": existing_sector_exposure,
+        # Signal context (the values gates read against thresholds)
+        "signal": {
+            "score": signal.get("score"),
+            "conviction": signal.get("conviction"),
+            "rating": signal.get("rating"),
+            "price_target_upside": signal.get("price_target_upside"),
+        },
+        "market_regime": market_regime,
+        # Config-derived gate thresholds — every one risk_guard evaluates
+        # on the ENTER path. Captured so grading can replay against a
+        # different threshold set without re-running the risk gate.
+        "thresholds": {
+            "min_score_to_enter": config.get("min_score_to_enter", 70),
+            "max_position_pct": config.get("max_position_pct", 0.05),
+            "bear_max_position_pct": config.get("bear_max_position_pct", 0.025),
+            "max_sector_pct": config.get("max_sector_pct", 0.25),
+            "max_equity_pct": config.get("max_equity_pct", 1.00),
+            "bear_block_underweight": config.get("bear_block_underweight", True),
+            "drawdown_halt_pct": config.get("drawdown_halt_pct"),
+            "correlation_block_threshold": config.get(
+                "correlation_block_threshold",
+            ),
+        },
+    }
+
+    outcome = "approved" if approved else "vetoed"
+    # First fired veto rule (the one that short-circuited). risk_guard
+    # only emits one veto event per ticker due to short-circuit; on the
+    # approved path the events list may still carry portfolio-level
+    # rows from the caller, so filter to per-ticker veto events.
+    veto_events = [
+        ev for ev in (events or [])
+        if ev.get("ticker") == ticker and ev.get("event_type") == "veto"
+    ]
+    vetoed_rule = veto_events[0].get("rule") if veto_events else None
+    agent_output = {
+        "outcome": outcome,
+        "reason": reason,
+        "vetoed_rule": vetoed_rule,
+        "events": veto_events,
+    }
+
+    summary = f"{ticker} risk_guard: outcome={outcome} reason={reason}"
+    return snapshot, agent_output, summary
+
+
+def capture_risk_guard(
+    *,
+    run_date: str,
+    ticker: str,
+    action: str,
+    dollar_size: float,
+    portfolio_nav: float,
+    peak_nav: float,
+    current_positions: dict,
+    sector: str | None,
+    market_regime: str,
+    signal: dict,
+    config: dict,
+    approved: bool,
+    reason: str,
+    events: list[dict] | None,
+    s3_client: Any | None = None,
+    s3_bucket: str = "alpha-engine-research",
+) -> str | None:
+    """Emit one ``executor:risk_guard`` artifact for a single
+    ``check_order`` invocation. Captures both vetoed and approved paths
+    (the counterfactual coverage that grading needs for precision-of-
+    refusal analytics).
+
+    No-op when the env-flag feature gate is off. Raises
+    ``DecisionCaptureWriteError`` on S3 failure per
+    ``feedback_no_silent_fails``.
+    """
+    if not is_decision_capture_enabled():
+        return None
+
+    snapshot, agent_output, summary = build_risk_guard_payload(
+        ticker=ticker,
+        action=action,
+        dollar_size=dollar_size,
+        portfolio_nav=portfolio_nav,
+        peak_nav=peak_nav,
+        current_positions=current_positions,
+        sector=sector,
+        market_regime=market_regime,
+        signal=signal,
+        config=config,
+        approved=approved,
+        reason=reason,
+        events=events,
+    )
+
+    run_id = f"{run_date}_{ticker}_{uuid.uuid4().hex[:8]}"
+
+    s3_key = capture_decision(
+        run_id=run_id,
+        agent_id=_AGENT_ID_RISK_GUARD,
+        model_metadata=None,
+        full_prompt_context=None,
+        input_data_snapshot=snapshot,
+        agent_output=agent_output,
+        input_data_summary=summary,
+        s3_client=s3_client,
+        s3_bucket=s3_bucket,
+    )
+    return s3_key
+
+
 __all__ = [
     "DecisionCaptureWriteError",
     "build_entry_trigger_payload",
     "build_position_sizer_payload",
+    "build_risk_guard_payload",
     "capture_entry_trigger",
     "capture_position_sizer",
+    "capture_risk_guard",
     "is_decision_capture_enabled",
 ]

--- a/tests/test_decision_capture.py
+++ b/tests/test_decision_capture.py
@@ -25,8 +25,10 @@ from executor.decision_capture import (
     _classify_trigger_kind,
     build_entry_trigger_payload,
     build_position_sizer_payload,
+    build_risk_guard_payload,
     capture_entry_trigger,
     capture_position_sizer,
+    capture_risk_guard,
     is_decision_capture_enabled,
 )
 
@@ -671,3 +673,279 @@ class TestPositionSizerCapture:
                 sized_outcome="approved",
                 s3_client=s3,
             )
+
+
+# ── Risk guard (PR 3) ────────────────────────────────────────────────────
+
+
+def _make_risk_guard_signal() -> dict:
+    """Signal dict shape as it lands in risk_guard.check_order."""
+    return {
+        "ticker": "AAPL",
+        "score": 78.5,
+        "conviction": "rising",
+        "rating": "BUY",
+        "price_target_upside": 0.18,
+        "sector": "technology",
+        "sector_rating": "overweight",
+    }
+
+
+def _make_current_positions(sector_for_held: str = "technology") -> dict:
+    """Sample current_positions dict — risk_guard reads market_value +
+    sector to compute sector exposure."""
+    return {
+        "MSFT": {"market_value": 50_000.0, "sector": sector_for_held},
+        "JPM":  {"market_value": 30_000.0, "sector": "financials"},
+    }
+
+
+def _make_risk_config() -> dict:
+    return {
+        "min_score_to_enter": 70,
+        "max_position_pct": 0.05,
+        "bear_max_position_pct": 0.025,
+        "max_sector_pct": 0.25,
+        "max_equity_pct": 1.00,
+        "bear_block_underweight": True,
+        "drawdown_halt_pct": 0.15,
+        "correlation_block_threshold": 0.80,
+    }
+
+
+class TestRiskGuardPayloadShape:
+    """Snapshot + agent_output for both approved and vetoed paths."""
+
+    def test_snapshot_carries_producer_provenance(self):
+        snapshot, _, _ = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=1_050_000.0,
+            current_positions=_make_current_positions(),
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=True, reason="ok", events=[],
+        )
+        assert snapshot["_producer"] == "alpha-engine.executor.risk_guard"
+        assert snapshot["_producer_version"] == "1.0.0"
+
+    def test_snapshot_carries_portfolio_state_and_drawdown(self):
+        snapshot, _, _ = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=950_000.0, peak_nav=1_000_000.0,
+            current_positions=_make_current_positions(),
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=True, reason="ok", events=[],
+        )
+        assert snapshot["portfolio_nav"] == 950_000.0
+        assert snapshot["peak_nav"] == 1_000_000.0
+        # drawdown_fraction = (peak - nav) / peak = 50000 / 1000000 = 0.05
+        assert abs(snapshot["drawdown_fraction"] - 0.05) < 1e-9
+        assert snapshot["n_open_positions"] == 2
+        # existing_sector_exposure for technology = MSFT's 50k (JPM is
+        # financials, excluded).
+        assert snapshot["existing_sector_exposure"] == 50_000.0
+
+    def test_snapshot_carries_full_gate_thresholds(self):
+        snapshot, _, _ = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=1_050_000.0,
+            current_positions={}, sector="technology",
+            market_regime="neutral", signal=_make_risk_guard_signal(),
+            config=_make_risk_config(),
+            approved=True, reason="ok", events=[],
+        )
+        thr = snapshot["thresholds"]
+        # All 8 gates captured so a future replay can re-evaluate
+        # against a different threshold set.
+        assert thr["min_score_to_enter"] == 70
+        assert thr["max_position_pct"] == 0.05
+        assert thr["bear_max_position_pct"] == 0.025
+        assert thr["max_sector_pct"] == 0.25
+        assert thr["max_equity_pct"] == 1.00
+        assert thr["bear_block_underweight"] is True
+        assert thr["drawdown_halt_pct"] == 0.15
+        assert thr["correlation_block_threshold"] == 0.80
+
+    def test_approved_path_records_outcome_approved(self):
+        _, output, summary = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=1_050_000.0,
+            current_positions={}, sector="technology",
+            market_regime="neutral", signal=_make_risk_guard_signal(),
+            config=_make_risk_config(),
+            approved=True, reason="ok", events=[],
+        )
+        assert output["outcome"] == "approved"
+        assert output["reason"] == "ok"
+        assert output["vetoed_rule"] is None
+        assert output["events"] == []
+        assert "outcome=approved" in summary
+
+    def test_vetoed_path_extracts_rule_from_events(self):
+        events = [
+            {
+                "ticker": "AAPL", "event_type": "veto", "rule": "min_score",
+                "reason": "Score 58.0 < minimum 70", "value": 58.0,
+                "threshold": 70.0,
+            },
+        ]
+        _, output, summary = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=1_050_000.0,
+            current_positions={}, sector="technology",
+            market_regime="neutral", signal=_make_risk_guard_signal(),
+            config=_make_risk_config(),
+            approved=False, reason="Score 58.0 < minimum 70", events=events,
+        )
+        assert output["outcome"] == "vetoed"
+        assert output["vetoed_rule"] == "min_score"
+        assert output["events"] == events
+        assert "outcome=vetoed" in summary
+
+    def test_events_filtered_to_per_ticker_veto_only(self):
+        """Approved path with portfolio-level events in scope: those must
+        not leak into the per-ticker artifact's events list."""
+        events = [
+            # Portfolio-level halt — different ticker / no ticker
+            {"event_type": "halt", "rule": "drawdown_halt", "reason": "p"},
+            # Some other ticker's veto (defensive — shouldn't happen in
+            # practice but the filter must be robust)
+            {
+                "ticker": "OTHER", "event_type": "veto", "rule": "min_score",
+                "reason": "x",
+            },
+        ]
+        _, output, _ = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=1_050_000.0,
+            current_positions={}, sector="technology",
+            market_regime="neutral", signal=_make_risk_guard_signal(),
+            config=_make_risk_config(),
+            approved=True, reason="ok", events=events,
+        )
+        assert output["outcome"] == "approved"
+        assert output["vetoed_rule"] is None
+        # Only this ticker's veto events would land in `events` — both
+        # input rows belong to other contexts, so the list is empty.
+        assert output["events"] == []
+
+    def test_zero_peak_nav_produces_zero_drawdown_safely(self):
+        """Anti-regression: division-by-zero guard on peak_nav=0."""
+        snapshot, _, _ = build_risk_guard_payload(
+            ticker="AAPL", action="ENTER", dollar_size=26_000.0,
+            portfolio_nav=1_000_000.0, peak_nav=0.0,
+            current_positions={}, sector="technology",
+            market_regime="neutral", signal=_make_risk_guard_signal(),
+            config=_make_risk_config(),
+            approved=True, reason="ok", events=[],
+        )
+        assert snapshot["drawdown_fraction"] == 0.0
+
+
+class TestRiskGuardCapture:
+    """End-to-end capture path with env-flag + S3 stub."""
+
+    def test_writes_v2_artifact_to_canonical_key(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3_key = capture_risk_guard(
+            run_date="2026-05-15", ticker="AAPL", action="ENTER",
+            dollar_size=26_000.0, portfolio_nav=1_000_000.0,
+            peak_nav=1_050_000.0,
+            current_positions=_make_current_positions(),
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=True, reason="ok", events=[], s3_client=s3,
+        )
+        s3.put_object.assert_called_once()
+        put_kwargs = s3.put_object.call_args.kwargs
+        assert put_kwargs["Bucket"] == "alpha-engine-research"
+        assert "/executor:risk_guard/" in put_kwargs["Key"]
+        assert put_kwargs["Key"].endswith(".json")
+        assert s3_key == put_kwargs["Key"]
+        body = json.loads(put_kwargs["Body"].decode("utf-8"))
+        assert body["schema_version"] == 2
+        assert body["agent_id"] == "executor:risk_guard"
+        assert body["model_metadata"] is None
+        assert body["full_prompt_context"] is None
+        assert body["input_data_snapshot"]["ticker"] == "AAPL"
+        assert body["agent_output"]["outcome"] == "approved"
+
+    def test_vetoed_artifact_carries_rule_and_events(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        events = [
+            {
+                "ticker": "AAPL", "event_type": "veto",
+                "rule": "max_position", "reason": "too big",
+                "value": 0.08, "threshold": 0.05,
+            },
+        ]
+        capture_risk_guard(
+            run_date="2026-05-15", ticker="AAPL", action="ENTER",
+            dollar_size=80_000.0, portfolio_nav=1_000_000.0,
+            peak_nav=1_050_000.0, current_positions={},
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=False, reason="too big", events=events, s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert body["agent_output"]["outcome"] == "vetoed"
+        assert body["agent_output"]["vetoed_rule"] == "max_position"
+        assert body["agent_output"]["events"] == events
+
+    def test_disabled_when_env_off(self, monkeypatch):
+        monkeypatch.delenv(
+            "ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", raising=False,
+        )
+        s3 = _make_s3_stub()
+        result = capture_risk_guard(
+            run_date="2026-05-15", ticker="AAPL", action="ENTER",
+            dollar_size=26_000.0, portfolio_nav=1_000_000.0,
+            peak_nav=1_050_000.0, current_positions={},
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=True, reason="ok", events=[], s3_client=s3,
+        )
+        assert result is None
+        s3.put_object.assert_not_called()
+
+    def test_s3_failure_propagates_capture_write_error(self, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3.put_object.side_effect = ClientError(
+            error_response={
+                "Error": {"Code": "AccessDenied", "Message": "Denied"},
+            },
+            operation_name="PutObject",
+        )
+        with pytest.raises(DecisionCaptureWriteError):
+            capture_risk_guard(
+                run_date="2026-05-15", ticker="AAPL", action="ENTER",
+                dollar_size=26_000.0, portfolio_nav=1_000_000.0,
+                peak_nav=1_050_000.0, current_positions={},
+                sector="technology", market_regime="neutral",
+                signal=_make_risk_guard_signal(), config=_make_risk_config(),
+                approved=True, reason="ok", events=[], s3_client=s3,
+            )
+
+    def test_run_id_includes_ticker_and_uuid_suffix(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        capture_risk_guard(
+            run_date="2026-05-15", ticker="NVDA", action="ENTER",
+            dollar_size=30_000.0, portfolio_nav=1_000_000.0,
+            peak_nav=1_050_000.0, current_positions={},
+            sector="technology", market_regime="neutral",
+            signal=_make_risk_guard_signal(), config=_make_risk_config(),
+            approved=True, reason="ok", events=[], s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        run_id = body["run_id"]
+        assert run_id.startswith("2026-05-15_NVDA_")
+        suffix = run_id.split("_")[-1]
+        assert len(suffix) == 8
+        assert all(c in "0123456789abcdef" for c in suffix)


### PR DESCRIPTION
## Summary

**PR 3 of 6** in the executor decision-capture arc (ROADMAP L2308). Closes the \"Risk Guard — N/A insufficient data\" gap in the Saturday evaluator email's Executor Components section. Per-\`check_order\` \`DecisionArtifact\` rows land at:

\`\`\`
s3://alpha-engine-research/decision_artifacts/{Y}/{M}/{D}/executor:risk_guard/{run_id}.json
\`\`\`

Plan doc: \`~/Development/alpha-engine-docs/private/executor-decision-capture-260511.md\`.

## The counterfactual is the key design choice

Captures BOTH the **vetoed** path AND the **approved** path so grading (PR 5) can measure precision-of-refusal:

- **Vetoed → won** (counterfactual we'd need anyway): would risk_guard have been better off approving?
- **Approved → drawdown**: did risk_guard miss a veto it should have fired?

Without the counterfactual, only one half of the precision/recall surface is gradable. The risk_events table from alpha-engine #139 carried only the vetoed side; this PR closes the symmetric gap on the artifact-capture layer.

## Capture point

In \`executor/deciders.py::decide_entries\`, right after the \`for ev in check_events: plan.risk_events.append(ev)\` loop, **BEFORE** the \`if not approved\` branch. Both code paths get an artifact (\`outcome=\"approved\"\` or \`outcome=\"vetoed\"\`).

## Schema snapshot (what's captured)

Snapshot mirrors every variable risk_guard reads at gate-evaluation time:

- **Per-ticker proposal:** ticker, action, dollar_size, sector, sector_rating
- **Portfolio state:** portfolio_nav, peak_nav, drawdown_fraction (computed), n_open_positions, existing_sector_exposure (mirrors risk_guard's internal sector-exposure calc — load-bearing for grading max_sector vetoes)
- **Signal context:** score, conviction, rating, price_target_upside, market_regime
- **All 8 config-derived gate thresholds:** min_score_to_enter, max_position_pct, bear_max_position_pct, max_sector_pct, max_equity_pct, bear_block_underweight, drawdown_halt_pct, correlation_block_threshold — captured so a replay can re-evaluate gates against a different threshold set without re-running risk_guard

agent_output carries:
- \`outcome\` ∈ {\`approved\`, \`vetoed\`}
- \`reason\` (the human-readable string from \`check_order\`)
- \`vetoed_rule\` (extracted from events list, filtered per-ticker; e.g. \`min_score\`, \`max_position\`, \`bear_underweight\`, \`max_sector\`, \`max_equity\`, \`correlation_block\`)
- \`events\` (raw list of veto events for this ticker — portfolio-level + other-ticker events filtered out)

## Test plan

- [x] **+12 new tests** in \`tests/test_decision_capture.py\`:
  - \`TestRiskGuardPayloadShape\` (7): producer provenance; portfolio state + drawdown_fraction math; existing sector exposure correctly filtered; full 8-gate threshold capture; approved/vetoed outcomes; per-ticker event filter; zero-peak_nav guard
  - \`TestRiskGuardCapture\` (5): canonical S3 key + v2 body; vetoed artifact carries rule + events; env-flag disabled no-op; ClientError → \`DecisionCaptureWriteError\` per \`feedback_no_silent_fails\`; run_id format pinned
- [x] Full alpha-engine suite: 613 → 625 (+12 new, all pass)
- [ ] Pre-push executor dry-run gate skipped (worktree without .venv); main-repo venv ran the full suite cleanly
- [ ] **Production exercise:** next weekday SF morning planner run with env flag set. ~25-35 artifacts/day under \`executor:risk_guard/\` (one per ENTER candidate reaching the risk_guard gate)

## Operator-side invariant preserved

Same \`ALPHA_ENGINE_DECISION_CAPTURE_ENABLED=true\` env flag enables PR 1's entry_triggers + PR 2's position_sizer + this PR's risk_guard captures together. Single activation surface across the arc.

## Out of scope

- PR 4: \`executor:exit_rules\` capture in \`intraday_exit_manager\` + \`strategies/exit_manager\`
- PR 5: alpha-engine-backtester per-component grading analytics consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)