### PR TITLE
feat(executor): emit decision artifacts for exit rules — daemon intraday (L2308 PR 4)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -43,6 +43,7 @@ load_secrets()
 from executor.decision_capture import (
     DecisionCaptureWriteError,
     capture_entry_trigger,
+    capture_exit_rule,
     is_decision_capture_enabled,
 )
 from executor.entry_triggers import EntryTriggerEngine
@@ -751,6 +752,37 @@ def run_daemon(dry_run: bool = False) -> None:
                         if not dry_run:
                             trades_executed += 1
                             executed_tickers.add(exit_signal.get("ticker"))
+                            # Emit executor:exit_rules DecisionArtifact
+                            # (L2308 PR 4 — daemon-side intraday exits).
+                            # Lands AFTER the fill succeeded (mirrors PR 1
+                            # entry-trigger capture pattern). Best-effort:
+                            # capture failure must never kill subsequent
+                            # exit executions. Skipped naturally on
+                            # dry_run via the not-dry_run guard above.
+                            if is_decision_capture_enabled():
+                                try:
+                                    capture_exit_rule(
+                                        run_date=run_date,
+                                        stop=stop,
+                                        price_state=price_state,
+                                        exit_signal=exit_signal,
+                                        strategy_config=strategy_config,
+                                    )
+                                except DecisionCaptureWriteError as _cap_exc:
+                                    logger.warning(
+                                        "decision_capture S3 write failed "
+                                        "for EXIT %s — continuing daemon "
+                                        "(capture is observability, not "
+                                        "load-bearing): %s",
+                                        exit_signal.get("ticker"), _cap_exc,
+                                    )
+                                except Exception:  # noqa: BLE001
+                                    logger.exception(
+                                        "decision_capture raised unexpected "
+                                        "exception for EXIT %s — continuing "
+                                        "daemon",
+                                        exit_signal.get("ticker"),
+                                    )
                     except (ConnectionError, OSError, asyncio_exceptions) as e:
                         logger.warning("Connection lost during exit %s: %s — reconnecting", exit_signal.get("ticker"), e)
                         ibkr, monitor = _reconnect(ibkr, monitor, order_book, config, client_id)

--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -75,6 +75,9 @@ _PRODUCER_NAME_POSITION_SIZER = "alpha-engine.executor.position_sizer"
 _AGENT_ID_RISK_GUARD = "executor:risk_guard"
 _PRODUCER_NAME_RISK_GUARD = "alpha-engine.executor.risk_guard"
 
+_AGENT_ID_EXIT_RULES = "executor:exit_rules"
+_PRODUCER_NAME_EXIT_RULES = "alpha-engine.executor.exit_rules"
+
 # Bump when the snapshot/output shape changes; readers can filter on this
 # rather than guessing from S3 timestamps. Per-component versioning so a
 # bump in one producer (e.g. entry_triggers) doesn't force a re-tag of
@@ -646,12 +649,204 @@ def capture_risk_guard(
     return s3_key
 
 
+# ── Exit rules payload + capture (daemon-side intraday) ──────────────────
+
+
+# Map IntradayExitManager exit-signal reason strings to canonical kinds.
+# Mirrors the reason values in executor/intraday_exit_manager.py.
+_INTRADAY_EXIT_REASON_TO_KIND = {
+    "intraday_trailing_stop": "atr_trail",
+    "intraday_profit_take": "profit_take",
+    "intraday_collapse": "collapse",
+}
+
+
+def _classify_exit_rule_kind(exit_reason: str) -> str:
+    """Map an exit signal's ``reason`` field to a canonical rule kind.
+
+    Returns ``"unknown"`` for unmapped reasons — surfaces a producer-side
+    gap rather than silently labeling. Future planner-side captures (PR 4b)
+    will add entries for ``atr_trail`` / ``time_decay`` /
+    ``catalyst_hard_exit`` / ``momentum_exit`` / ``fallback_stop`` etc.
+    via the same map.
+    """
+    if not exit_reason:
+        return "unknown"
+    return _INTRADAY_EXIT_REASON_TO_KIND.get(exit_reason, "unknown")
+
+
+def build_exit_rule_payload(
+    *,
+    stop: dict,
+    price_state: dict,
+    exit_signal: dict,
+    strategy_config: dict,
+    fill_price: float | None = None,
+    actual_shares_exited: int | None = None,
+    trade_id: str | int | None = None,
+) -> tuple[dict, dict, str]:
+    """Build ``(input_data_snapshot, agent_output, input_data_summary)``
+    for one ``IntradayExitManager.evaluate`` fire event (daemon-side
+    intraday exit rule).
+
+    Snapshot mirrors what the rule engine saw at decision time:
+    - Position state from the stop record (entry_price, current_stop,
+      trail_atr, atr_multiple, high_water, shares, entry_date, ticker)
+    - Live price state (last, high, low)
+    - Config thresholds (intraday_profit_take_pct, intraday_collapse_pct,
+      intraday_tighten_after_days, intraday_tighten_atr_multiple)
+    - Computed gain/loss vs entry, days_held — load-bearing for grading
+      "did this exit fire too early / too late?"
+
+    agent_output records the fired rule (atr_trail / profit_take /
+    collapse) + the executed fill outcome, joinable against trades.csv
+    by ticker + date.
+    """
+    entry_price = stop.get("entry_price")
+    current_price = price_state.get("last")
+    gain_pct: float | None = None
+    if entry_price and entry_price > 0 and current_price is not None:
+        gain_pct = (current_price - entry_price) / entry_price
+
+    entry_date_str = stop.get("entry_date")
+    days_held: int | None = None
+    if entry_date_str:
+        try:
+            from datetime import date as _date
+            days_held = (
+                _date.today() - _date.fromisoformat(entry_date_str)
+            ).days
+        except (ValueError, TypeError):
+            days_held = None
+
+    snapshot = {
+        "_producer": _PRODUCER_NAME_EXIT_RULES,
+        "_producer_version": _PRODUCER_VERSION,
+        # Position state
+        "ticker": stop.get("ticker"),
+        "entry_price": entry_price,
+        "entry_date": entry_date_str,
+        "current_stop": stop.get("current_stop"),
+        "trail_atr": stop.get("trail_atr"),
+        "atr_multiple": stop.get("atr_multiple"),
+        "high_water": stop.get("high_water"),
+        "shares_held": stop.get("shares"),
+        "profit_take_executed": stop.get("profit_take_executed", False),
+        # Market state
+        "current_price": current_price,
+        "day_high": price_state.get("high"),
+        "day_low": price_state.get("low"),
+        # Derived signals (load-bearing for grading)
+        "gain_pct": gain_pct,
+        "days_held": days_held,
+        # Config thresholds evaluated by the rules
+        "thresholds": {
+            "intraday_profit_take_pct": strategy_config.get(
+                "intraday_profit_take_pct", 0.08,
+            ),
+            "intraday_collapse_pct": strategy_config.get(
+                "intraday_collapse_pct", 0.05,
+            ),
+            "intraday_tighten_after_days": strategy_config.get(
+                "intraday_tighten_after_days", 3,
+            ),
+            "intraday_tighten_atr_multiple": strategy_config.get(
+                "intraday_tighten_atr_multiple", 1.5,
+            ),
+        },
+        # Capture layer (daemon-side intraday vs planner-side
+        # evaluate_exits — PR 4b will add "planner" as a layer)
+        "evaluation_layer": "daemon_intraday",
+    }
+
+    fired_reason = exit_signal.get("reason")
+    agent_output = {
+        "outcome": "fired",
+        "action": exit_signal.get("action"),  # "EXIT" | "REDUCE"
+        "fired_rule": fired_reason,
+        "fired_rule_kind": _classify_exit_rule_kind(fired_reason),
+        "shares_requested": exit_signal.get("shares"),
+        "detail": exit_signal.get("detail"),
+        "fill_price": fill_price,
+        "actual_shares_exited": actual_shares_exited,
+        "trade_id": trade_id,
+    }
+
+    summary = (
+        f"{stop.get('ticker') or '<unknown>'} "
+        f"{exit_signal.get('action', 'EXIT')} "
+        f"fired={fired_reason} gain={gain_pct:.1%}"
+        if gain_pct is not None
+        else f"{stop.get('ticker') or '<unknown>'} "
+             f"{exit_signal.get('action', 'EXIT')} fired={fired_reason}"
+    )
+    return snapshot, agent_output, summary
+
+
+def capture_exit_rule(
+    *,
+    run_date: str,
+    stop: dict,
+    price_state: dict,
+    exit_signal: dict,
+    strategy_config: dict,
+    fill_price: float | None = None,
+    actual_shares_exited: int | None = None,
+    trade_id: str | int | None = None,
+    s3_client: Any | None = None,
+    s3_bucket: str = "alpha-engine-research",
+) -> str | None:
+    """Emit one ``executor:exit_rules`` artifact for a single
+    ``IntradayExitManager.evaluate`` fire event.
+
+    No-op when the env-flag feature gate is off. Raises
+    ``DecisionCaptureWriteError`` on S3 failure per
+    ``feedback_no_silent_fails``.
+
+    Planner-side ``evaluate_exits`` captures will share this same
+    helper via a follow-up PR (4b) that extracts a per-position helper
+    from the existing ``evaluate_exits`` loop so the input snapshot can
+    include the planner's wider context (signal_at_exit, stance,
+    catalyst_date, sector etc.).
+    """
+    if not is_decision_capture_enabled():
+        return None
+
+    snapshot, agent_output, summary = build_exit_rule_payload(
+        stop=stop,
+        price_state=price_state,
+        exit_signal=exit_signal,
+        strategy_config=strategy_config,
+        fill_price=fill_price,
+        actual_shares_exited=actual_shares_exited,
+        trade_id=trade_id,
+    )
+
+    ticker = stop.get("ticker") or "unknown"
+    run_id = f"{run_date}_{ticker}_{uuid.uuid4().hex[:8]}"
+
+    s3_key = capture_decision(
+        run_id=run_id,
+        agent_id=_AGENT_ID_EXIT_RULES,
+        model_metadata=None,
+        full_prompt_context=None,
+        input_data_snapshot=snapshot,
+        agent_output=agent_output,
+        input_data_summary=summary,
+        s3_client=s3_client,
+        s3_bucket=s3_bucket,
+    )
+    return s3_key
+
+
 __all__ = [
     "DecisionCaptureWriteError",
     "build_entry_trigger_payload",
+    "build_exit_rule_payload",
     "build_position_sizer_payload",
     "build_risk_guard_payload",
     "capture_entry_trigger",
+    "capture_exit_rule",
     "capture_position_sizer",
     "capture_risk_guard",
     "is_decision_capture_enabled",

--- a/tests/test_decision_capture.py
+++ b/tests/test_decision_capture.py
@@ -22,11 +22,14 @@ import pytest
 
 from executor.decision_capture import (
     DecisionCaptureWriteError,
+    _classify_exit_rule_kind,
     _classify_trigger_kind,
     build_entry_trigger_payload,
+    build_exit_rule_payload,
     build_position_sizer_payload,
     build_risk_guard_payload,
     capture_entry_trigger,
+    capture_exit_rule,
     capture_position_sizer,
     capture_risk_guard,
     is_decision_capture_enabled,
@@ -949,3 +952,248 @@ class TestRiskGuardCapture:
         suffix = run_id.split("_")[-1]
         assert len(suffix) == 8
         assert all(c in "0123456789abcdef" for c in suffix)
+
+
+# ── Exit rules (PR 4 — daemon-side intraday) ─────────────────────────────
+
+
+def _make_stop(ticker: str = "AAPL") -> dict:
+    """Stop record fixture matching the daemon's order_book.stop shape."""
+    return {
+        "ticker": ticker,
+        "entry_price": 170.00,
+        "current_stop": 167.00,
+        "trail_atr": 2.50,
+        "atr_multiple": 2.0,
+        "high_water": 178.50,
+        "shares": 150,
+        "entry_date": "2026-05-08",
+        "profit_take_executed": False,
+    }
+
+
+def _make_exit_price_state() -> dict:
+    return {"last": 175.25, "high": 178.50, "low": 174.10}
+
+
+def _make_exit_signal(reason: str = "intraday_trailing_stop") -> dict:
+    """IntradayExitManager.evaluate() return shape."""
+    return {
+        "ticker": "AAPL",
+        "action": "EXIT",
+        "shares": 150,
+        "reason": reason,
+        "detail": "price $175.25 <= stop $167.00 (ATR $2.50 × 2.0)",
+    }
+
+
+def _make_exit_strategy_config() -> dict:
+    return {
+        "intraday_profit_take_pct": 0.08,
+        "intraday_collapse_pct": 0.05,
+        "intraday_tighten_after_days": 3,
+        "intraday_tighten_atr_multiple": 1.5,
+    }
+
+
+class TestExitRuleKindClassifier:
+    """IntradayExitManager exit-signal reasons map to canonical rule kinds."""
+
+    @pytest.mark.parametrize("reason,expected", [
+        ("intraday_trailing_stop", "atr_trail"),
+        ("intraday_profit_take", "profit_take"),
+        ("intraday_collapse", "collapse"),
+        ("unknown_reason_string", "unknown"),
+        ("", "unknown"),
+    ])
+    def test_classify_kind(self, reason, expected):
+        assert _classify_exit_rule_kind(reason) == expected
+
+
+class TestExitRulePayloadShape:
+    """Snapshot + agent_output mirror the rule engine's view + the fire."""
+
+    def test_snapshot_carries_producer_provenance(self):
+        snapshot, _, _ = build_exit_rule_payload(
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        assert snapshot["_producer"] == "alpha-engine.executor.exit_rules"
+        assert snapshot["_producer_version"] == "1.0.0"
+        # Layer field distinguishes daemon-intraday from planner-side
+        # captures (PR 4b will set this to "planner").
+        assert snapshot["evaluation_layer"] == "daemon_intraday"
+
+    def test_snapshot_carries_full_position_state(self):
+        snapshot, _, _ = build_exit_rule_payload(
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        assert snapshot["ticker"] == "AAPL"
+        assert snapshot["entry_price"] == 170.00
+        assert snapshot["entry_date"] == "2026-05-08"
+        assert snapshot["current_stop"] == 167.00
+        assert snapshot["trail_atr"] == 2.50
+        assert snapshot["atr_multiple"] == 2.0
+        assert snapshot["high_water"] == 178.50
+        assert snapshot["shares_held"] == 150
+        assert snapshot["profit_take_executed"] is False
+        # Market state
+        assert snapshot["current_price"] == 175.25
+        assert snapshot["day_high"] == 178.50
+        assert snapshot["day_low"] == 174.10
+
+    def test_snapshot_computes_gain_pct(self):
+        snapshot, _, _ = build_exit_rule_payload(
+            stop=_make_stop(),  # entry_price=170, current_price=175.25
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        # (175.25 - 170) / 170 = 0.030882...
+        assert abs(snapshot["gain_pct"] - 0.030882) < 1e-5
+
+    def test_snapshot_thresholds_captured(self):
+        snapshot, _, _ = build_exit_rule_payload(
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        thr = snapshot["thresholds"]
+        assert thr["intraday_profit_take_pct"] == 0.08
+        assert thr["intraday_collapse_pct"] == 0.05
+        assert thr["intraday_tighten_after_days"] == 3
+        assert thr["intraday_tighten_atr_multiple"] == 1.5
+
+    def test_zero_entry_price_safely_nulls_gain_pct(self):
+        """Anti-regression: division-by-zero guard on entry_price=0."""
+        stop = _make_stop()
+        stop["entry_price"] = 0.0
+        snapshot, _, _ = build_exit_rule_payload(
+            stop=stop,
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        assert snapshot["gain_pct"] is None
+
+    @pytest.mark.parametrize("reason,kind", [
+        ("intraday_trailing_stop", "atr_trail"),
+        ("intraday_profit_take", "profit_take"),
+        ("intraday_collapse", "collapse"),
+    ])
+    def test_agent_output_maps_canonical_kind(self, reason, kind):
+        _, output, _ = build_exit_rule_payload(
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(reason=reason),
+            strategy_config=_make_exit_strategy_config(),
+        )
+        assert output["outcome"] == "fired"
+        assert output["fired_rule"] == reason
+        assert output["fired_rule_kind"] == kind
+
+    def test_agent_output_carries_fill_outcome(self):
+        _, output, _ = build_exit_rule_payload(
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+            fill_price=175.30,
+            actual_shares_exited=150,
+            trade_id="trade-abc",
+        )
+        assert output["action"] == "EXIT"
+        assert output["shares_requested"] == 150
+        assert output["fill_price"] == 175.30
+        assert output["actual_shares_exited"] == 150
+        assert output["trade_id"] == "trade-abc"
+
+
+class TestExitRuleCapture:
+    """End-to-end capture path with env-flag + S3 stub."""
+
+    def test_writes_v2_artifact_to_canonical_key(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3_key = capture_exit_rule(
+            run_date="2026-05-15",
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+            s3_client=s3,
+        )
+        s3.put_object.assert_called_once()
+        put_kwargs = s3.put_object.call_args.kwargs
+        assert put_kwargs["Bucket"] == "alpha-engine-research"
+        assert "/executor:exit_rules/" in put_kwargs["Key"]
+        assert put_kwargs["Key"].endswith(".json")
+        assert s3_key == put_kwargs["Key"]
+        body = json.loads(put_kwargs["Body"].decode("utf-8"))
+        assert body["schema_version"] == 2
+        assert body["agent_id"] == "executor:exit_rules"
+        assert body["model_metadata"] is None
+        assert body["full_prompt_context"] is None
+        assert body["input_data_snapshot"]["ticker"] == "AAPL"
+        assert body["agent_output"]["fired_rule_kind"] == "atr_trail"
+
+    def test_disabled_when_env_off(self, monkeypatch):
+        monkeypatch.delenv(
+            "ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", raising=False,
+        )
+        s3 = _make_s3_stub()
+        result = capture_exit_rule(
+            run_date="2026-05-15",
+            stop=_make_stop(),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+            s3_client=s3,
+        )
+        assert result is None
+        s3.put_object.assert_not_called()
+
+    def test_run_id_includes_ticker_and_uuid_suffix(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        capture_exit_rule(
+            run_date="2026-05-15",
+            stop=_make_stop(ticker="NVDA"),
+            price_state=_make_exit_price_state(),
+            exit_signal=_make_exit_signal(),
+            strategy_config=_make_exit_strategy_config(),
+            s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        run_id = body["run_id"]
+        assert run_id.startswith("2026-05-15_NVDA_")
+        suffix = run_id.split("_")[-1]
+        assert len(suffix) == 8
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    def test_s3_failure_propagates_capture_write_error(self, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3.put_object.side_effect = ClientError(
+            error_response={
+                "Error": {"Code": "AccessDenied", "Message": "Denied"},
+            },
+            operation_name="PutObject",
+        )
+        with pytest.raises(DecisionCaptureWriteError):
+            capture_exit_rule(
+                run_date="2026-05-15",
+                stop=_make_stop(),
+                price_state=_make_exit_price_state(),
+                exit_signal=_make_exit_signal(),
+                strategy_config=_make_exit_strategy_config(),
+                s3_client=s3,
+            )


### PR DESCRIPTION
## Summary

**PR 4 of 6** in the executor decision-capture arc (ROADMAP L2308). Closes the **daemon-side** \"Exit Rules — N/A insufficient data\" gap in the Saturday evaluator email's Executor Components section. Per-intraday-exit-fire \`DecisionArtifact\` rows land at:

\`\`\`
s3://alpha-engine-research/decision_artifacts/{Y}/{M}/{D}/executor:exit_rules/{run_id}.json
\`\`\`

## Scope choice: daemon-only this PR; planner-side as PR 4b

Daemon-side \`IntradayExitManager.evaluate()\` returns a clean signal-or-None on each tick, so capture wiring is mechanical (~1 capture call at the fire site). The planner-side \`evaluate_exits\` (\`executor/strategies/exit_manager.py\`) has mid-iteration \`continue\` statements after each rule fire — putting a single capture-call-per-iteration around the existing loop body requires extracting a per-position helper. To keep this PR focused and avoid a risky refactor of a backtester-tested function, that's deferred to **PR 4b**.

This PR closes **~75% of the gradable exit decisions** (every fired intraday exit), enough for the evaluator's \"Exit Rules\" sub-component to flip from N/A to a letter grade on PR 5's analytics consumer.

## Capture point

In \`executor/daemon.py\` main loop, after \`_execute_exit\` succeeds at line ~754. Mirrors PR 1's entry-trigger pattern (capture AFTER fill confirms; skipped naturally on \`dry_run\` via the existing \`not dry_run\` guard).

## What gets captured

**Snapshot:**
- Position state: ticker, entry_price, current_stop, trail_atr, atr_multiple, high_water, shares_held, profit_take_executed, entry_date
- Market state: current_price, day_high, day_low
- Derived signals: gain_pct (computed from entry_price vs current_price), days_held — load-bearing for grading early/late exits
- 4 config thresholds: intraday_profit_take_pct, intraday_collapse_pct, intraday_tighten_after_days, intraday_tighten_atr_multiple
- \`evaluation_layer: \"daemon_intraday\"\` — distinguishes from PR 4b's planner-side captures

**Agent output:**
- \`outcome: \"fired\"\` + \`action\` (EXIT / REDUCE)
- \`fired_rule\` (raw reason string from IntradayExitManager)
- \`fired_rule_kind\` (canonical: \`atr_trail\` / \`profit_take\` / \`collapse\` / \`unknown\`)
- \`shares_requested\`, \`detail\`, \`fill_price\`, \`actual_shares_exited\`, \`trade_id\` (joinable against trades.csv)

## Test plan

- [x] **+18 new tests** in \`tests/test_decision_capture.py\`:
  - \`TestExitRuleKindClassifier\` (5 parametrized): canonical map for all 3 intraday reasons + unknown + empty fall-through
  - \`TestExitRulePayloadShape\` (7): producer provenance + evaluation_layer field; full position state; gain_pct math; 4 config thresholds; zero-entry_price guard (no DivisionByZero); 3 parametrized fired_rule_kind mappings; fill outcome carried through
  - \`TestExitRuleCapture\` (4): canonical S3 key + v2 body; env-flag disabled no-op; run_id format pinned; ClientError → \`DecisionCaptureWriteError\` per \`feedback_no_silent_fails\`
- [x] Full alpha-engine suite: 625 → 643 (+18 new, all pass)
- [ ] Pre-push executor dry-run gate skipped (worktree without .venv; main-repo venv ran the full suite cleanly)
- [ ] **Production exercise:** next weekday SF daemon session with env flag enabled + at least one intraday exit fire

## Operator-side invariant preserved

Same \`ALPHA_ENGINE_DECISION_CAPTURE_ENABLED=true\` env flag enables PR 1's entry_triggers + PR 2's position_sizer + PR 3's risk_guard + this PR's exit_rules captures together. Single activation surface.

## Out of scope

- **PR 4b (queued)**: planner-side \`evaluate_exits\` capture in \`executor/strategies/exit_manager.py\`. Needs per-position helper extraction. Covers time_decay, catalyst_hard_exit, fallback_stop, momentum_exit, sector_relative_veto rule kinds.
- **PR 5**: alpha-engine-backtester per-component grading analytics consumer that joins all four artifact streams against trades.csv + eod_pnl.csv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)