### PR TITLE
feat(daemon): publish IB price snapshot + heartbeat to S3 for surveillance Lambda

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -49,6 +49,10 @@ from executor.decision_capture import (
 from executor.entry_triggers import EntryTriggerEngine
 from executor.ibkr import IBKRClient
 from executor.intraday_exit_manager import IntradayExitManager
+from executor.intraday_snapshot import (
+    IntradaySnapshotWriter,
+    compute_surveillance_universe,
+)
 from executor.market_hours import is_market_hours
 from executor.notifier import send_daemon_status, send_trade_alert
 from executor.order_book import OrderBook
@@ -453,11 +457,45 @@ def run_daemon(dry_run: bool = False) -> None:
     exit_mgr = IntradayExitManager(strategy_config)
     entry_engine = EntryTriggerEngine(strategy_config)
 
-    # Subscribe to all tickers in the order book (+ SPY for roundtrip benchmarking)
-    tickers = order_book.all_tickers()
-    if "SPY" not in tickers:
-        tickers.append("SPY")
+    # Surveillance universe — signals.signals ∪ buy_candidates ∪ order_book ∪
+    # current_positions (+ SPY). Same universe is derived independently by
+    # the surveillance Lambda from the same canonical artifacts, so producer
+    # and consumer agree by construction (ROADMAP L1067). Best-effort:
+    # signals.json read failure degrades to order_book + positions only, so
+    # daemon still trades the order book even if signals are unreadable.
+    try:
+        from executor.signal_reader import read_signals_with_fallback
+        signals_for_surveillance = read_signals_with_fallback(
+            config["signals_bucket"], run_date,
+        )
+    except Exception as _sig_err:  # noqa: BLE001
+        logger.warning(
+            "surveillance: read_signals_with_fallback failed (%s) — "
+            "universe degrades to order_book + positions only",
+            _sig_err,
+        )
+        signals_for_surveillance = None
+    try:
+        positions_for_surveillance = (
+            list(ibkr.get_positions().keys()) if not dry_run else []
+        )
+    except Exception as _pos_err:  # noqa: BLE001
+        logger.warning("surveillance: get_positions failed (%s) — universe degrades", _pos_err)
+        positions_for_surveillance = []
+
+    tickers = compute_surveillance_universe(
+        signals_for_surveillance,
+        order_book_tickers=order_book.all_tickers(),
+        current_positions=positions_for_surveillance,
+    )
     monitor.subscribe(tickers)
+
+    # S3 snapshot writer — publishes latest_prices + heartbeat at every poll
+    # tick. Surveillance Lambda treats heartbeat staleness as daemon-down.
+    snapshot_writer = IntradaySnapshotWriter(
+        bucket=config["signals_bucket"],
+        daemon_pid=os.getpid(),
+    )
 
     n_urgent = len(order_book.pending_urgent_exits())
     send_daemon_status(
@@ -694,6 +732,21 @@ def run_daemon(dry_run: bool = False) -> None:
             # Per-tick structured log line consumed by uptime_tracker.
             # Format is stable — parsers match on the DAEMON_TICK prefix.
             logger.info("DAEMON_TICK ib_connected=%s", str(ibkr.ib.isConnected()).lower())
+
+            # ── Intraday S3 snapshot (surveillance Lambda producer) ───
+            # Fire-and-forget; failures log a warning. Surveillance Lambda
+            # treats heartbeat staleness as daemon-down (ROADMAP L1067).
+            try:
+                snapshot_writer.write(
+                    monitor.prices,
+                    ib_connected=ibkr.ib.isConnected(),
+                    subscribed_tickers=tickers,
+                )
+            except Exception as _snap_err:  # noqa: BLE001
+                # Defensive — IntradaySnapshotWriter.write should already
+                # swallow S3 errors. This catch ensures no unexpected
+                # exception from the writer leaks into the trade loop.
+                logger.warning("intraday snapshot writer raised: %s", _snap_err)
 
             # ── Heartbeat ─────────────────────────────────────────────
             _elapsed = _time.time() - _last_heartbeat

--- a/executor/intraday_snapshot.py
+++ b/executor/intraday_snapshot.py
@@ -1,0 +1,180 @@
+"""
+Intraday S3 snapshot writer for the executor surveillance arc.
+
+Publishes two artifacts from the daemon's IB market-data subscription set to
+S3 on every poll tick during market hours:
+
+- ``s3://{bucket}/intraday/latest_prices.json`` — current price state for
+  every ticker the daemon has live IB data for.
+- ``s3://{bucket}/intraday/heartbeat.json`` — daemon liveness signal:
+  timestamp, ``ib_connected``, daemon_pid, subscribed-ticker count. The
+  surveillance Lambda (PR 3, alpha-engine-research) treats staleness of
+  this file as a first-class daemon-down alert.
+
+**Surveillance universe.** :func:`compute_surveillance_universe` returns
+the union ``signals.signals ∪ signals.buy_candidates ∪ current_positions``
+that both producers (the daemon publishing snapshots) and consumers (the
+surveillance Lambda) compute identically from canonical artifacts. Universe
+consistency is enforced by construction, not by discipline — there is no
+``watchlist.yaml`` to drift.
+
+**Failure semantics.** S3 writes are fire-and-forget — failures are logged
+at WARNING and never raise. A failed snapshot write must never interrupt
+the daemon's order-execution loop. Stale snapshots are visible to the
+surveillance Lambda via heartbeat-timestamp staleness, which is itself the
+designed alert signal.
+
+ROADMAP L1067 PR 2b. Composes with ``alpha_engine_lib.telegram`` (lib v0.14.0,
+PR 1) and ``executor/notifier.py`` migration (PR 2a, merged).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime
+from typing import Any
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logger = logging.getLogger(__name__)
+
+LATEST_PRICES_KEY = "intraday/latest_prices.json"
+HEARTBEAT_KEY = "intraday/heartbeat.json"
+
+
+def compute_surveillance_universe(
+    signals: dict | None,
+    order_book_tickers: list[str] | None = None,
+    current_positions: list[str] | None = None,
+    *,
+    include_spy: bool = True,
+) -> list[str]:
+    """Compute the union of tickers the surveillance layer should watch.
+
+    Universe = ``signals.signals.keys() ∪ signals.buy_candidates ∪
+    order_book_tickers ∪ current_positions``. Sorted deterministic output.
+    Pre-population scanner output deliberately excluded — non-action there
+    isn't a surveillance signal.
+
+    :param signals: The ``signals.json`` payload as a dict (or None on read
+        failure). Keys read: ``signals`` (dict of ticker → rec) and
+        ``buy_candidates`` (list of ticker strings).
+    :param order_book_tickers: Tickers the daemon's order book is tracking
+        (held positions + active candidates). Optional; defaults to empty.
+    :param current_positions: Current IB position tickers. Optional;
+        defaults to empty. Belt-and-braces — positions are typically already
+        in ``order_book_tickers`` via the morning planner.
+    :param include_spy: If ``True`` (default), SPY is always included for
+        roundtrip benchmarking — matches existing daemon behavior.
+    :returns: Sorted deduplicated list of tickers.
+    """
+    universe: set[str] = set()
+
+    if signals:
+        signals_map = signals.get("signals")
+        if isinstance(signals_map, dict):
+            universe.update(signals_map.keys())
+        buy_cands = signals.get("buy_candidates")
+        if isinstance(buy_cands, list):
+            universe.update(t for t in buy_cands if isinstance(t, str))
+
+    if order_book_tickers:
+        universe.update(order_book_tickers)
+
+    if current_positions:
+        universe.update(current_positions)
+
+    if include_spy:
+        universe.add("SPY")
+
+    universe.discard("")
+    return sorted(universe)
+
+
+class IntradaySnapshotWriter:
+    """Writes daemon IB price snapshots + heartbeats to S3 each poll tick.
+
+    Fire-and-forget — S3 write failures are logged at WARNING and never
+    raise. Surveillance Lambda treats heartbeat staleness as a daemon-down
+    alert, so write failures naturally surface as surveillance signals
+    rather than silently lost data.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        daemon_pid: int | None = None,
+        s3_client: Any | None = None,
+    ) -> None:
+        """:param bucket: S3 bucket to write under (typically
+            ``alpha-engine-research``).
+        :param daemon_pid: Stamped into heartbeat for ops triage. Defaults
+            to ``os.getpid()``.
+        :param s3_client: Inject a pre-built boto3 client (tests). Defaults
+            to a freshly-constructed ``boto3.client("s3")``.
+        """
+        self._bucket = bucket
+        self._daemon_pid = daemon_pid if daemon_pid is not None else os.getpid()
+        self._s3 = s3_client if s3_client is not None else boto3.client("s3")
+
+    def write(
+        self,
+        prices: dict[str, dict],
+        *,
+        ib_connected: bool,
+        subscribed_tickers: list[str],
+    ) -> bool:
+        """Publish latest_prices + heartbeat artifacts to S3.
+
+        :param prices: Current price-state dict from ``PriceMonitor.prices``
+            (or any mapping with the same shape).
+        :param ib_connected: ``ibkr.ib.isConnected()`` — stamped on
+            heartbeat so a stale-but-present heartbeat with
+            ``ib_connected=False`` is distinguishable from a daemon-dead
+            scenario.
+        :param subscribed_tickers: The full surveillance universe the
+            daemon is subscribed to. Stamped on heartbeat for coverage
+            audit.
+        :returns: ``True`` if both artifacts wrote successfully, ``False``
+            otherwise (logged).
+        """
+        now = datetime.utcnow()
+        timestamp_iso = now.isoformat() + "Z"
+
+        prices_payload = {
+            "timestamp": timestamp_iso,
+            "prices": dict(prices),
+        }
+        heartbeat_payload = {
+            "timestamp": timestamp_iso,
+            "ib_connected": ib_connected,
+            "daemon_pid": self._daemon_pid,
+            "subscribed_tickers": list(subscribed_tickers),
+            "subscribed_count": len(subscribed_tickers),
+        }
+
+        prices_ok = self._put_json(LATEST_PRICES_KEY, prices_payload)
+        heartbeat_ok = self._put_json(HEARTBEAT_KEY, heartbeat_payload)
+        return prices_ok and heartbeat_ok
+
+    def _put_json(self, key: str, payload: dict) -> bool:
+        """Write a JSON dict to S3 as a single object. Fire-and-forget."""
+        try:
+            self._s3.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=json.dumps(payload, default=str).encode("utf-8"),
+                ContentType="application/json",
+            )
+            return True
+        except (ClientError, BotoCoreError) as e:
+            logger.warning(
+                "intraday snapshot write to s3://%s/%s failed (%s) — "
+                "surveillance Lambda will see heartbeat staleness",
+                self._bucket, key, type(e).__name__,
+            )
+            return False

--- a/tests/test_intraday_snapshot.py
+++ b/tests/test_intraday_snapshot.py
@@ -1,0 +1,218 @@
+"""Tests for executor/intraday_snapshot.py — surveillance universe
+computation + S3 snapshot writer (latest_prices + heartbeat).
+
+Pure-logic + mocked-S3 tests; no real boto3 or IB calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from executor.intraday_snapshot import (
+    HEARTBEAT_KEY,
+    LATEST_PRICES_KEY,
+    IntradaySnapshotWriter,
+    compute_surveillance_universe,
+)
+
+
+# ── compute_surveillance_universe ──────────────────────────────────────────
+
+
+class TestComputeSurveillanceUniverse:
+    def test_empty_inputs_returns_spy_only(self):
+        assert compute_surveillance_universe(None) == ["SPY"]
+
+    def test_signals_only(self):
+        sig = {"signals": {"AAPL": {}, "MSFT": {}}, "buy_candidates": ["NVDA"]}
+        assert compute_surveillance_universe(sig) == ["AAPL", "MSFT", "NVDA", "SPY"]
+
+    def test_order_book_only(self):
+        result = compute_surveillance_universe(None, order_book_tickers=["AAPL", "MSFT"])
+        assert result == ["AAPL", "MSFT", "SPY"]
+
+    def test_positions_only(self):
+        result = compute_surveillance_universe(None, current_positions=["GOOG"])
+        assert result == ["GOOG", "SPY"]
+
+    def test_full_union_dedups_and_sorts(self):
+        sig = {"signals": {"AAPL": {}, "MSFT": {}}, "buy_candidates": ["MSFT", "NVDA"]}
+        result = compute_surveillance_universe(
+            sig,
+            order_book_tickers=["AAPL", "TSLA"],
+            current_positions=["NVDA", "GOOG"],
+        )
+        # Union: AAPL, MSFT, NVDA, TSLA, GOOG + SPY. Sorted.
+        assert result == ["AAPL", "GOOG", "MSFT", "NVDA", "SPY", "TSLA"]
+
+    def test_include_spy_false_omits_spy(self):
+        sig = {"signals": {"AAPL": {}}}
+        result = compute_surveillance_universe(sig, include_spy=False)
+        assert result == ["AAPL"]
+
+    def test_handles_missing_signals_keys(self):
+        # signals.json with neither 'signals' nor 'buy_candidates' fields.
+        assert compute_surveillance_universe({}) == ["SPY"]
+
+    def test_handles_non_dict_signals_field(self):
+        # Defensive: a malformed signals.signals field shouldn't crash.
+        sig = {"signals": "not-a-dict", "buy_candidates": ["AAPL"]}
+        assert compute_surveillance_universe(sig) == ["AAPL", "SPY"]
+
+    def test_handles_non_list_buy_candidates(self):
+        sig = {"signals": {"AAPL": {}}, "buy_candidates": "not-a-list"}
+        assert compute_surveillance_universe(sig) == ["AAPL", "SPY"]
+
+    def test_filters_non_string_buy_candidates(self):
+        sig = {"signals": {}, "buy_candidates": ["AAPL", None, 123, "MSFT"]}
+        result = compute_surveillance_universe(sig)
+        assert "AAPL" in result and "MSFT" in result
+        assert None not in result and 123 not in result
+
+    def test_filters_empty_string_tickers(self):
+        result = compute_surveillance_universe(
+            None, order_book_tickers=["AAPL", ""], current_positions=[""],
+        )
+        assert "" not in result
+        assert "AAPL" in result
+
+    def test_spy_in_signals_no_double(self):
+        sig = {"signals": {"SPY": {}, "AAPL": {}}}
+        result = compute_surveillance_universe(sig)
+        assert result.count("SPY") == 1
+
+
+# ── IntradaySnapshotWriter ──────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_s3():
+    return MagicMock()
+
+
+@pytest.fixture
+def writer(mock_s3):
+    return IntradaySnapshotWriter(
+        bucket="test-bucket",
+        daemon_pid=12345,
+        s3_client=mock_s3,
+    )
+
+
+class TestIntradaySnapshotWriterHappyPath:
+    def test_returns_true_on_success(self, writer, mock_s3):
+        result = writer.write(
+            prices={"AAPL": {"last": 150.0}},
+            ib_connected=True,
+            subscribed_tickers=["AAPL"],
+        )
+        assert result is True
+
+    def test_writes_two_objects(self, writer, mock_s3):
+        writer.write(prices={}, ib_connected=True, subscribed_tickers=[])
+        assert mock_s3.put_object.call_count == 2
+
+    def test_correct_keys(self, writer, mock_s3):
+        writer.write(prices={}, ib_connected=True, subscribed_tickers=[])
+        keys = {call.kwargs["Key"] for call in mock_s3.put_object.call_args_list}
+        assert keys == {LATEST_PRICES_KEY, HEARTBEAT_KEY}
+
+    def test_correct_bucket(self, writer, mock_s3):
+        writer.write(prices={}, ib_connected=True, subscribed_tickers=[])
+        for call in mock_s3.put_object.call_args_list:
+            assert call.kwargs["Bucket"] == "test-bucket"
+
+    def test_content_type_json(self, writer, mock_s3):
+        writer.write(prices={}, ib_connected=True, subscribed_tickers=[])
+        for call in mock_s3.put_object.call_args_list:
+            assert call.kwargs["ContentType"] == "application/json"
+
+    def test_latest_prices_payload_shape(self, writer, mock_s3):
+        writer.write(
+            prices={"AAPL": {"last": 150.0, "high": 152.0}},
+            ib_connected=True,
+            subscribed_tickers=["AAPL", "SPY"],
+        )
+        prices_call = next(
+            c for c in mock_s3.put_object.call_args_list
+            if c.kwargs["Key"] == LATEST_PRICES_KEY
+        )
+        body = json.loads(prices_call.kwargs["Body"].decode("utf-8"))
+        assert "timestamp" in body
+        assert body["prices"] == {"AAPL": {"last": 150.0, "high": 152.0}}
+
+    def test_heartbeat_payload_shape(self, writer, mock_s3):
+        writer.write(
+            prices={},
+            ib_connected=True,
+            subscribed_tickers=["AAPL", "MSFT", "SPY"],
+        )
+        hb_call = next(
+            c for c in mock_s3.put_object.call_args_list
+            if c.kwargs["Key"] == HEARTBEAT_KEY
+        )
+        body = json.loads(hb_call.kwargs["Body"].decode("utf-8"))
+        assert body["ib_connected"] is True
+        assert body["daemon_pid"] == 12345
+        assert body["subscribed_count"] == 3
+        assert body["subscribed_tickers"] == ["AAPL", "MSFT", "SPY"]
+        assert "timestamp" in body
+
+    def test_ib_disconnected_stamped_on_heartbeat(self, writer, mock_s3):
+        writer.write(prices={}, ib_connected=False, subscribed_tickers=[])
+        hb_call = next(
+            c for c in mock_s3.put_object.call_args_list
+            if c.kwargs["Key"] == HEARTBEAT_KEY
+        )
+        body = json.loads(hb_call.kwargs["Body"].decode("utf-8"))
+        assert body["ib_connected"] is False
+
+
+# ── IntradaySnapshotWriter — failure swallowing ─────────────────────────────
+
+
+class TestIntradaySnapshotWriterFailureSwallowing:
+    def test_s3_client_error_returns_false_no_raise(self, mock_s3):
+        mock_s3.put_object.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "nope"}},
+            operation_name="PutObject",
+        )
+        writer = IntradaySnapshotWriter(
+            bucket="test-bucket", daemon_pid=1, s3_client=mock_s3,
+        )
+        assert writer.write(prices={}, ib_connected=True, subscribed_tickers=[]) is False
+
+    def test_partial_failure_returns_false(self, mock_s3):
+        # First put succeeds, second fails — write returns False overall.
+        mock_s3.put_object.side_effect = [
+            None,  # first put succeeds
+            ClientError(
+                error_response={"Error": {"Code": "ServiceUnavailable"}},
+                operation_name="PutObject",
+            ),
+        ]
+        writer = IntradaySnapshotWriter(
+            bucket="test-bucket", daemon_pid=1, s3_client=mock_s3,
+        )
+        assert writer.write(prices={}, ib_connected=True, subscribed_tickers=[]) is False
+
+
+# ── IntradaySnapshotWriter — daemon_pid default ─────────────────────────────
+
+
+class TestDaemonPidDefault:
+    def test_defaults_to_os_getpid(self, mock_s3):
+        writer = IntradaySnapshotWriter(bucket="b", s3_client=mock_s3)
+        writer.write(prices={}, ib_connected=True, subscribed_tickers=[])
+        hb_call = next(
+            c for c in mock_s3.put_object.call_args_list
+            if c.kwargs["Key"] == HEARTBEAT_KEY
+        )
+        body = json.loads(hb_call.kwargs["Body"].decode("utf-8"))
+        # Just confirm it's an int — actual value is the test runner's pid.
+        assert isinstance(body["daemon_pid"], int)
+        assert body["daemon_pid"] > 0


### PR DESCRIPTION
## Summary

**PR 2b of 3** in the L1067 executor-surveillance arc. Producer-side substrate that the surveillance Lambda (PR 3, alpha-engine-research) will consume.

Composes with [PR 1 (lib v0.14.0 telegram, merged)](https://github.com/cipher813/alpha-engine-lib/pull/45) + [PR 2a (notifier migration, merged)](https://github.com/cipher813/alpha-engine/pull/173).

## What ships

### New module: \`executor/intraday_snapshot.py\`

- **\`compute_surveillance_universe(signals, order_book_tickers, current_positions)\`** — pure function returning the union \`signals.signals ∪ signals.buy_candidates ∪ order_book ∪ current_positions ∪ {SPY}\`. Sorted, deduped, defensive against malformed signals payloads. **Both producer (daemon) and consumer (surveillance Lambda in PR 3) compute this identically from canonical artifacts** — universe consistency enforced by construction, not by discipline.
- **\`IntradaySnapshotWriter\`** — publishes \`s3://{bucket}/intraday/latest_prices.json\` + \`s3://{bucket}/intraday/heartbeat.json\` on every poll tick. Fire-and-forget: S3 failures log WARNING, never raise. Heartbeat stamps \`timestamp\`, \`ib_connected\`, \`daemon_pid\`, \`subscribed_tickers\`, \`subscribed_count\`.

### Daemon edits (\`executor/daemon.py\`)

- Surveillance universe computed at startup from \`read_signals_with_fallback\` + \`order_book.all_tickers()\` + \`ibkr.get_positions()\`. Read failures degrade gracefully — daemon still trades the order book even if signals are unreadable.
- \`monitor.subscribe(tickers)\` now uses the full surveillance universe instead of just \`order_book.all_tickers()\`.
- Per-poll-tick \`snapshot_writer.write()\` inserted right after the existing \`DAEMON_TICK\` structured log line. Defensive outer try/except ensures no exception leaks into the trade loop.

## Failure-correlated observability resolved by design

Heartbeat staleness (\`>poll_interval × 1.5\` in the surveillance Lambda's logic) is itself the loudest surveillance signal — *daemon-down* is more diagnostic than any individual price observation. The surveillance Lambda checks heartbeat freshness before reading prices; if stale, it fires a critical alert and skips other surveillance checks against potentially stale data.

## Known scope limit (not blocking)

IB subscription set is fixed at daemon startup. If \`signals.json\` universe changes mid-session, the daemon won't pick up new tickers until next restart. Institutional-default behavior for a daemon-mediated subscription pattern; mid-session subscription expansion (diff + \`reqMktData\` / \`cancelMktData\`) is deferred unless surveillance gaps surface in practice. Restart cadence (every weekday SF \`RunDaemon\` after the morning planner writes signals) bounds the staleness window to ~one trading day.

## Test surface

23 new tests in \`tests/test_intraday_snapshot.py\`:
- **Pure-function universe (12 cases):** empty inputs, single-source, full union dedup+sort, SPY inclusion override, malformed-input defenses (non-dict signals.signals, non-list buy_candidates, non-string ticker filtering, empty-string filtering, SPY dedup).
- **Mocked-S3 writer (11 cases):** payload shapes for both objects, correct keys/bucket/content-type, \`ib_connected\` propagation, daemon_pid default to \`os.getpid()\`, ClientError swallowed without raise, partial-failure (first put succeeds, second fails) returns False.

Full executor suite 753 → 776 green. Pre-push dry-run gate passed.

## First live exercise

Next \`RunDaemon\` SSM step after merge + boot-pull on ae-trading:
1. Verify CloudWatch \`/var/log/executor.log\` shows the new universe-computation log lines (degradation warnings should be absent on a clean signals.json).
2. Verify \`s3 ls s3://alpha-engine-research/intraday/\` shows both \`latest_prices.json\` + \`heartbeat.json\` updated at \`poll_interval\` cadence.
3. Verify \`subscribed_count\` in heartbeat is ~40-60 (full surveillance universe) vs ~10-15 (just order_book) pre-PR.
4. IB Pro tier cap audit: confirm concurrent symbol count stays under 100.

## Test plan

- [x] 23 new tests green
- [x] Full executor suite green (776/776)
- [x] Pre-push dry-run gate passed
- [ ] Manual S3 listing after first live daemon run confirms artifacts present + timestamps refreshing
- [ ] IB subscription audit confirms count < 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)