### PR TITLE
refactor(notifier): migrate to alpha_engine_lib.telegram substrate (v0.14.0)

### DIFF
--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -1,61 +1,31 @@
 """
-Telegram trade notification sender.
+Telegram trade notification sender — daemon-side structured-message formatters.
 
-Sends push notifications for intraday trade executions via Telegram bot API.
-Fire-and-forget with a 5-second timeout — a failed notification never blocks
-trade execution.
+Sits on top of ``alpha_engine_lib.telegram.send_message`` (lib v0.14.0+), which
+handles token/chat_id resolution, markdown escape, retry/timeout, and
+fire-and-forget bool-return semantics. This module contributes daemon-specific
+*message formatting* — emoji + structured trade/status templates — and
+nothing else.
 
 Setup (one-time):
   1. Message @BotFather on Telegram → /newbot → save the bot token
-  2. Add to .env: TELEGRAM_BOT_TOKEN=<token>
+  2. Set ``TELEGRAM_BOT_TOKEN`` in SSM at ``/alpha-engine/TELEGRAM_BOT_TOKEN``
   3. Message the bot, then call getUpdates to get your chat_id
-  4. Add to .env: TELEGRAM_CHAT_ID=<chat_id>
+  4. Set ``TELEGRAM_CHAT_ID`` in SSM at ``/alpha-engine/TELEGRAM_CHAT_ID``
+
+Migration arc: ROADMAP L1067 PR 2a (2026-05-13). Previously this module owned
+the primitive send path inline; the surveillance Lambda arc required a second
+producer, so the primitive was consolidated into ``alpha_engine_lib.telegram``
+to prevent the "two writers diverged silently" antipattern.
 """
 
 from __future__ import annotations
 
 import logging
 
-import requests
-
-from alpha_engine_lib.secrets import get_secret
+from alpha_engine_lib.telegram import send_message
 
 logger = logging.getLogger(__name__)
-
-_TELEGRAM_API = "https://api.telegram.org/bot{token}/sendMessage"
-
-
-def _escape_markdown(text: str) -> str:
-    """Escape Telegram Markdown v1 special characters.
-
-    Replaces characters that Telegram interprets as formatting markers
-    (_, `, [, ]) to prevent 400 Bad Request parse errors. Preserves
-    * for bold markers which we control in our message templates.
-    """
-    return (
-        text
-        .replace("_", "-")
-        .replace("`", "'")
-        .replace("[", "(")
-        .replace("]", ")")
-    )
-
-
-def _send_telegram(token: str, chat_id: str, text: str) -> bool:
-    """Fire-and-forget Telegram message. Returns True on success."""
-    try:
-        resp = requests.post(
-            _TELEGRAM_API.format(token=token),
-            json={"chat_id": chat_id, "text": _escape_markdown(text), "parse_mode": "Markdown"},
-            timeout=5,
-        )
-        if resp.status_code == 200:
-            return True
-        logger.warning("Telegram API returned %d: %s", resp.status_code, resp.text[:200])
-        return False
-    except Exception:
-        logger.warning("Telegram send failed", exc_info=True)
-        return False
 
 
 def send_trade_alert(
@@ -66,18 +36,12 @@ def send_trade_alert(
     trigger: str = "",
     source: str = "daemon",
 ) -> bool:
-    """
-    Send a Telegram push notification for a trade execution.
+    """Send a Telegram push notification for a trade execution.
 
-    Returns True if sent successfully, False otherwise.
+    Returns True if sent successfully, False otherwise (missing secrets,
+    network error, non-200 response — all swallowed by the lib substrate).
     """
-    token = get_secret("TELEGRAM_BOT_TOKEN", required=False)
-    chat_id = get_secret("TELEGRAM_CHAT_ID", required=False)
-    if not token or not chat_id:
-        logger.debug("Telegram not configured — skipping notification")
-        return False
-
-    emoji = {"BUY": "\U0001f7e2", "SELL": "\U0001f534", "REDUCE": "\U0001f7e1"}.get(action, "\u26aa")
+    emoji = {"BUY": "\U0001f7e2", "SELL": "\U0001f534", "REDUCE": "\U0001f7e1"}.get(action, "⚪")
     msg = (
         f"{emoji} *{action} {ticker}*\n"
         f"Shares: {shares} @ ${price:.2f}\n"
@@ -85,7 +49,7 @@ def send_trade_alert(
         f"Source: {source}"
     )
 
-    ok = _send_telegram(token, chat_id, msg)
+    ok = send_message(msg)
     if ok:
         logger.info("Telegram alert sent: %s %s", action, ticker)
     else:
@@ -94,11 +58,5 @@ def send_trade_alert(
 
 
 def send_daemon_status(message: str) -> bool:
-    """Send a general status message (daemon start/stop, errors)."""
-    token = get_secret("TELEGRAM_BOT_TOKEN", required=False)
-    chat_id = get_secret("TELEGRAM_CHAT_ID", required=False)
-    if not token or not chat_id:
-        logger.warning("Telegram not configured — TELEGRAM_BOT_TOKEN=%s TELEGRAM_CHAT_ID=%s", "set" if token else "MISSING", "set" if chat_id else "MISSING")
-        return False
-
-    return _send_telegram(token, chat_id, message)
+    """Send a general status message (daemon start/stop, errors, IB events)."""
+    return send_message(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ requests~=2.32
 # model_metadata + full_prompt_context, enabling deterministic executor
 # decision capture (L2308 — executor:entry_triggers / position_sizer /
 # risk_guard / exit_rules artifacts emitted from daemon + planner).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.13.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.14.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -13,7 +13,7 @@ import pytest
 from executor.entry_triggers import EntryTriggerEngine
 from executor.intraday_exit_manager import IntradayExitManager
 from executor.market_hours import is_market_hours, is_trading_day
-from executor.notifier import _escape_markdown, _send_telegram, send_daemon_status, send_trade_alert
+from executor.notifier import send_daemon_status, send_trade_alert
 from executor.retry import retry
 
 _ET = pytz.timezone("US/Eastern")
@@ -279,24 +279,11 @@ class TestMarketHours:
 
 
 class TestNotifier:
-    def test_escape_markdown(self):
-        assert _escape_markdown("hello_world") == "hello-world"
-        assert _escape_markdown("code`block`") == "code'block'"
-        assert _escape_markdown("[link]") == "(link)"
-
-    @patch("executor.notifier.requests.post")
-    def test_send_telegram_success(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=200)
-        assert _send_telegram("token", "123", "hello") is True
-
-    @patch("executor.notifier.requests.post")
-    def test_send_telegram_failure(self, mock_post):
-        mock_post.return_value = MagicMock(status_code=400, text="Bad Request")
-        assert _send_telegram("token", "123", "hello") is False
-
-    @patch("executor.notifier.requests.post", side_effect=Exception("timeout"))
-    def test_send_telegram_exception(self, mock_post):
-        assert _send_telegram("token", "123", "hello") is False
+    """Daemon-side formatter tests. Primitive send/escape behavior is locked
+    upstream in alpha_engine_lib.telegram's own test suite (29 tests). These
+    tests cover only the daemon-specific message-shape contracts and that
+    the formatters correctly route through the lib substrate.
+    """
 
     def test_send_trade_alert_no_config(self):
         # Preserve ALPHA_ENGINE_SECRETS_SOURCE=env from conftest so get_secret()
@@ -304,11 +291,25 @@ class TestNotifier:
         with patch.dict("os.environ", {"ALPHA_ENGINE_SECRETS_SOURCE": "env"}, clear=True):
             assert send_trade_alert("BUY", "AAPL", 10, 150.0) is False
 
-    @patch("executor.notifier._send_telegram", return_value=True)
+    @patch("executor.notifier.send_message", return_value=True)
     def test_send_trade_alert_success(self, mock_send):
-        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_CHAT_ID": "c"}):
-            assert send_trade_alert("BUY", "AAPL", 10, 150.0, "pullback", "daemon") is True
-            mock_send.assert_called_once()
+        assert send_trade_alert("BUY", "AAPL", 10, 150.0, "pullback", "daemon") is True
+        mock_send.assert_called_once()
+
+    @patch("executor.notifier.send_message", return_value=True)
+    def test_send_trade_alert_message_format(self, mock_send):
+        send_trade_alert("BUY", "AAPL", 10, 150.0, "pullback", "daemon")
+        msg = mock_send.call_args.args[0]
+        assert "*BUY AAPL*" in msg
+        assert "Shares: 10 @ $150.00" in msg
+        assert "Trigger: pullback" in msg
+        assert "Source: daemon" in msg
+
+    @patch("executor.notifier.send_message", return_value=True)
+    def test_send_trade_alert_unknown_action_uses_fallback_emoji(self, mock_send):
+        send_trade_alert("WEIRD", "AAPL", 10, 150.0)
+        msg = mock_send.call_args.args[0]
+        assert "*WEIRD AAPL*" in msg
 
     def test_send_daemon_status_no_config(self):
         # Preserve ALPHA_ENGINE_SECRETS_SOURCE=env from conftest so get_secret()
@@ -316,10 +317,10 @@ class TestNotifier:
         with patch.dict("os.environ", {"ALPHA_ENGINE_SECRETS_SOURCE": "env"}, clear=True):
             assert send_daemon_status("test") is False
 
-    @patch("executor.notifier._send_telegram", return_value=True)
+    @patch("executor.notifier.send_message", return_value=True)
     def test_send_daemon_status_success(self, mock_send):
-        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "t", "TELEGRAM_CHAT_ID": "c"}):
-            assert send_daemon_status("daemon started") is True
+        assert send_daemon_status("daemon started") is True
+        mock_send.assert_called_once_with("daemon started")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

**PR 2a of 3** in the L1067 executor-surveillance arc.

Rewrites \`executor/notifier.py\` to route through \`alpha_engine_lib.telegram.send_message\` (shipped today as lib v0.14.0, [alpha-engine-lib #45](https://github.com/cipher813/alpha-engine-lib/pull/45)). Daemon-specific message formatting (\`send_trade_alert\`, \`send_daemon_status\` — emoji, structured templates) stays; primitive send + markdown escape collapse into one-line calls into the lib substrate.

**Pure refactor — no behavior change.** Same bool return, same failure semantics (missing secrets / network error / non-200 → False; 200 → True), same emoji set, same templates.

## Why split from PR 2b

Original L1067 plan envisioned one big PR 2 covering both notifier migration AND daemon S3 snapshot writer + surveillance-universe expansion. Splitting:
- **PR 2a (this PR):** low-risk refactor of the notification primitive. No live-order-path impact.
- **PR 2b (next branch):** daemon proactively subscribes to \`signals ∪ buy_candidates ∪ current_positions\` (~40-60 tickers under IB 100-cap); publishes IB price snapshot + heartbeat to S3 at ~10s cadence. Touches the daemon's main loop + IB subscription set — warrants independent review.

## Changes

- \`executor/notifier.py\` — 105 lines → 56 lines. Drops inline \`_send_telegram\`, \`_escape_markdown\`, \`_TELEGRAM_API\`, requests/secrets imports. Adds \`from alpha_engine_lib.telegram import send_message\`.
- \`requirements.txt\` — \`alpha-engine-lib @v0.13.0\` → \`@v0.14.0\`.
- \`tests/test_intraday.py\` — drops 3 tests for now-deleted private symbols (locked upstream in lib's \`test_telegram.py\` with 29 tests); adds 2 daemon-formatter contract tests (message-format + unknown-action fallback emoji).

## Test plan

- [x] Full executor suite green: 753/753, 29.42s
- [x] \`test_intraday.py::TestNotifier\`: 6/6 pass
- [x] Pre-push dry-run gate passed
- [ ] First live exercise: next daemon order placement on ae-trading (post-merge, post-boot-pull). Should see Telegram alert identical in shape to today's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)