### PR TITLE
feat(executor): rescale batch_confidence_threshold to new |p_up - 0.5| * 2 units

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -27,7 +27,10 @@ min_score_to_enter: 30           # backstop only — predictor veto is primary g
 # 5 saturated at conf=0.99 — the per-ticker signal looked fine but the batch
 # distribution was degenerate. Default off; opt in only after shadow validation.
 batch_confidence_tightening_enabled: false
-batch_confidence_threshold: 0.65    # if mean batch confidence < this, tighten
+# Confidence semantics post-2026-05-12: |p_up - 0.5| * 2 ∈ [0, 1] (predictor PR #143).
+# Threshold rescaled from 0.65 (old winner-prob units) to 0.30 (new units) via
+# new = (old - 0.5) * 2.
+batch_confidence_threshold: 0.30    # if mean batch confidence < this, tighten
 batch_confidence_min_score_bump: 10 # bump min_score_to_enter by this when triggered
 momentum_gate_enabled: false      # disabled — predictor mean-reversion conflicts with this
 min_conviction_to_enter:         # only these conviction levels allow new entries

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -307,7 +307,10 @@ def _apply_batch_confidence_tightening(
     if not config.get("batch_confidence_tightening_enabled", False):
         return config
 
-    threshold = config.get("batch_confidence_threshold", 0.65)
+    # Confidence semantics post-2026-05-12: |p_up - 0.5| * 2 ∈ [0, 1]
+    # (alpha-engine-predictor PR #143). Prior 0.65 winner-prob threshold
+    # rescales to 0.30 via new = (old - 0.5) * 2.
+    threshold = config.get("batch_confidence_threshold", 0.30)
     bump = config.get("batch_confidence_min_score_bump", 10)
     base_min_score = config.get("min_score_to_enter", 70)
 


### PR DESCRIPTION
## Summary

Atomic with [alpha-engine-predictor PR #143](https://github.com/cipher813/alpha-engine-predictor/pull/143) (FLAT direction class collapse + confidence semantics flip).

The \`prediction_confidence\` field flowing in via \`predictions.json\` now spans \`[0, 1]\` anchored at coin-flip rather than \`[0.5, 1.0]\` anchored at winner-class probability. The executor's batch-tightening threshold default rescaled \`0.65 → 0.30\` via \`new = (old - 0.5) * 2\`.

## Why two small changes, not a bigger PR

- **\`batch_confidence_threshold\`** — flag is OFF by default in live risk.yaml, so this is future-proofing. A stale 0.65 in new units would never fire (mean batch confidence in new units is typically ~0.2-0.4) and silently disable the tightening if the flag were flipped on later.
- **\`confidence_sizing_min: 0.70\` / \`confidence_sizing_range: 0.60\`** intentionally NOT rescaled. Under new semantics, low-confidence preds now get \`adj=0.70\` (was \`1.00\` under old coin-flip-as-0.5), which is the **correct direction** (low conviction → smaller position). No behavioral inversion; the wider input range naturally produces wider sizing differentiation, which is what we want.
- **\`gbm_veto\` boolean** — set by predictor side, the executor just reads. Predictor PR #143 rescaled the threshold there.

## Composes with

- alpha-engine-predictor PR #143 — confidence formula + dead 3-class cleanup
- alpha-engine-config PR #138 — live \`predictor.yaml\` + \`executor/risk.yaml\` rescale (same change in live config)

## Test plan

- [x] Full executor suite 664 passing
- [ ] Wed 2026-05-13 morning brief: verify \`prediction_confidence\` distribution shifted (median ~0.20-0.40, was ~0.65-0.80). EOD email's per-position prediction-confidence cell should reflect new units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)