### PR TITLE
Fix executor import in replay_shadow_optimizer.py

### DIFF
--- a/scripts/replay_shadow_optimizer.py
+++ b/scripts/replay_shadow_optimizer.py
@@ -24,7 +24,12 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import sys
 from datetime import date, datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 
 import boto3
 import yaml


### PR DESCRIPTION
## Summary
- Follow-up to #168 — running `python scripts/replay_shadow_optimizer.py` from the repo root failed with `ModuleNotFoundError: No module named 'executor'` because `scripts/` isn't on `sys.path` by default
- Mirrors the `REPO_ROOT = Path(__file__).resolve().parent.parent; sys.path.insert(0, str(REPO_ROOT))` bootstrap used by sibling `scripts/backfill_*.py`

## Test plan
- [ ] `ae-trading "cd ~/alpha-engine && git pull && source .venv/bin/activate && python scripts/replay_shadow_optimizer.py"` reaches IB Gateway connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)