### PR TITLE
feat(universe): signal_reader delegates Layer 2 filter to alpha_engine_lib (v0.13.0)

### DIFF
--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -11,6 +11,8 @@ from datetime import date, timedelta
 import boto3
 from botocore.exceptions import ClientError
 
+from alpha_engine_lib.universe import filter_to_universe
+
 logger = logging.getLogger(__name__)
 
 
@@ -201,7 +203,7 @@ def filter_buy_candidates_to_universe(
         # executor.market_hours which touches signal_reader indirectly).
         from executor.price_cache import _open_universe_library
         universe_lib = _open_universe_library(signals_bucket)
-        universe_symbols = set(universe_lib.list_symbols())
+        universe_symbols = frozenset(universe_lib.list_symbols())
     except Exception as exc:  # noqa: BLE001 — see docstring
         logger.warning(
             "Skipping buy-candidate universe filter — could not open ArcticDB "
@@ -211,16 +213,17 @@ def filter_buy_candidates_to_universe(
         )
         return signals
 
-    allowed: list[dict] = []
-    dropped: list[str] = []
-    for entry in buy:
-        ticker = entry.get("ticker") if isinstance(entry, dict) else None
-        if ticker and ticker in universe_symbols:
-            allowed.append(entry)
-        elif ticker:
-            dropped.append(ticker)
+    # Membership predicate is delegated to ``alpha_engine_lib.universe`` so
+    # this Layer 2 filter and research's Layer 1 ``population_selector`` filter
+    # share one canonical code path (no silent divergence on universe drift —
+    # see lib v0.13.0 docstring).
+    allowed, dropped_entries = filter_to_universe(buy, universe_symbols)
+    dropped_tickers = [
+        entry["ticker"] for entry in dropped_entries
+        if isinstance(entry, dict) and isinstance(entry.get("ticker"), str)
+    ]
 
-    if dropped:
+    if dropped_tickers:
         logger.warning(
             "[signal_reader] dropped %d buy_candidate(s) not in ArcticDB "
             "universe: %s. Research's population_selector (alpha-engine-"
@@ -228,8 +231,8 @@ def filter_buy_candidates_to_universe(
             "reached here means one of: (a) Research bug, (b) manual edit "
             "to signals.json, (c) universe-library drift window. Not hard-"
             "failing because the remaining %d buy_candidate(s) are valid.",
-            len(dropped),
-            dropped,
+            len(dropped_tickers),
+            dropped_tickers,
             len(allowed),
         )
         signals = dict(signals)  # shallow copy to avoid mutating caller's dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ requests~=2.32
 # model_metadata + full_prompt_context, enabling deterministic executor
 # decision capture (L2308 — executor:entry_triggers / position_sizer /
 # risk_guard / exit_rules artifacts emitted from daemon + planner).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.12.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.13.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
## Summary

Closes the consumer half of ROADMAP L2853 for Layer 2 (executor-side buy-candidate universe filter). Membership predicate moves from inline manual partition loop to a single `filter_to_universe(buy, universe_symbols)` call from `alpha_engine_lib.universe` (v0.13.0).

Drop semantics (WARNING log with dropped-ticker list + len(allowed) callout, shallow-copy mutation of the signals dict, ArcticDB-open-failure soft-skip) all stay at the call site — the lib is IO-agnostic and behavior-agnostic.

Same predicate is now shared with alpha-engine-research's Layer 1 (`population_selector`). Silent divergence on universe drift becomes impossible by construction.

## Pin bump

- `alpha-engine-lib` @v0.12.0 → @v0.13.0 — `requirements.txt` only (executor doesn't have a Lambda Dockerfile lockstep gate; it deploys via boot-pull on EC2).

## Test plan

- [x] Existing universe-filter tests (`tests/test_signal_reader_universe_filter.py` — 8 cases): ArcticDB-fail soft-skip, no-dropped clean path, partial drop, all-dropped, empty-buy short-circuit, single ticker, no-mutation invariant. All pass against the delegated path.
- [x] Full executor suite: **684 passed**.
- [x] Behavior preserved: same WARNING log line, same dropped-ticker list shape, same shallow-copy mutation pattern, same return-shape contract.

## Related

- alpha-engine-lib PR #44 (v0.13.0 substrate) — MERGED
- alpha-engine-research PR #164 (Layer 1 delegation) — open

🤖 Generated with [Claude Code](https://claude.com/claude-code)