### PR TITLE
feat(executor): emit decision artifacts for exit rules — planner side (L2308 PR 4b)

### DIFF
--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -660,19 +660,50 @@ _INTRADAY_EXIT_REASON_TO_KIND = {
     "intraday_collapse": "collapse",
 }
 
+# Planner-side fired_rule_key values from
+# ``executor/strategies/exit_manager.py::_evaluate_single_position``.
+# Canonical kinds for the morning-planner exit-rule decision layer.
+# Where overlapping with daemon-side kinds (atr_trail, profit_take), the
+# planner key maps to the same canonical kind so grading analytics can
+# treat both layers consistently for those rules. Planner-only kinds
+# (catalyst_hard_exit, fallback_stop, momentum_exit, time_decay,
+# sector_veto_blocked) extend the vocabulary.
+_PLANNER_EXIT_RULE_KEY_TO_KIND = {
+    "catalyst_hard_exit": "catalyst_hard_exit",
+    "atr_trailing_stop": "atr_trail",
+    "sector_veto_blocked": "sector_veto_blocked",
+    "fallback_stop": "fallback_stop",
+    "profit_take": "profit_take",
+    "momentum_exit": "momentum_exit",
+    "time_decay": "time_decay",
+}
+
 
 def _classify_exit_rule_kind(exit_reason: str) -> str:
-    """Map an exit signal's ``reason`` field to a canonical rule kind.
+    """Map an exit signal's ``reason`` field to a canonical rule kind
+    for daemon-side intraday captures (PR 4).
 
     Returns ``"unknown"`` for unmapped reasons — surfaces a producer-side
-    gap rather than silently labeling. Future planner-side captures (PR 4b)
-    will add entries for ``atr_trail`` / ``time_decay`` /
-    ``catalyst_hard_exit`` / ``momentum_exit`` / ``fallback_stop`` etc.
-    via the same map.
+    gap rather than silently labeling.
     """
     if not exit_reason:
         return "unknown"
     return _INTRADAY_EXIT_REASON_TO_KIND.get(exit_reason, "unknown")
+
+
+def _classify_planner_exit_kind(fired_rule_key: str | None) -> str:
+    """Map planner-side ``fired_rule_key`` to a canonical rule kind for
+    planner-side captures (PR 4b).
+
+    ``None`` → ``"no_fire"`` (no rule fired — counterfactual coverage
+    row that grading uses to measure missed-exit precision).
+    Unmapped key → ``"unknown"`` (defensive; surfaces if a new rule
+    branch in ``_evaluate_single_position`` ships without updating this
+    map).
+    """
+    if fired_rule_key is None:
+        return "no_fire"
+    return _PLANNER_EXIT_RULE_KEY_TO_KIND.get(fired_rule_key, "unknown")
 
 
 def build_exit_rule_payload(
@@ -839,14 +870,194 @@ def capture_exit_rule(
     return s3_key
 
 
+# ── Planner-side exit rules payload + capture (PR 4b) ────────────────────
+
+
+def build_planner_exit_payload(
+    *,
+    ticker: str,
+    pos: dict,
+    research_signal: dict,
+    current_price: float,
+    stance: str | None,
+    catalyst_date,
+    stance_config: dict,
+    signal: dict | None,
+    fired_rule_key: str | None,
+) -> tuple[dict, dict, str]:
+    """Build ``(input_data_snapshot, agent_output, input_data_summary)``
+    for one ``evaluate_exits._evaluate_single_position`` invocation
+    (planner-side morning exit-rule layer).
+
+    Captures BOTH fired (signal non-None) and no-fire (signal is None)
+    positions. The no-fire counterfactual lets grading measure missed-
+    exit precision: positions where no exit rule fired in the planner
+    but later produced drawdowns are gradable as missed exits.
+
+    Snapshot mirrors what ``_evaluate_single_position`` saw at decision
+    time:
+    - Position state from ``pos`` (entry_date, avg_cost, sector, shares,
+      stance, catalyst_date)
+    - Research signal context (action, score, conviction)
+    - Resolved stance_config thresholds for each rule the planner
+      evaluated (atr_*, profit_take_pct, time_decay_*, momentum_*,
+      catalyst_*, sector_relative_*)
+    - Market state (current_price)
+    """
+    avg_cost = pos.get("avg_cost")
+    gain_pct: float | None = None
+    if avg_cost and avg_cost > 0:
+        gain_pct = (current_price - avg_cost) / avg_cost
+
+    snapshot = {
+        "_producer": _PRODUCER_NAME_EXIT_RULES,
+        "_producer_version": _PRODUCER_VERSION,
+        "ticker": ticker,
+        # Position state
+        "entry_date": pos.get("entry_date"),
+        "avg_cost": avg_cost,
+        "shares_held": pos.get("shares"),
+        "market_value": pos.get("market_value"),
+        "sector": pos.get("sector"),
+        "stance": stance,
+        "catalyst_date": catalyst_date,
+        # Market state
+        "current_price": current_price,
+        "gain_pct": gain_pct,
+        # Research-side signal context (the planner reads this to decide
+        # whether the position is still in HOLD vs already exiting)
+        "research_action": research_signal.get("signal", "HOLD"),
+        "research_score": research_signal.get("score"),
+        "research_conviction": research_signal.get("conviction"),
+        # Resolved (stance-aware) config thresholds for each rule
+        # branch ``_evaluate_single_position`` evaluated. Captured so a
+        # replay can re-evaluate with different thresholds without
+        # re-running the planner.
+        "thresholds": {
+            "atr_period": stance_config.get("atr_period"),
+            "atr_multiple": stance_config.get("atr_multiple"),
+            "fallback_stop_enabled": stance_config.get(
+                "fallback_stop_enabled", True,
+            ),
+            "fallback_stop_pct": stance_config.get("fallback_stop_pct"),
+            "profit_take_pct": stance_config.get("profit_take_pct"),
+            "time_decay_enabled": stance_config.get("time_decay_enabled"),
+            "time_decay_days": stance_config.get("time_decay_days"),
+            "momentum_exit_enabled": stance_config.get(
+                "momentum_exit_enabled",
+            ),
+            "momentum_exit_threshold": stance_config.get(
+                "momentum_exit_threshold",
+            ),
+            "catalyst_follow_through_days": stance_config.get(
+                "catalyst_follow_through_days",
+            ),
+        },
+        "evaluation_layer": "planner",
+    }
+
+    fired_rule_kind = _classify_planner_exit_kind(fired_rule_key)
+    if signal is not None:
+        agent_output = {
+            "outcome": "fired",
+            "action": signal.get("action"),  # "EXIT" | "REDUCE"
+            "fired_rule": signal.get("reason"),
+            "fired_rule_key": fired_rule_key,
+            "fired_rule_kind": fired_rule_kind,
+            "shares_requested": signal.get("shares"),
+            "detail": signal.get("detail"),
+        }
+        summary = (
+            f"{ticker} {signal.get('action', 'EXIT')} "
+            f"fired={fired_rule_key} kind={fired_rule_kind}"
+        )
+    else:
+        # No-fire counterfactual row. fired_rule_key may be None (truly
+        # nothing fired) or "sector_veto_blocked" (ATR fired but was
+        # suppressed by sector veto — load-bearing for grading the veto
+        # decision separately from the no-fire decision).
+        agent_output = {
+            "outcome": "no_fire",
+            "action": None,
+            "fired_rule": None,
+            "fired_rule_key": fired_rule_key,
+            "fired_rule_kind": fired_rule_kind,
+            "shares_requested": None,
+            "detail": None,
+        }
+        summary = f"{ticker} no_fire kind={fired_rule_kind}"
+
+    return snapshot, agent_output, summary
+
+
+def capture_planner_exit(
+    *,
+    run_date: str,
+    ticker: str,
+    pos: dict,
+    research_signal: dict,
+    current_price: float,
+    stance: str | None,
+    catalyst_date,
+    stance_config: dict,
+    signal: dict | None,
+    fired_rule_key: str | None,
+    s3_client: Any | None = None,
+    s3_bucket: str = "alpha-engine-research",
+) -> str | None:
+    """Emit one ``executor:exit_rules`` artifact for a single planner-
+    side ``_evaluate_single_position`` invocation.
+
+    Same agent_id as PR 4's daemon-side captures (``executor:exit_rules``)
+    so grading analytics can read them from one S3 prefix. The
+    ``evaluation_layer`` field on the snapshot distinguishes
+    ``"planner"`` (PR 4b) from ``"daemon_intraday"`` (PR 4).
+
+    No-op when the env-flag feature gate is off. Raises
+    ``DecisionCaptureWriteError`` on S3 failure per
+    ``feedback_no_silent_fails``.
+    """
+    if not is_decision_capture_enabled():
+        return None
+
+    snapshot, agent_output, summary = build_planner_exit_payload(
+        ticker=ticker,
+        pos=pos,
+        research_signal=research_signal,
+        current_price=current_price,
+        stance=stance,
+        catalyst_date=catalyst_date,
+        stance_config=stance_config,
+        signal=signal,
+        fired_rule_key=fired_rule_key,
+    )
+
+    run_id = f"{run_date}_{ticker}_{uuid.uuid4().hex[:8]}"
+
+    s3_key = capture_decision(
+        run_id=run_id,
+        agent_id=_AGENT_ID_EXIT_RULES,
+        model_metadata=None,
+        full_prompt_context=None,
+        input_data_snapshot=snapshot,
+        agent_output=agent_output,
+        input_data_summary=summary,
+        s3_client=s3_client,
+        s3_bucket=s3_bucket,
+    )
+    return s3_key
+
+
 __all__ = [
     "DecisionCaptureWriteError",
     "build_entry_trigger_payload",
     "build_exit_rule_payload",
+    "build_planner_exit_payload",
     "build_position_sizer_payload",
     "build_risk_guard_payload",
     "capture_entry_trigger",
     "capture_exit_rule",
+    "capture_planner_exit",
     "capture_position_sizer",
     "capture_risk_guard",
     "is_decision_capture_enabled",

--- a/executor/strategies/exit_manager.py
+++ b/executor/strategies/exit_manager.py
@@ -543,6 +543,143 @@ def check_momentum_exit(
     return None
 
 
+def _evaluate_single_position(
+    *,
+    ticker: str,
+    pos: dict,
+    research_action: str,
+    current_price: float,
+    history,
+    sector_etf_histories: dict | None,
+    stance_config: dict,
+    catalyst_date,
+    entry_date,
+    run_date: str,
+    feature_lookup,
+) -> tuple[dict | None, str | None]:
+    """Run all exit-rule checks for a single held position.
+
+    Returns ``(signal, fired_rule_key)`` where ``fired_rule_key`` is one of:
+    ``catalyst_hard_exit`` / ``atr_trailing_stop`` / ``sector_veto_blocked`` /
+    ``fallback_stop`` / ``profit_take`` / ``momentum_exit`` / ``time_decay``,
+    or ``(None, None)`` if no rule fired.
+
+    Extracted from the loop body of ``evaluate_exits`` to enable per-
+    position capture wiring (L2308 PR 4b) without losing the existing
+    mid-iteration short-circuit semantics. Behavior is identical to the
+    pre-refactor loop body — caller verifies via the existing
+    ``test_exit_manager.py`` suite.
+
+    Note: ``sector_veto_blocked`` is reported when ATR fired but the
+    sector-relative veto suppressed it (load-bearing for grading the
+    sector-veto decision separately from the ATR-fire decision).
+    """
+    # 0. Catalyst hard exit — runs FIRST so the deadline supersedes
+    # price-based checks (the thesis is mechanically expired).
+    catalyst_exit = check_catalyst_hard_exit(
+        ticker=ticker,
+        catalyst_date=catalyst_date,
+        run_date=run_date,
+        strategy_config=stance_config,
+    )
+    if catalyst_exit:
+        return catalyst_exit, "catalyst_hard_exit"
+
+    # 1. ATR trailing stop (with sector-relative veto)
+    atr_signal = check_atr_trailing_stop(
+        ticker=ticker,
+        current_price=current_price,
+        entry_date=entry_date,
+        price_history=history,
+        strategy_config=stance_config,
+        feature_lookup=feature_lookup,
+        run_date=run_date,
+    )
+    if atr_signal:
+        sector = pos.get("sector", "")
+        etf_ticker = SECTOR_ETF_MAP.get(sector, "SPY")
+        etf_history = (
+            sector_etf_histories.get(etf_ticker)
+            if sector_etf_histories
+            else None
+        )
+        if check_sector_relative_veto(
+            ticker, sector, history, etf_history, stance_config
+        ):
+            logger.info(
+                f"ATR exit for {ticker} vetoed — outperforming sector ({sector})"
+            )
+            # Sector veto blocked the ATR exit; fall through to other
+            # checks. Mark this position-iteration so capture can record
+            # the suppressed-fire event separately from the ultimate
+            # outcome (no-fire / time-decay / etc.).
+            atr_signal = None  # consumed by veto
+            atr_fired_then_vetoed = True
+        else:
+            return atr_signal, "atr_trailing_stop"
+    else:
+        atr_fired_then_vetoed = False
+
+    if atr_signal is None and stance_config.get("fallback_stop_enabled", True):
+        # ATR returned None (or was vetoed by sector check) — try fallback
+        # fixed-percentage stop. Note: post-sector-veto the fallback stop
+        # is still considered (matches pre-refactor behavior where the
+        # `elif stance_config.get(...)` only ran when ATR returned None
+        # AT THE check_atr_trailing_stop call site, not after sector veto.
+        # To preserve identical behavior, guard fallback on "ATR returned
+        # None at the call site" — track via the original `atr_signal`
+        # before the veto branch consumed it).
+        if not atr_fired_then_vetoed:
+            fallback_signal = check_fallback_stop(
+                ticker=ticker,
+                current_price=current_price,
+                entry_price=pos.get("avg_cost"),
+                strategy_config=stance_config,
+            )
+            if fallback_signal:
+                return fallback_signal, "fallback_stop"
+
+    # 2. Profit-taking
+    avg_cost = pos.get("avg_cost")
+    profit_signal = check_profit_take(
+        ticker=ticker,
+        current_price=current_price,
+        avg_cost=avg_cost,
+        strategy_config=stance_config,
+    )
+    if profit_signal:
+        return profit_signal, "profit_take"
+
+    # 3. Momentum exit
+    momentum_signal = check_momentum_exit(
+        ticker=ticker,
+        price_history=history,
+        strategy_config=stance_config,
+        feature_lookup=feature_lookup,
+        run_date=run_date,
+    )
+    if momentum_signal:
+        return momentum_signal, "momentum_exit"
+
+    # 4. Time-based decay
+    time_signal = check_time_decay(
+        ticker=ticker,
+        entry_date=entry_date,
+        run_date=run_date,
+        signal_action=research_action,
+        strategy_config=stance_config,
+    )
+    if time_signal:
+        return time_signal, "time_decay"
+
+    # Sector-vetoed-ATR positions are recorded for the artifact's
+    # fired-then-vetoed signal even though the outcome is no_fire.
+    if atr_fired_then_vetoed:
+        return None, "sector_veto_blocked"
+
+    return None, None
+
+
 def evaluate_exits(
     current_positions: dict[str, dict],
     signals_by_ticker: dict[str, dict],
@@ -586,7 +723,25 @@ def evaluate_exits(
 
     Returns:
         List of signal dicts with action="EXIT" or "REDUCE" and reason field.
+
+    L2308 PR 4b: per-position decision-capture artifacts are emitted via
+    ``executor.decision_capture.capture_planner_exit`` for every position
+    that reaches the rule-evaluation phase (regardless of whether a rule
+    fired). Skipped positions (missing entry_date, research-already-
+    exiting, no price) are NOT captured — they have no exit-decision
+    semantics to grade.
     """
+    # Local import to avoid circular: decision_capture imports the lib,
+    # exit_manager is imported deep in the planner stack — keep the
+    # capture dependency at call time only.
+    from executor.decision_capture import (
+        DecisionCaptureWriteError,
+        capture_planner_exit,
+        is_decision_capture_enabled,
+    )
+
+    capture_enabled = is_decision_capture_enabled()
+
     strategy_signals = []
 
     for ticker, pos in current_positions.items():
@@ -607,111 +762,62 @@ def evaluate_exits(
 
         history = price_histories.get(ticker)
 
-        # Resolve stance-conditional config view. ``stance`` and
-        # ``catalyst_date`` are denormalized onto the trades row at
-        # ENTER time (trade_logger.py stance/catalyst_date columns,
-        # 2026-05-11). Position-side propagation via
-        # ``get_entry_stance_and_catalyst`` from trade_logger.
-        # Stance overrides cascade per STANCE_EXIT_OVERRIDES: value
-        # widens ATR + extends time decay, quality + catalyst
-        # disable time decay, catalyst adds the hard exit check below.
-        # Legacy positions (no stance) fall through to baseline config.
+        # Resolve stance-conditional config view.
         stance = pos.get("stance")
         catalyst_date = pos.get("catalyst_date")
         stance_config = _resolve_strategy_config_for_stance(
             strategy_config, stance,
         )
 
-        # 0. Catalyst hard exit — catalyst-stance positions exit at
-        # catalyst_date + follow-through days regardless of price.
-        # Runs FIRST so the deadline supersedes other checks (the
-        # thesis is mechanically expired; price-based checks would
-        # otherwise hold the position past its event window).
-        catalyst_exit = check_catalyst_hard_exit(
+        signal, fired_rule_key = _evaluate_single_position(
             ticker=ticker,
+            pos=pos,
+            research_action=research_action,
+            current_price=current_price,
+            history=history,
+            sector_etf_histories=sector_etf_histories,
+            stance_config=stance_config,
             catalyst_date=catalyst_date,
-            run_date=run_date,
-            strategy_config=stance_config,
-        )
-        if catalyst_exit:
-            strategy_signals.append(catalyst_exit)
-            continue
-
-        # 1. ATR trailing stop (with sector-relative veto)
-        atr_signal = check_atr_trailing_stop(
-            ticker=ticker,
-            current_price=current_price,
             entry_date=entry_date,
-            price_history=history,
-            strategy_config=stance_config,
-            feature_lookup=feature_lookup,
             run_date=run_date,
+            feature_lookup=feature_lookup,
         )
-        if atr_signal:
-            # Check sector-relative veto before accepting ATR exit
-            sector = pos.get("sector", "")
-            etf_ticker = SECTOR_ETF_MAP.get(sector, "SPY")
-            etf_history = (
-                sector_etf_histories.get(etf_ticker)
-                if sector_etf_histories
-                else None
-            )
-            if check_sector_relative_veto(
-                ticker, sector, history, etf_history, stance_config
-            ):
-                logger.info(
-                    f"ATR exit for {ticker} vetoed — outperforming sector ({sector})"
+
+        if signal is not None:
+            strategy_signals.append(signal)
+
+        # Emit executor:exit_rules planner-side DecisionArtifact (L2308
+        # PR 4b). Captures BOTH fired and no-fire positions to give
+        # grading the counterfactual coverage (no-fire decisions that
+        # later produced drawdowns are gradable as missed exits).
+        # Best-effort: capture failure must never kill planning flow.
+        if capture_enabled:
+            try:
+                capture_planner_exit(
+                    run_date=run_date,
+                    ticker=ticker,
+                    pos=pos,
+                    research_signal=research_signal,
+                    current_price=current_price,
+                    stance=stance,
+                    catalyst_date=catalyst_date,
+                    stance_config=stance_config,
+                    signal=signal,
+                    fired_rule_key=fired_rule_key,
                 )
-            else:
-                strategy_signals.append(atr_signal)
-                continue  # ATR exit takes priority over other checks
-        elif stance_config.get("fallback_stop_enabled", True):
-            # ATR returned None — try fallback fixed-percentage stop
-            fallback_signal = check_fallback_stop(
-                ticker=ticker,
-                current_price=current_price,
-                entry_price=pos.get("avg_cost"),
-                strategy_config=stance_config,
-            )
-            if fallback_signal:
-                strategy_signals.append(fallback_signal)
-                continue
-
-        # 2. Profit-taking
-        avg_cost = pos.get("avg_cost")
-        profit_signal = check_profit_take(
-            ticker=ticker,
-            current_price=current_price,
-            avg_cost=avg_cost,
-            strategy_config=stance_config,
-        )
-        if profit_signal:
-            strategy_signals.append(profit_signal)
-            continue  # Profit-take fires, skip remaining checks
-
-        # 3. Momentum exit
-        momentum_signal = check_momentum_exit(
-            ticker=ticker,
-            price_history=history,
-            strategy_config=stance_config,
-            feature_lookup=feature_lookup,
-            run_date=run_date,
-        )
-        if momentum_signal:
-            strategy_signals.append(momentum_signal)
-            continue  # Momentum exit fires, skip time decay
-
-        # 4. Time-based decay (quality + catalyst stances disable this
-        # via STANCE_EXIT_OVERRIDES; value extends it to 30 trading days).
-        time_signal = check_time_decay(
-            ticker=ticker,
-            entry_date=entry_date,
-            run_date=run_date,
-            signal_action=research_action,
-            strategy_config=stance_config,
-        )
-        if time_signal:
-            strategy_signals.append(time_signal)
+            except DecisionCaptureWriteError as _cap_exc:
+                logger.warning(
+                    "decision_capture S3 write failed for PLANNER_EXIT %s "
+                    "— continuing planning (capture is observability, not "
+                    "load-bearing): %s",
+                    ticker, _cap_exc,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "decision_capture raised unexpected exception for "
+                    "PLANNER_EXIT %s — continuing planning",
+                    ticker,
+                )
 
     return strategy_signals
 

--- a/tests/test_decision_capture.py
+++ b/tests/test_decision_capture.py
@@ -23,13 +23,16 @@ import pytest
 from executor.decision_capture import (
     DecisionCaptureWriteError,
     _classify_exit_rule_kind,
+    _classify_planner_exit_kind,
     _classify_trigger_kind,
     build_entry_trigger_payload,
     build_exit_rule_payload,
+    build_planner_exit_payload,
     build_position_sizer_payload,
     build_risk_guard_payload,
     capture_entry_trigger,
     capture_exit_rule,
+    capture_planner_exit,
     capture_position_sizer,
     capture_risk_guard,
     is_decision_capture_enabled,
@@ -1197,3 +1200,298 @@ class TestExitRuleCapture:
                 strategy_config=_make_exit_strategy_config(),
                 s3_client=s3,
             )
+
+
+# ── Planner-side exit rules (PR 4b) ──────────────────────────────────────
+
+
+def _make_planner_pos() -> dict:
+    """Held-position fixture matching what main.py builds for evaluate_exits."""
+    return {
+        "shares": 150,
+        "market_value": 26_287.50,
+        "avg_cost": 170.00,
+        "sector": "technology",
+        "entry_date": "2026-05-08",
+        "stance": "momentum",
+        "catalyst_date": None,
+    }
+
+
+def _make_planner_research_signal(action: str = "HOLD") -> dict:
+    return {
+        "signal": action,
+        "score": 78.5,
+        "conviction": "rising",
+    }
+
+
+def _make_planner_stance_config() -> dict:
+    """Stance-resolved strategy config — what _resolve_strategy_config_for_stance
+    returns inside evaluate_exits."""
+    return {
+        "atr_period": 14,
+        "atr_multiple": 2.0,
+        "fallback_stop_enabled": True,
+        "fallback_stop_pct": 0.10,
+        "profit_take_pct": 0.20,
+        "time_decay_enabled": True,
+        "time_decay_days": 21,
+        "momentum_exit_enabled": True,
+        "momentum_exit_threshold": -0.05,
+        "catalyst_follow_through_days": 3,
+    }
+
+
+def _make_planner_signal(action: str = "EXIT", reason: str = "atr_trailing_stop") -> dict:
+    """evaluate_exits' returned signal-dict shape."""
+    return {
+        "ticker": "AAPL",
+        "action": action,
+        "shares": 150,
+        "reason": reason,
+        "detail": "trail stop at $167.50",
+    }
+
+
+class TestPlannerExitKindClassifier:
+    @pytest.mark.parametrize("key,expected", [
+        ("catalyst_hard_exit", "catalyst_hard_exit"),
+        ("atr_trailing_stop", "atr_trail"),
+        ("sector_veto_blocked", "sector_veto_blocked"),
+        ("fallback_stop", "fallback_stop"),
+        ("profit_take", "profit_take"),
+        ("momentum_exit", "momentum_exit"),
+        ("time_decay", "time_decay"),
+        ("unknown_key", "unknown"),
+    ])
+    def test_known_keys(self, key, expected):
+        assert _classify_planner_exit_kind(key) == expected
+
+    def test_none_maps_to_no_fire(self):
+        """None fired_rule_key → 'no_fire' — the counterfactual coverage
+        row for grading."""
+        assert _classify_planner_exit_kind(None) == "no_fire"
+
+
+class TestPlannerExitPayloadShape:
+    def test_snapshot_carries_producer_provenance_and_layer(self):
+        snapshot, _, _ = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+        )
+        assert snapshot["_producer"] == "alpha-engine.executor.exit_rules"
+        # evaluation_layer distinguishes from daemon_intraday — same
+        # agent_id (executor:exit_rules) but different decision layer.
+        assert snapshot["evaluation_layer"] == "planner"
+
+    def test_snapshot_carries_full_position_and_market_state(self):
+        snapshot, _, _ = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(action="HOLD"),
+            current_price=175.25, stance="momentum",
+            catalyst_date="2026-05-20",
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+        )
+        assert snapshot["ticker"] == "AAPL"
+        assert snapshot["entry_date"] == "2026-05-08"
+        assert snapshot["avg_cost"] == 170.00
+        assert snapshot["shares_held"] == 150
+        assert snapshot["market_value"] == 26_287.50
+        assert snapshot["sector"] == "technology"
+        assert snapshot["stance"] == "momentum"
+        assert snapshot["catalyst_date"] == "2026-05-20"
+        assert snapshot["current_price"] == 175.25
+        assert snapshot["research_action"] == "HOLD"
+        assert snapshot["research_score"] == 78.5
+        assert snapshot["research_conviction"] == "rising"
+        # gain_pct = (175.25 - 170) / 170 = 0.030882...
+        assert abs(snapshot["gain_pct"] - 0.030882) < 1e-5
+
+    def test_snapshot_thresholds_carry_resolved_stance_config(self):
+        snapshot, _, _ = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+        )
+        thr = snapshot["thresholds"]
+        # All 10 rule thresholds captured so replay can re-evaluate.
+        assert thr["atr_period"] == 14
+        assert thr["atr_multiple"] == 2.0
+        assert thr["fallback_stop_enabled"] is True
+        assert thr["profit_take_pct"] == 0.20
+        assert thr["time_decay_enabled"] is True
+        assert thr["time_decay_days"] == 21
+        assert thr["momentum_exit_threshold"] == -0.05
+        assert thr["catalyst_follow_through_days"] == 3
+
+    def test_fired_outcome_records_rule_key_and_kind(self):
+        _, output, summary = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=_make_planner_signal(action="EXIT", reason="trail stop"),
+            fired_rule_key="atr_trailing_stop",
+        )
+        assert output["outcome"] == "fired"
+        assert output["action"] == "EXIT"
+        assert output["fired_rule"] == "trail stop"
+        assert output["fired_rule_key"] == "atr_trailing_stop"
+        assert output["fired_rule_kind"] == "atr_trail"
+        assert output["shares_requested"] == 150
+        assert "fired=atr_trailing_stop" in summary
+
+    def test_no_fire_outcome_with_none_key(self):
+        _, output, summary = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+        )
+        assert output["outcome"] == "no_fire"
+        assert output["fired_rule_key"] is None
+        assert output["fired_rule_kind"] == "no_fire"
+        assert output["action"] is None
+        assert "no_fire" in summary
+
+    def test_sector_veto_blocked_carried_as_no_fire_with_specific_kind(self):
+        """When ATR fires but the sector-relative veto suppresses it,
+        the planner returns (None, 'sector_veto_blocked') — the artifact
+        must record this distinct kind separately from a normal no_fire."""
+        _, output, _ = build_planner_exit_payload(
+            ticker="AAPL", pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key="sector_veto_blocked",
+        )
+        assert output["outcome"] == "no_fire"
+        assert output["fired_rule_key"] == "sector_veto_blocked"
+        assert output["fired_rule_kind"] == "sector_veto_blocked"
+
+    def test_zero_avg_cost_safely_nulls_gain_pct(self):
+        pos = _make_planner_pos()
+        pos["avg_cost"] = 0.0
+        snapshot, _, _ = build_planner_exit_payload(
+            ticker="AAPL", pos=pos,
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+        )
+        assert snapshot["gain_pct"] is None
+
+
+class TestPlannerExitCapture:
+    """End-to-end capture path with env-flag + S3 stub."""
+
+    def test_writes_v2_artifact_to_canonical_key(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3_key = capture_planner_exit(
+            run_date="2026-05-15", ticker="AAPL",
+            pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=_make_planner_signal(),
+            fired_rule_key="atr_trailing_stop",
+            s3_client=s3,
+        )
+        s3.put_object.assert_called_once()
+        put_kwargs = s3.put_object.call_args.kwargs
+        # Same agent_id as PR 4 daemon-side captures so grading reads
+        # one S3 prefix; layer field distinguishes producer.
+        assert "/executor:exit_rules/" in put_kwargs["Key"]
+        assert s3_key == put_kwargs["Key"]
+        body = json.loads(put_kwargs["Body"].decode("utf-8"))
+        assert body["schema_version"] == 2
+        assert body["agent_id"] == "executor:exit_rules"
+        assert body["model_metadata"] is None
+        assert body["input_data_snapshot"]["evaluation_layer"] == "planner"
+        assert body["agent_output"]["fired_rule_kind"] == "atr_trail"
+
+    def test_no_fire_captured_as_counterfactual(self, monkeypatch):
+        """Counterfactual coverage: every position that reaches the
+        rule-evaluation phase produces an artifact, including no-fire
+        positions. Grading uses these to measure missed-exit precision."""
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        capture_planner_exit(
+            run_date="2026-05-15", ticker="MSFT",
+            pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=180.00, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+            s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert body["agent_output"]["outcome"] == "no_fire"
+        assert body["agent_output"]["fired_rule_kind"] == "no_fire"
+
+    def test_disabled_when_env_off(self, monkeypatch):
+        monkeypatch.delenv(
+            "ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", raising=False,
+        )
+        s3 = _make_s3_stub()
+        result = capture_planner_exit(
+            run_date="2026-05-15", ticker="AAPL",
+            pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=175.25, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+            s3_client=s3,
+        )
+        assert result is None
+        s3.put_object.assert_not_called()
+
+    def test_s3_failure_propagates_capture_write_error(self, monkeypatch):
+        from botocore.exceptions import ClientError
+
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        s3.put_object.side_effect = ClientError(
+            error_response={
+                "Error": {"Code": "AccessDenied", "Message": "Denied"},
+            },
+            operation_name="PutObject",
+        )
+        with pytest.raises(DecisionCaptureWriteError):
+            capture_planner_exit(
+                run_date="2026-05-15", ticker="AAPL",
+                pos=_make_planner_pos(),
+                research_signal=_make_planner_research_signal(),
+                current_price=175.25, stance="momentum", catalyst_date=None,
+                stance_config=_make_planner_stance_config(),
+                signal=None, fired_rule_key=None,
+                s3_client=s3,
+            )
+
+    def test_run_id_format_pinned(self, monkeypatch):
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        s3 = _make_s3_stub()
+        capture_planner_exit(
+            run_date="2026-05-15", ticker="NVDA",
+            pos=_make_planner_pos(),
+            research_signal=_make_planner_research_signal(),
+            current_price=400.00, stance="momentum", catalyst_date=None,
+            stance_config=_make_planner_stance_config(),
+            signal=None, fired_rule_key=None,
+            s3_client=s3,
+        )
+        body = json.loads(s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        run_id = body["run_id"]
+        assert run_id.startswith("2026-05-15_NVDA_")
+        suffix = run_id.split("_")[-1]
+        assert len(suffix) == 8
+        assert all(c in "0123456789abcdef" for c in suffix)


### PR DESCRIPTION
## Summary

**PR 4b of 6** in the executor decision-capture arc (ROADMAP L2308). Closes the **planner-side** exit-rules capture gap left by PR 4 (which shipped daemon-side intraday only). Per-position \`DecisionArtifact\` lands at the same canonical S3 path as PR 4 — same \`executor:exit_rules\` agent_id — but distinguished via \`evaluation_layer: \"planner\"\` field on the snapshot.

## Why this PR matters

PR 4 captured daemon-side intraday fires (trailing_stop / profit_take / collapse) — observed **only** when a rule actually fired. PR 4b captures planner-side per-position evaluations — **fires AND no-fires** — so grading has counterfactual coverage. No-fire positions that later produced drawdowns are gradable as missed exits; pre-this-PR they were invisible to the artifact stream.

This closes the remaining 25% of gradable exit decisions in the L2308 arc.

## Refactor risk + mitigation

The pre-refactor \`evaluate_exits\` loop body had mid-iteration \`continue\` statements after each rule fire. Putting a single capture-call-per-iteration around it required extracting a per-position helper.

**Risk:** the ATR sector-veto interaction has subtle behavior — pre-refactor, when ATR fires but sector-veto suppresses it, the position falls through to subsequent rule checks (profit_take, momentum_exit, time_decay), NOT into the fallback_stop branch (the \`elif fallback_stop_enabled\` only ran when the original \`check_atr_trailing_stop\` returned None, not after sector veto consumed the signal).

**Mitigation:** preserved via an \`atr_fired_then_vetoed\` local flag in the refactor. Verified by the existing test_exit_manager.py + test_exit_manager_stance.py suites — 96/96 pass with identical assertions.

## Changes

**\`executor/strategies/exit_manager.py\`:**
- Extracted \`_evaluate_single_position(...)\` returning \`(signal_or_None, fired_rule_key_or_None)\`. Identical behavior to the pre-refactor loop body.
- \`evaluate_exits\` now calls the helper, appends signal if non-None, AND emits a planner-side capture artifact per position. Same env-flag + try/except pattern as PRs 1-4.
- Capture wired only for positions that **reach** the rule-evaluation phase. Skipped positions (no entry_date / research-already-exiting / no price) get no artifact.

**\`executor/decision_capture.py\`:**
- New \`_PLANNER_EXIT_RULE_KEY_TO_KIND\` map (7 keys) — overlapping kinds (atr_trail, profit_take) match daemon-side so grading treats layers consistently
- \`_classify_planner_exit_kind(fired_rule_key)\` — None → \`\"no_fire\"\` (counterfactual coverage row), unmapped → \`\"unknown\"\`
- \`build_planner_exit_payload()\` — snapshot mirrors position state + research signal + 10 resolved-stance-config thresholds + market state; agent_output records outcome ∈ {fired, no_fire} + fired_rule_key + canonical fired_rule_kind
- \`capture_planner_exit()\` — same \`executor:exit_rules\` agent_id as PR 4, same run_id convention

## Test plan

- [x] **+21 new tests**:
  - \`TestPlannerExitKindClassifier\` (8 parametrized + 1 none): all 7 canonical keys + unknown fall-through + None → \"no_fire\"
  - \`TestPlannerExitPayloadShape\` (7): producer + layer field; full position + market state; 10 stance-config thresholds; fired_outcome records rule_key + kind; no_fire with None; sector_veto_blocked carried as no_fire with specific kind; zero-avg_cost guard
  - \`TestPlannerExitCapture\` (5): canonical S3 key + v2 body w/ layer field; counterfactual no_fire captured; env-flag disabled no-op; ClientError → \`DecisionCaptureWriteError\`; run_id format pinned
- [x] **Refactor regression check:** test_exit_manager.py + test_exit_manager_stance.py — 96/96 pass with identical assertions to pre-refactor
- [x] Full alpha-engine suite: 643 → 664 (+21 new, all pass)

## Composes with

- **PR 4 alpha-engine #163 (MERGED)** — same agent_id + S3 prefix; \`evaluation_layer\` field on snapshot distinguishes the two producer layers so grading can decompose performance by layer
- **PRs 1-3** (MERGED) — same env-flag activation invariant. Flipping \`ALPHA_ENGINE_DECISION_CAPTURE_ENABLED=true\` in SSM (\`/alpha-engine/ALPHA_ENGINE_DECISION_CAPTURE_ENABLED\`) enables all 5 producer surfaces together
- **PR 5 alpha-engine-backtester #188 (MERGED)** — substrate analytics consumer reads this PR's artifacts under the same \`executor:exit_rules/\` prefix; no consumer change needed (prefix-listing agnostic of layer)

## L2308 arc status after this PR

| PR | Status |
|---|---|
| 0a — lib v0.10.0 | ✅ MERGED |
| 0b — backtester replay cascade | ✅ MERGED |
| 0c — research orchestrator cascade | ✅ MERGED |
| 1 — \`executor:entry_triggers\` | ✅ MERGED |
| 2 — \`executor:position_sizer\` | ✅ MERGED |
| 3 — \`executor:risk_guard\` | ✅ MERGED |
| 4 — \`executor:exit_rules\` (daemon) | ✅ MERGED |
| **4b — \`executor:exit_rules\` (planner)** | 🟡 **THIS PR** |
| 5 — backtester substrate analytics | ✅ MERGED |
| 5b — artifact-joined grading dimensions | ⏸ gated on ≥2 weeks of artifact accumulation |

Producer side is **complete** after this PR merges. The arc moves to observation mode: enable the env flag in SSM, let the Saturday SF accumulate ≥2 weeks of artifacts, then PR 5b layers grading dimensions on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)