### PR TITLE
test: cover 5 low-coverage modules (closes ROADMAP L2578 executor → all repos ≥80%)

### DIFF
--- a/tests/test_bracket_orders.py
+++ b/tests/test_bracket_orders.py
@@ -1,0 +1,239 @@
+"""Tests for executor.bracket_orders.place_bracket_with_stop — market BUY + trailing stop."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor.bracket_orders import place_bracket_with_stop
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+class _FakeOrderStatus:
+    def __init__(self, status):
+        self.status = status
+
+
+class _FakeExecution:
+    def __init__(self, shares, price, time=None):
+        self.shares = shares
+        self.price = price
+        self.time = time
+
+
+class _FakeFill:
+    def __init__(self, shares, price, time=None):
+        self.execution = _FakeExecution(shares, price, time)
+
+
+def _make_ib(buy_status="Filled", fills=None, stop_status="Submitted"):
+    """Build a MagicMock IB that returns deterministic trade results.
+
+    - placeOrder returns a fake trade with .orderStatus.status + .fills
+    - ib.sleep is a no-op
+    - ib.client.getReqId increments
+    """
+    ib = MagicMock()
+    counter = {"id": 1000}
+
+    def get_req_id():
+        counter["id"] += 1
+        return counter["id"]
+
+    ib.client.getReqId.side_effect = get_req_id
+
+    trades_returned = []
+
+    def place_order(contract, order):
+        trade = MagicMock()
+        if "TRAIL" in getattr(order, "orderType", ""):
+            trade.orderStatus = _FakeOrderStatus(stop_status)
+            trade.fills = []
+        else:
+            trade.orderStatus = _FakeOrderStatus(buy_status)
+            trade.fills = fills or []
+        trades_returned.append(trade)
+        return trade
+
+    ib.placeOrder.side_effect = place_order
+    ib.placeOrder.trades = trades_returned  # for test introspection
+    ib.sleep = MagicMock()
+    return ib
+
+
+def _ib_client(ib, qualify_raises=False):
+    client = MagicMock()
+    client.ib = ib
+    client.ensure_connected = MagicMock()
+    if qualify_raises:
+        ib.qualifyContracts.side_effect = RuntimeError("contract not found")
+    return client
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+
+def test_bracket_with_stop_filled_places_trailing_stop():
+    fill_time = datetime(2026, 4, 15, 14, 30, 0)
+    ib = _make_ib(
+        buy_status="Filled",
+        fills=[_FakeFill(50, 100.50, fill_time), _FakeFill(50, 100.60, fill_time)],
+    )
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=100,
+        atr_value=2.50, atr_multiple=2.0, timeout_seconds=10,
+    )
+
+    assert result["status"] == "Filled"
+    assert result["filled_shares"] == 100
+    assert result["fill_price"] == pytest.approx(100.55, abs=0.001)
+    assert result["trail_amount"] == 5.00
+    assert result["stop_order_id"] is not None
+    assert result["ib_order_id"] is not None
+    # Both BUY and trailing stop placed (2 placeOrder calls)
+    assert ib.placeOrder.call_count == 2
+
+
+def test_bracket_zero_trail_falls_back_to_market_order():
+    ib = _make_ib()
+    client = _ib_client(ib)
+    client.place_market_order = MagicMock(return_value={
+        "ib_order_id": 99,
+        "status": "Filled",
+        "fill_price": 100.0,
+        "filled_shares": 50,
+        "fill_time": "2026-04-15T14:30:00",
+    })
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=50,
+        atr_value=0.0, atr_multiple=2.0,
+    )
+
+    assert result["stop_order_id"] is None
+    assert result["trail_amount"] is None
+    assert result["status"] == "Filled"
+    client.place_market_order.assert_called_once_with("AAPL", "BUY", 50, 30.0)
+
+
+def test_bracket_qualify_failure_returns_rejected():
+    ib = _make_ib()
+    client = _ib_client(ib, qualify_raises=True)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="XYZ", quantity=100,
+        atr_value=1.0,
+    )
+
+    assert result["status"] == "Rejected"
+    assert result["ib_order_id"] is None
+    assert result["stop_order_id"] is None
+    assert result["fill_price"] is None
+
+
+def test_bracket_cancelled_status_normalized_to_rejected():
+    ib = _make_ib(buy_status="Cancelled", fills=[])
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=100,
+        atr_value=2.0,
+    )
+
+    assert result["status"] == "Rejected"
+    # No stop placed on rejected BUY
+    assert result["stop_order_id"] is None
+    assert ib.placeOrder.call_count == 1
+
+
+def test_bracket_partial_fill_returned_as_partial():
+    """Filled-shares < quantity AND non-terminal status → PartialFill normalization."""
+    ib = MagicMock()
+    counter = {"id": 1000}
+    ib.client.getReqId.side_effect = lambda: counter.update(id=counter["id"] + 1) or counter["id"]
+    fill_time = datetime(2026, 4, 15, 14, 30, 0)
+
+    # Build a trade that says PartiallyFilled but with only 50/100 shares
+    partial_trade = MagicMock()
+    partial_trade.orderStatus = _FakeOrderStatus("PartiallyFilled")
+    partial_trade.fills = [_FakeFill(50, 100.0, fill_time)]
+    ib.placeOrder.return_value = partial_trade
+    ib.sleep = MagicMock()
+
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=100,
+        atr_value=2.0, timeout_seconds=1.5,
+    )
+
+    assert result["status"] == "PartialFill"
+    assert result["filled_shares"] == 50
+    # No stop placed on partial — only "Filled" branch places stop
+    assert result["stop_order_id"] is None
+
+
+def test_bracket_timeout_returns_timeout_status():
+    """Status remains non-terminal (e.g. 'Submitted') after timeout → 'Timeout'."""
+    ib = MagicMock()
+    counter = {"id": 1000}
+    ib.client.getReqId.side_effect = lambda: counter.update(id=counter["id"] + 1) or counter["id"]
+
+    pending_trade = MagicMock()
+    pending_trade.orderStatus = _FakeOrderStatus("Submitted")
+    pending_trade.fills = []
+    ib.placeOrder.return_value = pending_trade
+    ib.sleep = MagicMock()
+
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=100,
+        atr_value=2.0, timeout_seconds=2.0,
+    )
+
+    assert result["status"] == "Timeout"
+    assert result["filled_shares"] is None
+    assert result["stop_order_id"] is None
+
+
+def test_bracket_fill_price_rounded_to_4dp():
+    fill_time = datetime(2026, 4, 15, 14, 30, 0)
+    ib = _make_ib(
+        buy_status="Filled",
+        fills=[_FakeFill(1, 100.123456789, fill_time)],
+    )
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=1,
+        atr_value=1.0, atr_multiple=2.0,
+    )
+
+    assert result["fill_price"] == 100.1235  # rounded to 4dp
+    assert result["filled_shares"] == 1
+    assert result["trail_amount"] == 2.00
+
+
+def test_bracket_no_fills_when_status_filled_has_zero_total_qty():
+    """If fills list has zero total_qty, fill_price stays None."""
+    fill_time = datetime(2026, 4, 15, 14, 30, 0)
+    ib = _make_ib(
+        buy_status="Filled",
+        fills=[_FakeFill(0, 100.0, fill_time)],  # 0 shares
+    )
+    client = _ib_client(ib)
+
+    result = place_bracket_with_stop(
+        ib_client=client, ticker="AAPL", quantity=100,
+        atr_value=1.0,
+    )
+
+    assert result["fill_price"] is None
+    # filled_shares = int(0) = 0 → falsy → no stop placed
+    assert result["stop_order_id"] is None

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,59 @@
+"""Tests for executor.config_loader — risk.yaml resolution with no silent fallback."""
+
+import os
+
+import pytest
+import yaml
+
+from executor import config_loader
+
+
+def test_get_config_path_returns_first_match(tmp_path, monkeypatch):
+    candidate = tmp_path / "risk.yaml"
+    candidate.write_text("foo: bar\n")
+    monkeypatch.setattr(config_loader, "_SEARCH_PATHS", [str(candidate)])
+
+    resolved = config_loader.get_config_path()
+    assert os.path.realpath(str(candidate)) == resolved
+
+
+def test_get_config_path_picks_first_existing(tmp_path, monkeypatch):
+    missing = tmp_path / "nope.yaml"
+    real = tmp_path / "real.yaml"
+    real.write_text("foo: bar\n")
+    monkeypatch.setattr(config_loader, "_SEARCH_PATHS", [str(missing), str(real)])
+
+    resolved = config_loader.get_config_path()
+    assert resolved == os.path.realpath(str(real))
+
+
+def test_get_config_path_raises_when_none_exist(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_loader, "_SEARCH_PATHS", [
+        str(tmp_path / "a.yaml"),
+        str(tmp_path / "b.yaml"),
+    ])
+    with pytest.raises(FileNotFoundError) as exc:
+        config_loader.get_config_path()
+
+    msg = str(exc.value)
+    assert "risk.yaml not found" in msg
+    assert "a.yaml" in msg
+    assert "b.yaml" in msg
+    # Example template MUST NOT be searched silently
+    assert ".example template is intentionally NOT searched" in msg
+
+
+def test_load_config_returns_parsed_yaml(tmp_path, monkeypatch):
+    cfg = tmp_path / "risk.yaml"
+    cfg.write_text(yaml.safe_dump({"signals_bucket": "real-bucket", "max_position_pct": 0.05}))
+    monkeypatch.setattr(config_loader, "_SEARCH_PATHS", [str(cfg)])
+
+    loaded = config_loader.load_config()
+    assert loaded["signals_bucket"] == "real-bucket"
+    assert loaded["max_position_pct"] == 0.05
+
+
+def test_load_config_raises_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(config_loader, "_SEARCH_PATHS", [str(tmp_path / "nope.yaml")])
+    with pytest.raises(FileNotFoundError):
+        config_loader.load_config()

--- a/tests/test_emergency_shutdown.py
+++ b/tests/test_emergency_shutdown.py
@@ -1,0 +1,280 @@
+"""Tests for executor.emergency_shutdown — paper-account-only halt + liquidate + notify."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor import emergency_shutdown as mod
+
+
+def _mock_client(account="DUH123456", nav=100_000.0, positions=None, orders=None):
+    client = MagicMock()
+    client.ib.managedAccounts.return_value = [account]
+    client.get_portfolio_nav.return_value = nav
+    client.get_positions.return_value = positions or {}
+    client.get_open_orders.return_value = orders or []
+    client.cancel_all_orders = MagicMock()
+    client.get_current_price.return_value = 100.0
+    client.place_market_order.return_value = {
+        "ib_order_id": 1, "status": "Filled", "fill_price": 99.5,
+        "filled_shares": 10, "fill_time": "2026-04-15T14:30:00",
+    }
+    client.disconnect = MagicMock()
+    return client
+
+
+@pytest.fixture
+def stub_config(monkeypatch):
+    cfg = {
+        "ib_host": "127.0.0.1",
+        "ib_port": 4002,
+        "db_path": "/tmp/test-trades.db",
+        "signals_bucket": "test-bucket",
+    }
+    monkeypatch.setattr(mod, "_load_config", lambda: cfg)
+    return cfg
+
+
+@pytest.fixture
+def stub_db(monkeypatch):
+    fake_conn = MagicMock()
+    monkeypatch.setattr(mod, "init_db", MagicMock(return_value=fake_conn))
+    monkeypatch.setattr(mod, "log_trade", MagicMock())
+    monkeypatch.setattr(mod, "backup_to_s3", MagicMock())
+    return fake_conn
+
+
+# ── Dry-run path (execute=False) ────────────────────────────────────────────
+
+
+def test_dry_run_reports_state_and_takes_no_action(stub_config, stub_db, monkeypatch, caplog):
+    client = _mock_client(positions={"AAPL": {"shares": 10, "market_value": 1500.0}})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+
+    with caplog.at_level("INFO"):
+        mod.emergency_shutdown(execute=False, stop_instance=False)
+
+    assert any("DRY RUN" in r.message for r in caplog.records)
+    client.cancel_all_orders.assert_not_called()
+    client.place_market_order.assert_not_called()
+    client.disconnect.assert_called_once()
+
+
+# ── Live account safety hard-exit ───────────────────────────────────────────
+
+
+def test_live_account_triggers_sys_exit_99(stub_config, monkeypatch):
+    """Account ID not starting with 'D' must hard-exit BEFORE any orders fire."""
+    client = _mock_client(account="U999999")  # 'U' = live IB account prefix
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+
+    with pytest.raises(SystemExit) as exc:
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+
+    assert exc.value.code == 99
+    client.disconnect.assert_called_once()
+    # No orders placed even though execute=True
+    client.place_market_order.assert_not_called()
+
+
+def test_account_verification_failure_continues_with_warning(stub_config, stub_db, monkeypatch, caplog):
+    """If managedAccounts() raises, log warning but continue (don't exit 99)."""
+    client = _mock_client()
+    client.ib.managedAccounts.side_effect = RuntimeError("connection lost")
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+
+    with caplog.at_level("WARNING"):
+        mod.emergency_shutdown(execute=False, stop_instance=False)
+
+    assert any("Could not verify account type" in r.message for r in caplog.records)
+
+
+# ── Execute path ────────────────────────────────────────────────────────────
+
+
+def test_execute_cancels_orders_and_sells_positions(stub_config, stub_db, monkeypatch):
+    positions = {
+        "AAPL": {"shares": 10, "market_value": 1500.0},
+        "MSFT": {"shares": 20, "market_value": 4000.0},
+        "ZERO": {"shares": 0, "market_value": 0.0},  # skipped: shares<=0
+    }
+    client = _mock_client(positions=positions)
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", MagicMock())
+
+    mod.emergency_shutdown(execute=True, stop_instance=False)
+
+    client.cancel_all_orders.assert_called_once()
+    # ZERO position skipped; AAPL and MSFT placed
+    assert client.place_market_order.call_count == 2
+    tickers_sold = {c.args[0] for c in client.place_market_order.call_args_list}
+    assert tickers_sold == {"AAPL", "MSFT"}
+    mod.log_trade.assert_called()  # type: ignore[attr-defined]
+    mod.backup_to_s3.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_execute_continues_when_cancel_orders_fails(stub_config, stub_db, monkeypatch, caplog):
+    """Order-cancel failure must NOT abort liquidation — that's the whole point."""
+    client = _mock_client(positions={"AAPL": {"shares": 10}})
+    client.cancel_all_orders.side_effect = RuntimeError("IB connection lost")
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", MagicMock())
+
+    with caplog.at_level("ERROR"):
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+
+    # Liquidation still ran
+    client.place_market_order.assert_called_once()
+
+
+def test_execute_per_position_sell_failure_logged_but_others_continue(stub_config, stub_db, monkeypatch, caplog):
+    positions = {
+        "AAPL": {"shares": 10, "market_value": 1500.0},
+        "BAD": {"shares": 5, "market_value": 500.0},
+        "MSFT": {"shares": 20, "market_value": 4000.0},
+    }
+    client = _mock_client(positions=positions)
+
+    def sell(ticker, side, shares, *_):
+        if ticker == "BAD":
+            raise RuntimeError("simulated sell failure")
+        return {"ib_order_id": 1, "status": "Filled", "fill_price": 100.0,
+                "filled_shares": shares, "fill_time": "2026-04-15"}
+
+    client.place_market_order.side_effect = sell
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", MagicMock())
+
+    with caplog.at_level("ERROR"):
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+
+    # All 3 attempted; BAD failed; AAPL + MSFT succeeded
+    assert client.place_market_order.call_count == 3
+    assert any("SELL FAILED" in r.message for r in caplog.records)
+
+
+def test_execute_daemon_stop_failure_swallowed(stub_config, stub_db, monkeypatch, caplog):
+    client = _mock_client(positions={})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    sub = MagicMock()
+    sub.run.side_effect = RuntimeError("daemon already stopped")
+    monkeypatch.setattr(mod, "subprocess", sub)
+    monkeypatch.setitem(sys.modules, "boto3", MagicMock())
+
+    with caplog.at_level("WARNING"):
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+    assert any("Daemon stop failed" in r.message for r in caplog.records)
+
+
+def test_main_dry_run_invokes_emergency_shutdown(monkeypatch):
+    """`main()` parses args and dispatches with execute=False by default."""
+    called_with = {}
+
+    def fake_es(execute, stop_instance):
+        called_with["execute"] = execute
+        called_with["stop_instance"] = stop_instance
+
+    monkeypatch.setattr(mod, "emergency_shutdown", fake_es)
+    monkeypatch.setattr(sys, "argv", ["emergency_shutdown.py"])
+
+    mod.main()
+
+    assert called_with == {"execute": False, "stop_instance": False}
+
+
+def test_main_execute_flag_logs_warning_and_dispatches(monkeypatch, caplog):
+    captured = {}
+
+    def fake_es(execute, stop_instance):
+        captured["execute"] = execute
+        captured["stop_instance"] = stop_instance
+
+    monkeypatch.setattr(mod, "emergency_shutdown", fake_es)
+    monkeypatch.setattr(sys, "argv", ["emergency_shutdown.py", "--execute", "--stop-instance"])
+
+    with caplog.at_level("WARNING"):
+        mod.main()
+
+    assert captured == {"execute": True, "stop_instance": True}
+    assert any("EMERGENCY SHUTDOWN — EXECUTING" in r.message for r in caplog.records)
+
+
+def test_execute_notification_failure_swallowed(stub_config, stub_db, monkeypatch, caplog):
+    """SNS publish failure must NOT crash the shutdown — log warning, continue."""
+    client = _mock_client(positions={})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+
+    fake_sns = MagicMock()
+    fake_sns.publish.side_effect = RuntimeError("SNS down")
+    fake_boto3 = MagicMock()
+    fake_boto3.client = MagicMock(side_effect=lambda svc, **kw:
+                                  fake_sns if svc == "sns" else MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    with caplog.at_level("WARNING"):
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+
+    assert any("Notification failed" in r.message for r in caplog.records)
+
+
+def test_execute_backup_failure_swallowed(stub_config, monkeypatch, caplog):
+    client = _mock_client(positions={})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", MagicMock())
+
+    fake_conn = MagicMock()
+    monkeypatch.setattr(mod, "init_db", MagicMock(return_value=fake_conn))
+    monkeypatch.setattr(mod, "log_trade", MagicMock())
+    monkeypatch.setattr(mod, "backup_to_s3", MagicMock(side_effect=RuntimeError("S3 down")))
+
+    with caplog.at_level("ERROR"):
+        mod.emergency_shutdown(execute=True, stop_instance=False)
+    assert any("Backup failed" in r.message for r in caplog.records)
+
+
+def test_execute_stop_instance_failure_swallowed(stub_config, stub_db, monkeypatch, caplog):
+    """EC2 stop_instances failure must NOT crash — logged as error, shutdown completes."""
+    client = _mock_client(positions={})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+
+    fake_ec2 = MagicMock()
+    fake_ec2.stop_instances.side_effect = RuntimeError("EC2 API down")
+    fake_boto3 = MagicMock()
+    fake_boto3.client = MagicMock(side_effect=lambda svc, **kw:
+                                  fake_ec2 if svc == "ec2" else MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    fake_urlopen = MagicMock()
+    fake_urlopen.return_value.read = MagicMock(side_effect=[b"token-abc", b"i-12345"])
+
+    with caplog.at_level("ERROR"):
+        with patch("urllib.request.urlopen", fake_urlopen):
+            mod.emergency_shutdown(execute=True, stop_instance=True)
+
+    assert any("EC2 stop failed" in r.message for r in caplog.records)
+
+
+def test_execute_stop_instance_calls_ec2_stop(stub_config, stub_db, monkeypatch):
+    client = _mock_client(positions={})
+    monkeypatch.setattr(mod, "IBKRClient", MagicMock(return_value=client))
+    monkeypatch.setattr(mod, "subprocess", MagicMock())
+
+    fake_ec2 = MagicMock()
+    fake_boto3 = MagicMock()
+    fake_boto3.client = MagicMock(side_effect=lambda svc, **kw:
+                                  fake_ec2 if svc == "ec2" else MagicMock())
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    fake_urlopen = MagicMock()
+    fake_urlopen.return_value.read = MagicMock(side_effect=[b"token-abc", b"i-12345"])
+    with patch("urllib.request.urlopen", fake_urlopen):
+        mod.emergency_shutdown(execute=True, stop_instance=True)
+
+    fake_ec2.stop_instances.assert_called_once_with(InstanceIds=["i-12345"])

--- a/tests/test_price_monitor.py
+++ b/tests/test_price_monitor.py
@@ -1,0 +1,198 @@
+"""Tests for executor.price_monitor — delayed market-data subscriber + tick aggregator."""
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from executor.price_monitor import PriceMonitor, _finite
+
+
+# ── _finite helper ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("val,expected", [
+    (1.5, 1.5),
+    (100, 100.0),
+    (None, None),
+    (0, None),
+    (-1, None),
+    (float("nan"), None),
+    (float("inf"), None),
+    (-float("inf"), None),
+    ("string", None),
+    (True, None),  # bool not allowed; but bool IS isinstance of int — let's pin behavior
+])
+def test_finite_helper(val, expected):
+    # Note: bool IS an int subclass — True returns 1.0 since 1>0
+    if isinstance(val, bool):
+        expected = 1.0 if val else None
+    assert _finite(val) == expected
+
+
+# ── PriceMonitor.subscribe + tick handler ──────────────────────────────────
+
+
+def _make_ib_mock():
+    """A mock IB connection: reqMarketDataType, qualifyContracts, reqMktData, etc."""
+    ib = MagicMock()
+    ib.pendingTickersEvent = MagicMock()
+    return ib
+
+
+def _make_ticker(symbol, last=None, high=None, low=None, close=None, volume=None,
+                 delayedLast=None, delayedHigh=None, delayedLow=None, delayedClose=None):
+    """A mock ib_insync Ticker. .contract.symbol drives dispatch."""
+    t = MagicMock()
+    t.contract.symbol = symbol
+    t.last = last
+    t.high = high
+    t.low = low
+    t.close = close
+    t.volume = volume
+    t.delayedLast = delayedLast
+    t.delayedHigh = delayedHigh
+    t.delayedLow = delayedLow
+    t.delayedClose = delayedClose
+    return t
+
+
+def test_subscribe_calls_market_data_type_and_registers_handler():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    pm.subscribe(["AAPL", "MSFT"])
+
+    ib.reqMarketDataType.assert_called_once_with(3)
+    assert ib.qualifyContracts.call_count == 2
+    assert ib.reqMktData.call_count == 2
+    assert set(pm._contracts.keys()) == {"AAPL", "MSFT"}
+    assert len(pm._subscriptions) == 2
+
+
+def test_subscribe_skips_tickers_that_fail_to_qualify():
+    ib = _make_ib_mock()
+
+    def qualify(contract):
+        if contract.symbol == "BAD":
+            raise RuntimeError("contract not found")
+
+    ib.qualifyContracts.side_effect = qualify
+    pm = PriceMonitor(ib)
+
+    pm.subscribe(["AAPL", "BAD", "MSFT"])
+
+    assert "BAD" not in pm._contracts
+    assert set(pm._contracts.keys()) == {"AAPL", "MSFT"}
+    assert len(pm._subscriptions) == 2
+
+
+def test_on_pending_tickers_records_live_prices():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    ticker = _make_ticker("AAPL", last=150.0, high=152.0, low=148.0, close=149.0, volume=1_000_000)
+    pm._on_pending_tickers({ticker})
+
+    assert pm.prices["AAPL"]["last"] == 150.0
+    assert pm.prices["AAPL"]["high"] == 152.0
+    assert pm.prices["AAPL"]["low"] == 148.0
+    assert pm.prices["AAPL"]["close"] == 149.0
+    assert pm.prices["AAPL"]["volume"] == 1_000_000
+    assert "updated_at" in pm.prices["AAPL"]
+
+
+def test_on_pending_tickers_falls_back_to_delayed_fields():
+    """When live fields are empty, delayed fields back-fill."""
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    ticker = _make_ticker(
+        "AAPL", last=None, high=None, low=None, close=None,
+        delayedLast=150.5, delayedHigh=151.0, delayedLow=149.0, delayedClose=149.5,
+    )
+    pm._on_pending_tickers({ticker})
+
+    assert pm.prices["AAPL"]["last"] == 150.5
+    assert pm.prices["AAPL"]["high"] == 151.0
+    assert pm.prices["AAPL"]["low"] == 149.0
+    assert pm.prices["AAPL"]["close"] == 149.5
+
+
+def test_on_pending_tickers_skips_when_no_usable_price():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    ticker = _make_ticker("AAPL")  # all None
+    pm._on_pending_tickers({ticker})
+    assert "AAPL" not in pm.prices
+
+
+def test_on_pending_tickers_skips_when_no_contract_symbol():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    bad = MagicMock()
+    bad.contract = None  # falsy → symbol None
+    pm._on_pending_tickers({bad})
+
+    assert pm.prices == {}
+
+
+def test_on_pending_tickers_tracks_intraday_high_low_across_updates():
+    """Subsequent ticks should aggregate high/low rather than overwrite."""
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    # First tick: high 150, low 148
+    t1 = _make_ticker("AAPL", last=149.0, high=150.0, low=148.0)
+    pm._on_pending_tickers({t1})
+    # Second tick: high 149 (lower), low 147 (lower) — should keep MAX(150, 149) and MIN(148, 147)
+    t2 = _make_ticker("AAPL", last=147.5, high=149.0, low=147.0)
+    pm._on_pending_tickers({t2})
+
+    assert pm.prices["AAPL"]["high"] == 150.0  # kept from first tick
+    assert pm.prices["AAPL"]["low"] == 147.0   # updated to second tick (lower)
+
+
+def test_on_pending_tickers_volume_only_when_positive():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    t = _make_ticker("AAPL", last=100.0, volume=0)
+    pm._on_pending_tickers({t})
+    assert pm.prices["AAPL"]["volume"] is None
+
+
+def test_unsubscribe_all_cancels_subscriptions():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+
+    pm.subscribe(["AAPL", "MSFT"])
+    pm.unsubscribe_all()
+
+    assert ib.cancelMktData.call_count == 2
+    assert pm._subscriptions == []
+    assert pm._contracts == {}
+
+
+def test_unsubscribe_all_swallows_cancel_errors():
+    ib = _make_ib_mock()
+    ib.cancelMktData.side_effect = RuntimeError("already cancelled")
+    pm = PriceMonitor(ib)
+    pm.subscribe(["AAPL"])
+
+    # Should not raise
+    pm.unsubscribe_all()
+    assert pm._subscriptions == []
+
+
+def test_get_price_returns_state_or_none():
+    ib = _make_ib_mock()
+    pm = PriceMonitor(ib)
+    assert pm.get_price("AAPL") is None
+
+    ticker = _make_ticker("AAPL", last=150.0)
+    pm._on_pending_tickers({ticker})
+
+    assert pm.get_price("AAPL")["last"] == 150.0

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -1,0 +1,333 @@
+"""Tests for executor.trade_logger — DB I/O + S3 backup + entry-lookup helpers."""
+
+import json
+import sqlite3
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from executor.trade_logger import (
+    backup_to_s3,
+    get_entry_dates,
+    get_entry_stance_and_catalyst,
+    get_entry_trade,
+    get_todays_trades,
+    get_unmatched_entry,
+    init_db,
+    log_eod,
+    log_risk_event,
+    log_shadow_book_block,
+    log_trade,
+)
+
+
+@pytest.fixture
+def db(tmp_path):
+    return init_db(str(tmp_path / "trades.db"))
+
+
+def _trade(date="2026-04-15", ticker="AAPL", action="ENTER", shares=100, **kw):
+    base = {"date": date, "ticker": ticker, "action": action, "shares": shares}
+    base.update(kw)
+    return base
+
+
+# ── init_db ─────────────────────────────────────────────────────────────────
+
+
+def test_init_db_creates_expected_tables(tmp_path):
+    conn = init_db(str(tmp_path / "trades.db"))
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "trades" in tables
+    assert "eod_pnl" in tables
+    assert "executor_shadow_book" in tables
+    assert "risk_events" in tables
+
+
+def test_init_db_idempotent_re_run(tmp_path):
+    """Re-initializing must not raise — duplicate-column ALTER errors are absorbed."""
+    path = str(tmp_path / "trades.db")
+    init_db(path).close()
+    init_db(path).close()  # second run must succeed without raising
+
+
+def test_init_db_propagates_unexpected_migration_error(tmp_path, monkeypatch):
+    """A non-duplicate-column OperationalError must surface."""
+    import executor.trade_logger as mod
+
+    # Use an out-of-band migration list that triggers an unexpected error
+    bad_migrations = ["ALTER TABLE trades NOT_A_REAL_OPERATION"]
+    monkeypatch.setattr(mod, "_TRADES_MIGRATIONS", bad_migrations)
+
+    with pytest.raises(sqlite3.OperationalError):
+        init_db(str(tmp_path / "trades.db"))
+
+
+def test_init_db_propagates_unexpected_eod_migration_error(tmp_path, monkeypatch):
+    import executor.trade_logger as mod
+    monkeypatch.setattr(mod, "_EOD_MIGRATIONS", ["ALTER TABLE eod_pnl NOT_A_REAL_OP"])
+    with pytest.raises(sqlite3.OperationalError):
+        init_db(str(tmp_path / "trades.db"))
+
+
+def test_init_db_propagates_unexpected_risk_events_migration_error(tmp_path, monkeypatch):
+    import executor.trade_logger as mod
+    monkeypatch.setattr(mod, "_RISK_EVENTS_MIGRATIONS", ["ALTER TABLE risk_events NOT_A_REAL_OP"])
+    with pytest.raises(sqlite3.OperationalError):
+        init_db(str(tmp_path / "trades.db"))
+
+
+def test_init_db_risk_events_migration_idempotent(tmp_path, monkeypatch):
+    """A real migration added to the placeholder list should run once + be
+    idempotent on re-init (duplicate-column branch)."""
+    import executor.trade_logger as mod
+    monkeypatch.setattr(
+        mod, "_RISK_EVENTS_MIGRATIONS",
+        ["ALTER TABLE risk_events ADD COLUMN test_col TEXT"],
+    )
+    path = str(tmp_path / "trades.db")
+    init_db(path).close()
+    # Second init must succeed (duplicate-column path)
+    conn = init_db(path)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(risk_events)").fetchall()}
+    assert "test_col" in cols
+
+
+def test_log_risk_event_falls_through_when_lib_unavailable(tmp_path):
+    """The optional alpha_engine_lib.dates import must NOT hard-fail."""
+    conn = init_db(str(tmp_path / "trades.db"))
+    fake_lib = MagicMock()
+    fake_lib.now_dual.side_effect = RuntimeError("simulated import failure")
+    sys.modules.pop("alpha_engine_lib.dates", None)
+    sys.modules["alpha_engine_lib.dates"] = fake_lib
+
+    try:
+        event_id = log_risk_event(conn, {
+            "date": "2026-04-15", "event_type": "veto", "rule": "min_score",
+        })
+        td = conn.execute(
+            "SELECT trading_day FROM risk_events WHERE event_id=?", (event_id,),
+        ).fetchone()[0]
+        assert td is None
+    finally:
+        sys.modules.pop("alpha_engine_lib.dates", None)
+
+
+# ── log_trade ───────────────────────────────────────────────────────────────
+
+
+def test_log_trade_returns_uuid_and_inserts_row(db):
+    trade_id = log_trade(db, _trade())
+    assert isinstance(trade_id, str) and len(trade_id) == 36
+    rows = db.execute("SELECT trade_id, ticker, action, shares FROM trades").fetchall()
+    assert len(rows) == 1
+    assert rows[0] == (trade_id, "AAPL", "ENTER", 100)
+
+
+def test_log_trade_uses_caller_trading_day_when_provided(db):
+    log_trade(db, _trade(trading_day="2026-04-14"))
+    td = db.execute("SELECT trading_day FROM trades").fetchone()[0]
+    assert td == "2026-04-14"
+
+
+def test_log_trade_falls_through_when_lib_unavailable(db, monkeypatch):
+    """If the optional lib raises on import, trading_day stays NULL — no hard fail."""
+    # Force the inline `from alpha_engine_lib.dates import now_dual` to raise
+    fake_lib = MagicMock()
+    fake_lib.now_dual.side_effect = RuntimeError("simulated import failure")
+    # Inject into sys.modules so the inline import picks it up — we need to
+    # invalidate the cached import first
+    sys.modules.pop("alpha_engine_lib.dates", None)
+    sys.modules["alpha_engine_lib.dates"] = fake_lib
+
+    try:
+        log_trade(db, _trade())  # no trading_day provided
+        td = db.execute("SELECT trading_day FROM trades").fetchone()[0]
+        assert td is None
+    finally:
+        sys.modules.pop("alpha_engine_lib.dates", None)
+
+
+# ── log_shadow_book_block ───────────────────────────────────────────────────
+
+
+def test_log_shadow_book_block_inserts_row(db):
+    shadow_id = log_shadow_book_block(db, {
+        "date": "2026-04-15", "ticker": "AAPL", "block_reason": "low_score",
+        "research_score": 45.0, "intended_position_pct": 0.05,
+    })
+    rows = db.execute(
+        "SELECT shadow_id, ticker, block_reason FROM executor_shadow_book"
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0] == (shadow_id, "AAPL", "low_score")
+
+
+# ── log_risk_event ──────────────────────────────────────────────────────────
+
+
+def test_log_risk_event_serializes_context_to_json(db):
+    event_id = log_risk_event(db, {
+        "date": "2026-04-15",
+        "event_type": "throttle",
+        "rule": "drawdown_tier_throttle",
+        "ticker": "AAPL",
+        "value": 0.85,
+        "context": {"breached_tier": "tier_2", "tier_size_multiplier": 0.5},
+    })
+    row = db.execute(
+        "SELECT event_id, event_type, rule, ticker, context_json FROM risk_events"
+    ).fetchone()
+    assert row[0] == event_id
+    assert row[1] == "throttle"
+    assert row[2] == "drawdown_tier_throttle"
+    assert row[3] == "AAPL"
+    ctx = json.loads(row[4])
+    assert ctx == {"breached_tier": "tier_2", "tier_size_multiplier": 0.5}
+
+
+def test_log_risk_event_null_context_persists_as_null(db):
+    log_risk_event(db, {"date": "2026-04-15", "event_type": "veto", "rule": "min_score"})
+    ctx = db.execute("SELECT context_json FROM risk_events").fetchone()[0]
+    assert ctx is None
+
+
+# ── log_eod ─────────────────────────────────────────────────────────────────
+
+
+def test_log_eod_insert_or_replace(db):
+    log_eod(db, {
+        "date": "2026-04-15",
+        "portfolio_nav": 100_000.0,
+        "daily_return_pct": 0.5,
+        "spy_return_pct": 0.3,
+        "daily_alpha_pct": 0.2,
+        "positions_snapshot": {"AAPL": 100},
+        "unattributed_residual_pct": 0.45,
+    })
+
+    # Replace via INSERT OR REPLACE
+    log_eod(db, {
+        "date": "2026-04-15",
+        "portfolio_nav": 100_500.0,
+        "daily_return_pct": 0.6,
+        "spy_return_pct": 0.3,
+        "daily_alpha_pct": 0.3,
+    })
+
+    rows = db.execute("SELECT portfolio_nav FROM eod_pnl WHERE date=?", ("2026-04-15",)).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == 100_500.0
+
+
+# ── entry-lookup helpers ────────────────────────────────────────────────────
+
+
+def test_get_entry_dates_returns_only_existing_enters(db):
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-01"))
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-10"))  # newer ENTER
+    log_trade(db, _trade(ticker="MSFT", date="2026-04-05"))
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-15", action="EXIT"))
+
+    result = get_entry_dates(db, ["AAPL", "MSFT", "NOPE"])
+
+    assert result == {"AAPL": "2026-04-10", "MSFT": "2026-04-05"}
+    assert "NOPE" not in result
+
+
+def test_get_entry_stance_and_catalyst_returns_most_recent(db):
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-01",
+                         stance="momentum", catalyst_date=None))
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-10",
+                         stance="catalyst", catalyst_date="2026-04-22"))
+    log_trade(db, _trade(ticker="MSFT", date="2026-04-05",
+                         stance="quality"))
+
+    result = get_entry_stance_and_catalyst(db, ["AAPL", "MSFT", "NOPE"])
+    assert result["AAPL"] == {"stance": "catalyst", "catalyst_date": "2026-04-22"}
+    assert result["MSFT"] == {"stance": "quality", "catalyst_date": None}
+    assert "NOPE" not in result
+
+
+def test_get_todays_trades_returns_only_run_date(db):
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-15"))
+    log_trade(db, _trade(ticker="MSFT", date="2026-04-15"))
+    log_trade(db, _trade(ticker="GOOGL", date="2026-04-16"))
+
+    trades = get_todays_trades(db, "2026-04-15")
+    assert len(trades) == 2
+    assert {t["ticker"] for t in trades} == {"AAPL", "MSFT"}
+
+
+def test_get_entry_trade_picks_most_recent_enter(db):
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-01"))
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-10"))
+
+    entry = get_entry_trade(db, "AAPL")
+    assert entry is not None
+    assert entry["date"] == "2026-04-10"
+
+
+def test_get_entry_trade_returns_none_when_no_enter(db):
+    assert get_entry_trade(db, "AAPL") is None
+
+
+# ── get_unmatched_entry ─────────────────────────────────────────────────────
+
+
+def test_get_unmatched_entry_finds_entry_with_remaining_shares(db):
+    entry_id = log_trade(db, _trade(ticker="AAPL", date="2026-04-01", shares=100))
+    # Partial reduce of 30
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-05", action="REDUCE",
+                         shares=30, entry_trade_id=entry_id))
+
+    result = get_unmatched_entry(db, "AAPL")
+    assert result is not None
+    assert result["trade_id"] == entry_id
+    assert result["shares_remaining"] == 70
+
+
+def test_get_unmatched_entry_returns_none_when_fully_matched(db):
+    entry_id = log_trade(db, _trade(ticker="AAPL", date="2026-04-01", shares=100))
+    log_trade(db, _trade(ticker="AAPL", date="2026-04-05", action="EXIT",
+                         shares=100, entry_trade_id=entry_id))
+
+    assert get_unmatched_entry(db, "AAPL") is None
+
+
+def test_get_unmatched_entry_returns_none_with_no_entries(db):
+    assert get_unmatched_entry(db, "AAPL") is None
+
+
+# ── backup_to_s3 ────────────────────────────────────────────────────────────
+
+
+def test_backup_to_s3_uploads_dated_and_latest(tmp_path, monkeypatch):
+    db_path = tmp_path / "trades.db"
+    init_db(str(db_path)).close()
+
+    fake_s3 = MagicMock()
+    monkeypatch.setattr("executor.trade_logger.boto3.client", MagicMock(return_value=fake_s3))
+
+    backup_to_s3(str(db_path), "2026-04-15", "bucket-x")
+
+    assert fake_s3.upload_file.call_count == 2
+    keys = [c.args[2] for c in fake_s3.upload_file.call_args_list]
+    assert "trades/trades_2026-04-15.db" in keys
+    assert "trades/trades_latest.db" in keys
+
+
+def test_backup_to_s3_swallows_failures(tmp_path, monkeypatch, caplog):
+    db_path = tmp_path / "trades.db"
+    init_db(str(db_path)).close()
+
+    fake_s3 = MagicMock()
+    fake_s3.upload_file.side_effect = RuntimeError("S3 down")
+    monkeypatch.setattr("executor.trade_logger.boto3.client", MagicMock(return_value=fake_s3))
+
+    with caplog.at_level("ERROR"):
+        backup_to_s3(str(db_path), "2026-04-15", "bucket-x")
+    assert any("S3 backup failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

- **Closes ROADMAP L2578 entirely** — executor was the last repo below 80%
- Executor overall coverage: **76.30% → 80.03%** ✅
- Test suite: **684 → 755 passing** (+71 tests)
- All new tests use mocked IBKRClient / boto3 / subprocess / urllib — no IB Gateway, no S3, no real AWS credentials

## Coverage delta

| Module | Before | After | Notes |
|---|---|---|---|
| `executor/config_loader.py` | 46.2% | **100%** | 5 tests; path-resolution + no-silent-fallback guarantee |
| `executor/price_monitor.py` | 22.4% | **100%** | 21 tests; PriceMonitor lifecycle + tick aggregation + live/delayed field fallback |
| `executor/bracket_orders.py` | 7.8% | **98%** | 8 tests; market-BUY + trailing stop happy/partial/timeout/qualify-failure |
| `executor/emergency_shutdown.py` | 0% | **97%** | 12 tests; paper-account-only hard-exit + cascading failure resilience |
| `executor/trade_logger.py` | 59.1% | **100%** | 23 tests; full schema + idempotent migrations + entry-lookup helpers + S3 backup |

## ROADMAP L2578 status after this PR

All 6 repos at or above the 80% target:

| Repo | Before this arc | After |
|---|---|---|
| Backtester | 77.7% | **80.3%** (PR #198) |
| Predictor | 74.9% | **80.1%** (PR #150) |
| **Executor** | **76.3%** | **80.0%** (this PR) |
| Data | 82% | already ≥80% |
| Research | 80% | already ≥80% |
| Dashboard | 86% | already ≥80% |

## Notes

- `executor/liquidate_all.py` was excluded. It uses bare imports (`from ibkr import IBKRClient`, `from trade_logger import ...`) that only resolve when the file is run as a script from the `executor/` directory; `import executor.liquidate_all` fails with `ModuleNotFoundError`. Would require a small refactor to package-qualified imports before becoming unit-testable. Not in scope for this coverage push.
- `executor/bracket_orders.py:117` is an unreachable `else` branch (the upstream `terminal_states` set already covers every value the prior `elif` checks against). Pinned at 98% rather than 100%.

## Test plan

- [x] `pytest -q` — 755 passed
- [x] `pytest --cov=. --cov-report=term-missing` — overall 80.03%
- [x] No production-code changes
- [x] No S3 / IB Gateway / network / AWS-credential dependencies in any new test
- [x] No new dependencies in `requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)