### PR TITLE
fix(optimizer-shadow): handle production list-of-dicts universe shape

### DIFF
--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -181,9 +181,7 @@ def _build_universe(
     candidates: set[str] = set()
     candidates.update(predictions_by_ticker.keys())
     candidates.update(current_positions.keys())
-    universe_list = signals_raw.get("universe", [])
-    if isinstance(universe_list, list):
-        candidates.update(universe_list)
+    candidates.update(_extract_universe_tickers(signals_raw.get("universe", [])))
 
     candidates.discard(_SPY)
     candidates.discard(_CASH)
@@ -196,6 +194,28 @@ def _build_universe(
         )
 
     return eligible + [_SPY, _CASH]
+
+
+def _extract_universe_tickers(universe_list: Any) -> list[str]:
+    """Normalize `signals_raw['universe']` to a list of ticker strings.
+
+    Production signals.json emits the universe as a list of per-ticker dicts
+    (`{"ticker": "COST", "signal": "ENTER", "score": 55.3, ...}`); legacy /
+    minimal payloads emit a flat list of ticker strings. Accept both shapes —
+    unknown shapes are skipped silently so the wrapper degrades to a
+    smaller universe rather than failing the whole optimizer call.
+    """
+    if not isinstance(universe_list, list):
+        return []
+    out: list[str] = []
+    for el in universe_list:
+        if isinstance(el, str):
+            out.append(el)
+        elif isinstance(el, dict):
+            t = el.get("ticker")
+            if isinstance(t, str) and t:
+                out.append(t)
+    return out
 
 
 def _has_usable_history(ticker: str, price_histories: dict[str, pd.DataFrame]) -> bool:

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -32,6 +32,7 @@ from executor.optimizer_shadow import (
     _build_universe,
     _build_w_prev,
     _compute_trade_deltas,
+    _extract_universe_tickers,
     run_shadow_optimizer,
 )
 
@@ -103,6 +104,61 @@ def test_happy_path_assembles_inputs_and_writes_to_s3():
     assert latest_call["Key"] == "predictor/optimizer_shadow/latest.json"
     body = json.loads(dated_call["Body"])
     assert body["shadow_status"] == "ok"
+
+
+def test_extract_universe_tickers_accepts_production_dict_shape():
+    """Production signals.json emits `universe` as a list of per-ticker dicts.
+
+    Regression for the 2026-05-12 first-shadow-run failure where the wrapper
+    blindly called `candidates.update(universe_list)` and raised
+    `TypeError: unhashable type: 'dict'` on the live payload shape.
+    """
+    universe = [
+        {"ticker": "COST", "signal": "ENTER", "score": 55.3, "rating": "BUY"},
+        {"ticker": "AAPL", "signal": "HOLD", "score": 70.1},
+    ]
+    assert _extract_universe_tickers(universe) == ["COST", "AAPL"]
+
+
+def test_extract_universe_tickers_accepts_legacy_string_shape():
+    """Legacy / minimal payloads emit a flat list of ticker strings."""
+    assert _extract_universe_tickers(["AAPL", "MSFT"]) == ["AAPL", "MSFT"]
+
+
+def test_extract_universe_tickers_skips_malformed_entries():
+    """Mixed / malformed shapes degrade silently; valid entries still extracted."""
+    universe = [
+        {"ticker": "AAPL"},
+        {"no_ticker_key": "foo"},
+        "MSFT",
+        42,
+        None,
+        {"ticker": ""},
+        {"ticker": None},
+    ]
+    assert _extract_universe_tickers(universe) == ["AAPL", "MSFT"]
+
+
+def test_extract_universe_tickers_handles_non_list_input():
+    assert _extract_universe_tickers(None) == []
+    assert _extract_universe_tickers({"unexpected": "shape"}) == []
+
+
+def test_build_universe_accepts_production_universe_dict_shape():
+    """Full _build_universe call must succeed when signals_raw['universe'] is
+    a list of dicts (the live signals.json shape)."""
+    inputs = _baseline_inputs()
+    inputs["signals_raw"]["universe"] = [
+        {"ticker": "AAPL", "signal": "ENTER", "score": 72.0},
+        {"ticker": "MSFT", "signal": "HOLD", "score": 65.0},
+        {"ticker": "JNJ", "signal": "ENTER", "score": 60.0},
+    ]
+    tickers = _build_universe(
+        inputs["signals_raw"], inputs["predictions_by_ticker"],
+        inputs["current_positions"], inputs["price_histories"],
+    )
+    assert set(tickers[:-2]) == {"AAPL", "MSFT", "JNJ"}
+    assert tickers[-2:] == ["SPY", "CASH"]
 
 
 def test_universe_assembly_filters_tickers_without_history():


### PR DESCRIPTION
## Summary

- First shadow optimizer run (2026-05-12 weekday SF) failed with `TypeError: unhashable type: 'dict'` — caught by the wrapper's broad-except and persisted as a failure sentinel at `s3://alpha-engine-research/predictor/optimizer_shadow/2026-05-12.json`.
- Root cause: `_build_universe` called `candidates.update(signals_raw['universe'])` where the live signals.json emits `universe` as a list of per-ticker dicts (`{\"ticker\": \"COST\", \"signal\": \"ENTER\", ...}`), not a flat list of ticker strings. Test fixture used the latter so the gap was invisible until production hit it.
- Fix: new `_extract_universe_tickers` helper normalizes both shapes and degrades silently on malformed entries.

## Test plan
- [x] `pytest tests/test_optimizer_shadow.py` — 13/13 pass (5 new regression tests)
- [x] `pytest tests/` — full executor suite 669/669 pass
- [ ] Next weekday SF firing writes a real `shadow_status: \"ok\"` log to `s3://alpha-engine-research/predictor/optimizer_shadow/2026-05-13.json` with plausible weights (SPY ∈ [0.70, 0.93]; CASH ≈ 0.03; n_active ∈ [3, 25]); failure modes documented in `~/Development/alpha-engine-docs/private/portfolio-optimizer-260511.md` § \"First shadow log inspection checklist\".

## Composes with

- ROADMAP L2207 — Portfolio-optimizer arc PR 4.5 was explicitly gated on first-shadow-log validation. Once tomorrow's run is clean, PR 4.5 (CLI mode + Saturday SF state) is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)