### PR TITLE
fix(optimizer): use log returns in shadow wrapper (canonical-alpha alignment)

### DIFF
--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -237,12 +237,22 @@ def _build_returns_panel(
     price_histories: dict[str, pd.DataFrame],
     cash_idx: int,
 ) -> np.ndarray:
+    """Daily LOG returns for covariance estimation.
+
+    Convention matches the 2026-05-09 21d log-domain canonical-alpha cutover
+    (alpha-engine-predictor PRs A-E + 2026-05-10 transition arc): alpha_hat
+    consumed by the optimizer is 21d log alpha (predictor's predicted_alpha
+    field), so the Sigma fed in must be in the same log-units family. Daily
+    log variance compounds linearly to higher horizons (Var_T = T · Var_daily
+    for iid log returns).
+    """
     series_by_ticker: dict[str, pd.Series] = {}
     for i, t in enumerate(tickers):
         if i == cash_idx:
             continue
         df = price_histories[t]
-        s = df["close"].tail(_RETURNS_LOOKBACK_DAYS + 1).pct_change().dropna()
+        close = df["close"].tail(_RETURNS_LOOKBACK_DAYS + 1)
+        s = np.log(close).diff().dropna()
         series_by_ticker[t] = s
 
     aligned = pd.DataFrame(series_by_ticker).dropna()


### PR DESCRIPTION
## Summary

Companion to **alpha-engine-backtester [#186](https://github.com/cipher813/alpha-engine-backtester/pull/186)**. Aligns the shadow-mode wrapper's covariance-panel construction with the 2026-05-09 21d log-domain canonical-alpha cutover (predictor PRs A-E + the 2026-05-10 transition arc).

The optimizer's `alpha_hat` is the predictor's 21d log alpha (`canonical_predicted_alpha`). For the MVO objective `wᵀα̂ − λ·wᵀΣw` to live in a dimensionally consistent units family, Σ must be estimated from **log returns** — daily log variance compounds linearly to higher horizons (`Var_T = T · Var_daily` for i.i.d. log returns), so the 21d α̂ and daily Σ live in the same log-units family.

Plan: [`alpha-engine-docs/private/portfolio-optimizer-260511.md`](https://github.com/cipher813/alpha-engine-docs/blob/main/private/portfolio-optimizer-260511.md) — unit-conventions section.

## Changes

`executor/optimizer_shadow.py::_build_returns_panel`:

```diff
- s = df["close"].tail(_RETURNS_LOOKBACK_DAYS + 1).pct_change().dropna()
+ close = df["close"].tail(_RETURNS_LOOKBACK_DAYS + 1)
+ s = np.log(close).diff().dropna()
```

Plus a docstring noting the convention + cross-referencing the canonical-alpha cutover.

## Production impact

**Negligible numerical change** — for typical daily moves (~1%), `log(1+r) ≈ r` to second order, so the Σ matrix shifts by ~0.5% per element on average. The optimizer's output weights will be very close to what they were on first emission. The substantive value is **framework alignment** — consistency with canonical-alpha labels + the downstream gates that will compare optimizer outputs.

Shadow wrapper is non-blocking by design (any failure writes a sentinel + logs WARNING) — no functional risk.

## Test plan

- [x] 16 optimizer-related tests green (8 portfolio_optimizer kernel + 8 shadow wrapper)
- [x] Full alpha-engine suite green: **625 passed** in 2.84s
- [x] Pre-push dry-run gate passed

## Context — why both fixes land today

This is the third lapse-correction in the portfolio-optimizer arc; Brian flagged all three within minutes of each other:

1. **alpha-engine-backtester #186** (in progress) — gate anchored on raw Sharpe; corrected to skilled-risk basket (Sortino + PSR + CVaR + max DD)
2. **alpha-engine-backtester #186 (additional commit)** — returns_panel used arithmetic returns; corrected to log returns
3. **This PR** — shadow wrapper had the same arithmetic-returns bug

All three are "align portfolio-optimizer arc to canonical framework" — both the evaluator-revamp anchor + the 21d log-domain returns convention should have been baked in from PR 1. Memory updated at `feedback_anchor_gates_on_skilled_risk_not_sharpe.md`; the canonical-alpha framework was already documented at [[handoff_260510_canonical_alpha_cutover_transition_arc]] and I missed propagating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)