### PR TITLE
feat(secrets): migrate to alpha_engine_lib.secrets.get_secret() — PR 6 of arc

### DIFF
--- a/executor/eod_emailer.py
+++ b/executor/eod_emailer.py
@@ -26,6 +26,8 @@ from email.mime.text import MIMEText
 import boto3
 from botocore.exceptions import ClientError
 
+from alpha_engine_lib.secrets import get_secret
+
 _GMAIL_SMTP_HOST = "smtp.gmail.com"
 _GMAIL_SMTP_PORT = 587
 
@@ -444,7 +446,7 @@ def send_eod_email(
         except Exception as e:
             logger.warning("EOD email archival failed (non-fatal): %s", e)
 
-    app_password = os.environ.get("GMAIL_APP_PASSWORD", "").replace(" ", "")
+    app_password = (get_secret("GMAIL_APP_PASSWORD", required=False, default="") or "").replace(" ", "")
 
     if app_password:
         # Gmail SMTP — email originates from Gmail's servers, passes SPF/DKIM

--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -15,9 +15,10 @@ Setup (one-time):
 from __future__ import annotations
 
 import logging
-import os
 
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +71,8 @@ def send_trade_alert(
 
     Returns True if sent successfully, False otherwise.
     """
-    token = os.getenv("TELEGRAM_BOT_TOKEN")
-    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    token = get_secret("TELEGRAM_BOT_TOKEN", required=False)
+    chat_id = get_secret("TELEGRAM_CHAT_ID", required=False)
     if not token or not chat_id:
         logger.debug("Telegram not configured — skipping notification")
         return False
@@ -94,8 +95,8 @@ def send_trade_alert(
 
 def send_daemon_status(message: str) -> bool:
     """Send a general status message (daemon start/stop, errors)."""
-    token = os.getenv("TELEGRAM_BOT_TOKEN")
-    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    token = get_secret("TELEGRAM_BOT_TOKEN", required=False)
+    chat_id = get_secret("TELEGRAM_CHAT_ID", required=False)
     if not token or not chat_id:
         logger.warning("Telegram not configured — TELEGRAM_BOT_TOKEN=%s TELEGRAM_CHAT_ID=%s", "set" if token else "MISSING", "set" if chat_id else "MISSING")
         return False

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -23,13 +23,14 @@ Usage:
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections import deque
 from datetime import date, datetime, timedelta
 
 import pandas as pd
 import requests
+
+from alpha_engine_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class PolygonClient:
     """Rate-limited polygon.io REST client with dividend adjustment."""
 
     def __init__(self, api_key: str | None = None, calls_per_min: int = 5):
-        self._api_key = api_key or os.environ.get("POLYGON_API_KEY", "")
+        self._api_key = api_key or get_secret("POLYGON_API_KEY", required=False, default="")
         if not self._api_key:
             raise ValueError("POLYGON_API_KEY not set")
         self._calls_per_min = calls_per_min

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ requests~=2.32
 # model_metadata + full_prompt_context, enabling deterministic executor
 # decision capture (L2308 — executor:entry_triggers / position_sizer /
 # risk_guard / exit_rules artifacts emitted from daemon + planner).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.10.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.12.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,32 @@
-"""Add project root to sys.path so executor.* imports work."""
+"""Test fixtures + sys.path setup.
+
+Pins ``ALPHA_ENGINE_SECRETS_SOURCE=env`` for the test process so
+``alpha_engine_lib.secrets.get_secret()`` (post 2026-05-12 .env→SSM
+migration, PR 6 of the arc) reads from monkeypatched env vars only —
+never the real SSM Parameter Store.
+"""
 import sys
 import os
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+os.environ.setdefault("ALPHA_ENGINE_SECRETS_SOURCE", "env")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_secrets_from_ssm(monkeypatch):
+    """Re-pin ``ALPHA_ENGINE_SECRETS_SOURCE=env`` per test + clear the
+    per-process secret cache. See
+    ``alpha-engine-docs/private/env-to-ssm-260512.md`` § Risks.
+    """
+    monkeypatch.setenv("ALPHA_ENGINE_SECRETS_SOURCE", "env")
+    try:
+        from alpha_engine_lib.secrets import clear_cache
+    except ImportError:
+        yield
+        return
+    clear_cache()
+    yield
+    clear_cache()

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -299,7 +299,9 @@ class TestNotifier:
         assert _send_telegram("token", "123", "hello") is False
 
     def test_send_trade_alert_no_config(self):
-        with patch.dict("os.environ", {}, clear=True):
+        # Preserve ALPHA_ENGINE_SECRETS_SOURCE=env from conftest so get_secret()
+        # reads from this (cleared) env-dict instead of falling through to SSM.
+        with patch.dict("os.environ", {"ALPHA_ENGINE_SECRETS_SOURCE": "env"}, clear=True):
             assert send_trade_alert("BUY", "AAPL", 10, 150.0) is False
 
     @patch("executor.notifier._send_telegram", return_value=True)
@@ -309,7 +311,9 @@ class TestNotifier:
             mock_send.assert_called_once()
 
     def test_send_daemon_status_no_config(self):
-        with patch.dict("os.environ", {}, clear=True):
+        # Preserve ALPHA_ENGINE_SECRETS_SOURCE=env from conftest so get_secret()
+        # reads from this (cleared) env-dict instead of falling through to SSM.
+        with patch.dict("os.environ", {"ALPHA_ENGINE_SECRETS_SOURCE": "env"}, clear=True):
             assert send_daemon_status("test") is False
 
     @patch("executor.notifier._send_telegram", return_value=True)

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -1,0 +1,65 @@
+"""Regression: no module in this repo reads a secret via ``os.environ.get``
+or ``os.getenv``.
+
+After the 2026-05-12 ``.env`` → SSM migration (PR 6 of the arc), every
+secret-bearing call site routes through ``alpha_engine_lib.secrets.get_secret()``.
+This test re-greps the codebase on every CI run so a future commit can't
+silently re-introduce a secret read via ``os.environ``.
+
+Non-secret env vars are allowed for now — they migrate to alpha-engine-config
+YAML in PR 8 of the arc.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_PINNED_SECRETS = frozenset(
+    [
+        "ANTHROPIC_API_KEY",
+        "LANGCHAIN_API_KEY",
+        "LANGSMITH_API_KEY",
+        "VOYAGE_API_KEY",
+        "POLYGON_API_KEY",
+        "FMP_API_KEY",
+        "FINNHUB_API_KEY",
+        "FRED_API_KEY",
+        "GMAIL_APP_PASSWORD",
+        "GITHUB_TOKEN",
+        "RAG_DATABASE_URL",
+        "EDGAR_IDENTITY",
+        "TELEGRAM_BOT_TOKEN",
+        "TELEGRAM_CHAT_ID",
+    ]
+)
+
+_ENV_READ_RE = re.compile(
+    r'os\.(?:environ\.get|getenv)\(\s*["\']([A-Z_][A-Z0-9_]*)["\']'
+)
+
+
+def _iter_python_files():
+    for path in _REPO_ROOT.rglob("*.py"):
+        parts = set(path.parts)
+        if parts & {".venv", "trading-env", "build", "tests", "node_modules", "package"}:
+            continue
+        yield path
+
+
+def test_no_secret_environ_reads():
+    violations: list[tuple[Path, int, str]] = []
+    for path in _iter_python_files():
+        text = path.read_text()
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for match in _ENV_READ_RE.finditer(line):
+                name = match.group(1)
+                if name in _PINNED_SECRETS:
+                    violations.append((path.relative_to(_REPO_ROOT), lineno, name))
+    assert not violations, (
+        "Found os.environ.get / os.getenv reads of pinned secrets — use "
+        "`from alpha_engine_lib.secrets import get_secret` instead:\n"
+        + "\n".join(f"  {p}:{ln}  {name}" for p, ln, name in violations)
+    )


### PR DESCRIPTION
## Summary
- Replaces 4 secret call sites across 3 modules with `get_secret()`.
- Bumps lib pin v0.10.0 → v0.12.0.
- Migrated secrets: `POLYGON_API_KEY` (polygon_client), `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` (notifier × 2 each), `GMAIL_APP_PASSWORD` (eod_emailer).
- Notifier was using `os.getenv()` instead of `os.environ.get()` — both match the regression-test regex.
- Conftest + autouse fixture + regression test added.
- Two existing tests fixed (`patch.dict(clear=True)` was wiping `ALPHA_ENGINE_SECRETS_SOURCE` too).

## Why
PR 6 of 9 in the `.env`-deprecation arc — closes ROADMAP P1 line ~2780. Plan doc: `alpha-engine-docs/private/env-to-ssm-260512.md`.

EC2-only deploy (no Lambda, no Dockerfile per CLAUDE.md) — `boot-pull.service` picks up the new lib pin automatically on next trading-instance boot. No deploy-artifact lockstep concern here.

## Test plan
- [x] Suite 670/670 passing (was 670 — 2 fails recovered)
- [x] `test_no_secret_environ_reads` confirms zero secret reads via `os.environ` / `os.getenv`
- [ ] **Next weekday SF (Tue 2026-05-13)** — `RunDaemon` + `RunMorningPlanner` SSM steps exercise POLYGON + TELEGRAM + GMAIL paths

## Out of scope
- Non-secret env migration (`AWS_REGION`, `LANGCHAIN_PROJECT` if any) → PR 8
- Dashboard repo → PR 7
- `.env` deletion → PR 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)