### PR TITLE
feat(executor): portfolio optimizer cutover — PR 5

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -189,13 +189,28 @@ notifications:
 # Informational only — not a gate. The predictor features handle the signal.
 earnings_proximity_warning_days: 2
 
-# ── Portfolio optimizer (PR 2 of portfolio-optimizer-260511 arc) ────────────
-# Shadow-mode MVO optimizer runs alongside the legacy 1/n sizer and writes
-# target weights + diagnostics to S3 (predictor/optimizer_shadow/{date}.json)
-# without affecting order placement. Default OFF — enable per-environment.
-# Cutover to drive actual order placement lands in a later PR after 2-3 days
-# of shadow logs confirm plausible target weights.
+# ── Portfolio optimizer (PR 2 + PR 5 of portfolio-optimizer-260511 arc) ─────
+# Two flags govern the optimizer's effect on the order book:
+#
+#   shadow_portfolio_optimizer: runs the MVO optimizer alongside the legacy
+#     1/n sizer and writes target weights + diagnostics to S3
+#     (predictor/optimizer_shadow/{date}.json) without affecting order
+#     placement. Safe to enable any time — read-only observability.
+#
+#   use_portfolio_optimizer: PR 5 cutover. When true, the legacy
+#     _plan_entries path is SKIPPED and the optimizer's would_be_trades
+#     drive the order book directly. Exits (_plan_exits_and_reduces +
+#     strategy_exits + drawdown forced exits) still fire as protective
+#     overrides. Requires shadow_portfolio_optimizer: true (the cutover
+#     reads the same shadow log).
+#
+# Pre-flip checklist for use_portfolio_optimizer (alpha-engine-config side):
+#   1. Ad-hoc backtester cutover-gate verdict: pass (ROADMAP L156-157)
+#   2. ≥ 2-3 trading days of plausible shadow logs in S3
+#   3. No optimizer infeasibility errors (diagnostics.status: optimal)
+#   4. Operator explicit go-ahead
 shadow_portfolio_optimizer: false
+use_portfolio_optimizer: false
 
 portfolio_optimizer:
   # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty.

--- a/executor/main.py
+++ b/executor/main.py
@@ -1192,31 +1192,47 @@ def run(
                             )
 
         # ── 3. Process ENTER signals ─────────────────────────────────────────────
-        n_entered, entry_orders, blocked_entries, plan_risk_events = _plan_entries(
-            enter_signals=enter_signals,
-            signals_raw=signals_raw,
-            predictions_by_ticker=predictions_by_ticker,
-            config=config,
-            strategy_config=strategy_config,
-            market_regime=market_regime,
-            sector_ratings=sector_ratings,
-            ibkr=ibkr,
-            portfolio_nav=portfolio_nav,
-            peak_nav=peak_nav,
-            current_positions=current_positions,
-            price_histories=price_histories,
-            atr_map=atr_map,
-            dd_multiplier=dd_multiplier,
-            signal_age_days=signal_age_days,
-            earnings_by_ticker=earnings_by_ticker,
-            vwap_map=vwap_map,
-            coverage_map=coverage_map,
-            ob=ob,
-            run_date=run_date,
-            dry_run=dry_run,
-            simulate=simulate,
-            predictions_date=predictions_date,
-        )
+        # Cutover flag (PR 5 of portfolio-optimizer-260511): when true, the
+        # legacy 1/n entry planner is skipped — the optimizer's MVO solution
+        # in step 5b drives the order book directly. Research EXIT / REDUCE
+        # signals + strategy_exits + drawdown forced exits still fire in
+        # step 4–5 below as protective overrides.
+        use_optimizer = bool(config.get("use_portfolio_optimizer", False))
+        if use_optimizer and not simulate and not dry_run:
+            logger.info(
+                "use_portfolio_optimizer=True — skipping legacy _plan_entries; "
+                "optimizer drives entries from step 5b would_be_trades"
+            )
+            n_entered = 0
+            entry_orders: list[dict] = []
+            blocked_entries: list[dict] = []
+            plan_risk_events: list[dict] = []
+        else:
+            n_entered, entry_orders, blocked_entries, plan_risk_events = _plan_entries(
+                enter_signals=enter_signals,
+                signals_raw=signals_raw,
+                predictions_by_ticker=predictions_by_ticker,
+                config=config,
+                strategy_config=strategy_config,
+                market_regime=market_regime,
+                sector_ratings=sector_ratings,
+                ibkr=ibkr,
+                portfolio_nav=portfolio_nav,
+                peak_nav=peak_nav,
+                current_positions=current_positions,
+                price_histories=price_histories,
+                atr_map=atr_map,
+                dd_multiplier=dd_multiplier,
+                signal_age_days=signal_age_days,
+                earnings_by_ticker=earnings_by_ticker,
+                vwap_map=vwap_map,
+                coverage_map=coverage_map,
+                ob=ob,
+                run_date=run_date,
+                dry_run=dry_run,
+                simulate=simulate,
+                predictions_date=predictions_date,
+            )
         orders.extend(entry_orders)
 
         # Log blocked entries to shadow book for evaluation
@@ -1262,20 +1278,35 @@ def run(
         )
         orders.extend(exit_orders)
 
-        # ── 5b. Shadow portfolio optimizer (PR 2 of portfolio-optimizer-260511) ──
+        # ── 5b. Portfolio optimizer — shadow (PR 2) or live (PR 5) ───────────────
         #
-        # Runs the constrained MVO optimizer on the same inputs the legacy
-        # planner just used, logs target weights + diagnostics to S3, and
-        # NEVER raises into the legacy path. Production behaviour is
-        # unchanged. The shadow log is the primary observability artifact
-        # for deciding when to cut over (PR 5).
-        if (
+        # Shadow mode (``shadow_portfolio_optimizer: true``): runs the MVO
+        # optimizer alongside the legacy 1/n planner, logs target weights +
+        # diagnostics to S3, NEVER touches the order book.
+        #
+        # Cutover mode (``use_portfolio_optimizer: true``, PR 5 of
+        # portfolio-optimizer-260511): the legacy ``_plan_entries`` above
+        # was skipped; here we translate ``would_be_trades`` from the
+        # optimizer log into ``ob.add_entry`` / ``ob.add_urgent_exit``
+        # records. Exits already populated by ``_plan_exits_and_reduces``
+        # take precedence (OrderBook dedup-by-ticker handles overlaps).
+        #
+        # On failure of the optimizer in cutover mode we leave the order
+        # book empty rather than fall back to the legacy path — wrong
+        # trades are strictly worse than no trades for a one-day window.
+        # ``legacy_sizer_fallback`` is deferred to a later PR.
+        shadow_log: dict | None = None
+        run_optimizer_now = (
             not simulate and not dry_run
-            and config.get("shadow_portfolio_optimizer", False)
-        ):
+            and (
+                config.get("shadow_portfolio_optimizer", False)
+                or use_optimizer
+            )
+        )
+        if run_optimizer_now:
             try:
                 from executor.optimizer_shadow import run_shadow_optimizer
-                run_shadow_optimizer(
+                shadow_log = run_shadow_optimizer(
                     signals_raw=signals_raw,
                     predictions_by_ticker=predictions_by_ticker,
                     current_positions=current_positions,
@@ -1290,6 +1321,38 @@ def run(
                 logger.warning(
                     f"Shadow portfolio optimizer wrapper raised "
                     f"(non-blocking): {_shadow_err}"
+                )
+                shadow_log = None
+
+        if use_optimizer and not simulate and not dry_run:
+            from executor.optimizer_cutover import (
+                apply_optimizer_targets_to_orderbook,
+                is_log_usable,
+            )
+            if is_log_usable(shadow_log):
+                opt_entries, opt_exits = apply_optimizer_targets_to_orderbook(
+                    log=shadow_log,
+                    ob=ob,
+                    ibkr=ibkr,
+                    current_positions=current_positions,
+                    price_histories=price_histories,
+                    atr_map=atr_map,
+                    strategy_config=strategy_config,
+                    vwap_map=vwap_map,
+                    signals_raw=signals_raw,
+                    predictions_by_ticker=predictions_by_ticker,
+                    market_regime=market_regime,
+                    run_date=run_date,
+                    predictions_date=predictions_date,
+                )
+                n_entered = len(opt_entries)
+            else:
+                logger.error(
+                    "use_portfolio_optimizer=True but optimizer log is not "
+                    "usable (shadow_status=%r, diag=%r) — leaving order book "
+                    "empty for safety. Operator must investigate.",
+                    (shadow_log or {}).get("shadow_status"),
+                    ((shadow_log or {}).get("diagnostics") or {}).get("status"),
                 )
 
         # ── 6. Write stop records and save order book for daemon ────────────────

--- a/executor/optimizer_cutover.py
+++ b/executor/optimizer_cutover.py
@@ -1,0 +1,294 @@
+"""
+Portfolio-optimizer cutover — PR 5 of the portfolio-optimizer-260511 arc.
+
+When ``use_portfolio_optimizer: true`` in config/risk.yaml, the legacy
+1/n ``_plan_entries`` path in main.py is replaced by the optimizer's
+``would_be_trades`` list: target weights from the MVO kernel drive the
+order book directly. ``_plan_exits_and_reduces`` is preserved unchanged
+so research EXIT/REDUCE signals + strategy_exits (ATR / time-decay) +
+drawdown forced exits continue to fire as protective overrides.
+
+The kernel + shadow wrapper are in:
+    executor/portfolio_optimizer.py   (PR 1 — pure kernel)
+    executor/optimizer_shadow.py      (PR 2 — read-only logger)
+
+Plan doc: ~/Development/alpha-engine-docs/private/portfolio-optimizer-260511.md
+Pre-flip checklist (alpha-engine-config flag flip is a separate PR):
+  - PR 4 ad-hoc backtester cutover-gate verdict: pass (ROADMAP L156-157)
+  - ≥ 2-3 trading days of plausible shadow logs (today = N=1)
+  - Operator go-ahead
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import pandas as pd
+
+from executor.order_book import OrderBook
+
+logger = logging.getLogger(__name__)
+
+
+_OK_DIAG_STATUSES = ("optimal", "optimal_inaccurate")
+
+
+def is_log_usable(log: dict | None) -> bool:
+    """Return True iff the shadow log is safe to drive the order book.
+
+    Conservative gate: refuses anything but a clean ``optimal`` /
+    ``optimal_inaccurate`` solve. Callers fall back to an empty order
+    book on False (safer than wrong trades).
+    """
+    if not log:
+        return False
+    if log.get("shadow_status") != "ok":
+        return False
+    diag = log.get("diagnostics") or {}
+    if diag.get("status") not in _OK_DIAG_STATUSES:
+        return False
+    if not log.get("would_be_trades"):
+        return False
+    return True
+
+
+def apply_optimizer_targets_to_orderbook(
+    log: dict,
+    ob: OrderBook,
+    ibkr: Any,
+    current_positions: dict[str, dict],
+    price_histories: dict[str, pd.DataFrame] | None,
+    atr_map: dict[str, float],
+    strategy_config: dict,
+    vwap_map: dict[str, float | None],
+    signals_raw: dict | None,
+    predictions_by_ticker: dict[str, dict],
+    market_regime: str,
+    run_date: str,
+    predictions_date: str | None,
+) -> tuple[list[dict], list[dict]]:
+    """Translate optimizer ``would_be_trades`` into order-book records.
+
+    Returns ``(entries_added, exits_added)`` for the caller's summary /
+    health reporting. Dedup is handled by ``OrderBook.add_entry`` /
+    ``add_urgent_exit`` (by ticker / by ticker+signal respectively) so
+    callers may invoke this after the legacy exit path has already
+    populated urgent_exits — overlapping SELLs are skipped.
+    """
+    trades = log.get("would_be_trades") or []
+    signals_date = (
+        signals_raw.get("date", run_date) if signals_raw else run_date
+    )
+    signals_by_ticker = (signals_raw or {}).get("signals", {}) or {}
+
+    entries: list[dict] = []
+    exits: list[dict] = []
+
+    for trade in trades:
+        ticker = trade.get("ticker")
+        if not ticker:
+            continue
+        action = trade.get("action")
+        target_weight = float(trade.get("target_weight", 0.0))
+        delta_dollars = float(trade.get("delta_dollars", 0.0))
+
+        current_price = _get_current_price(ibkr, ticker)
+        if current_price is None or current_price <= 0:
+            logger.warning(
+                "optimizer_cutover: skip %s — no current_price from ibkr", ticker,
+            )
+            continue
+
+        if action == "BUY":
+            record = _build_entry_record(
+                ticker=ticker,
+                delta_dollars=delta_dollars,
+                target_weight=target_weight,
+                current_price=current_price,
+                atr_map=atr_map,
+                price_histories=price_histories,
+                strategy_config=strategy_config,
+                vwap_map=vwap_map,
+                signals_by_ticker=signals_by_ticker,
+                predictions_by_ticker=predictions_by_ticker,
+                market_regime=market_regime,
+                signals_date=signals_date,
+                predictions_date=predictions_date,
+            )
+            if record is None:
+                continue
+            ob.add_entry(record)
+            entries.append(record)
+        elif action == "SELL":
+            record = _build_urgent_exit_record(
+                ticker=ticker,
+                delta_dollars=delta_dollars,
+                target_weight=target_weight,
+                current_price=current_price,
+                current_positions=current_positions,
+                signals_by_ticker=signals_by_ticker,
+                predictions_by_ticker=predictions_by_ticker,
+                market_regime=market_regime,
+                signals_date=signals_date,
+                predictions_date=predictions_date,
+            )
+            if record is None:
+                continue
+            ob.add_urgent_exit(record)
+            exits.append(record)
+        else:
+            logger.warning(
+                "optimizer_cutover: unknown action %r for %s", action, ticker,
+            )
+
+    logger.info(
+        "optimizer_cutover: applied %d entries + %d urgent_exits from "
+        "%d would_be_trades",
+        len(entries), len(exits), len(trades),
+    )
+    return entries, exits
+
+
+def _get_current_price(ibkr: Any, ticker: str) -> float | None:
+    try:
+        return ibkr.get_current_price(ticker)
+    except Exception as e:
+        logger.warning("optimizer_cutover: get_current_price(%s) raised: %s", ticker, e)
+        return None
+
+
+def _build_entry_record(
+    ticker: str,
+    delta_dollars: float,
+    target_weight: float,
+    current_price: float,
+    atr_map: dict[str, float],
+    price_histories: dict[str, pd.DataFrame] | None,
+    strategy_config: dict,
+    vwap_map: dict[str, float | None],
+    signals_by_ticker: dict[str, dict],
+    predictions_by_ticker: dict[str, dict],
+    market_regime: str,
+    signals_date: str,
+    predictions_date: str | None,
+) -> dict | None:
+    if delta_dollars <= 0:
+        return None
+    shares = int(math.floor(delta_dollars / current_price))
+    if shares <= 0:
+        logger.info(
+            "optimizer_cutover: skip %s BUY — delta_dollars $%.2f < price $%.2f",
+            ticker, delta_dollars, current_price,
+        )
+        return None
+
+    ticker_atr_pct = float(atr_map.get(ticker, 0.0) or 0.0)
+    atr_dollar = ticker_atr_pct * current_price
+    pullback_atr_mult = strategy_config.get("intraday_pullback_atr_multiple", 1.0)
+    scaled_pullback_pct = ticker_atr_pct * pullback_atr_mult
+
+    sig = signals_by_ticker.get(ticker, {}) or {}
+    pred = predictions_by_ticker.get(ticker, {}) or {}
+
+    return {
+        "ticker": ticker,
+        "signal": "ENTER",
+        "signal_date": signals_date,
+        "prediction_date": predictions_date,
+        "shares": shares,
+        "current_price": current_price,
+        "dollar_size": round(delta_dollars, 2),
+        "position_pct": round(target_weight, 6),
+        "atr_value": atr_dollar,
+        "atr_pct": ticker_atr_pct,
+        "triggers": {
+            "pullback_pct": scaled_pullback_pct,
+            "pullback_atr_multiple": pullback_atr_mult,
+            "atr_pct": ticker_atr_pct,
+            "vwap_discount": strategy_config.get("intraday_vwap_discount_pct", 0.005),
+            "vwap": vwap_map.get(ticker) if vwap_map else None,
+            "support_level": None,
+        },
+        "research_score": sig.get("score"),
+        "research_conviction": sig.get("conviction"),
+        "research_rating": sig.get("rating"),
+        "sector": sig.get("sector"),
+        "sector_rating": sig.get("sector_rating"),
+        "market_regime": market_regime,
+        "price_target_upside": sig.get("price_target_upside"),
+        "thesis_summary": sig.get("thesis_summary"),
+        "predicted_direction": pred.get("predicted_direction"),
+        "prediction_confidence": pred.get("prediction_confidence"),
+        "predicted_alpha": pred.get("predicted_alpha"),
+        "stance": pred.get("stance"),
+        "catalyst_date": pred.get("catalyst_date"),
+        "sizing_source": "portfolio_optimizer",
+        "sizing_factors": {
+            "optimizer_target_weight": target_weight,
+            "optimizer_delta_dollars": round(delta_dollars, 2),
+        },
+    }
+
+
+def _build_urgent_exit_record(
+    ticker: str,
+    delta_dollars: float,
+    target_weight: float,
+    current_price: float,
+    current_positions: dict[str, dict],
+    signals_by_ticker: dict[str, dict],
+    predictions_by_ticker: dict[str, dict],
+    market_regime: str,
+    signals_date: str,
+    predictions_date: str | None,
+) -> dict | None:
+    pos = current_positions.get(ticker)
+    if not pos:
+        logger.info(
+            "optimizer_cutover: skip %s SELL — no current position",
+            ticker,
+        )
+        return None
+    shares_held = int(pos.get("shares", 0))
+    if shares_held <= 0:
+        return None
+
+    if target_weight <= 1e-9:
+        shares_to_sell = shares_held
+        signal_kind = "EXIT"
+        reason = "optimizer_target_zero"
+    else:
+        # Scale-down: sell |delta_dollars| / price, clipped to held.
+        shares_to_sell = int(math.floor(abs(delta_dollars) / current_price))
+        shares_to_sell = max(0, min(shares_to_sell, shares_held))
+        if shares_to_sell == 0:
+            return None
+        signal_kind = "REDUCE" if shares_to_sell < shares_held else "EXIT"
+        reason = (
+            "optimizer_scale_down" if signal_kind == "REDUCE"
+            else "optimizer_target_zero"
+        )
+
+    sig = signals_by_ticker.get(ticker, {}) or {}
+    pred = predictions_by_ticker.get(ticker, {}) or {}
+
+    return {
+        "ticker": ticker,
+        "signal": signal_kind,
+        "signal_date": signals_date,
+        "prediction_date": predictions_date,
+        "shares": shares_to_sell,
+        "reason": reason,
+        "detail": f"optimizer target_weight={target_weight:.4f}",
+        "research_score": sig.get("score"),
+        "research_conviction": sig.get("conviction"),
+        "research_rating": sig.get("rating"),
+        "sector_rating": pos.get("sector", ""),
+        "market_regime": market_regime,
+        "predicted_direction": pred.get("predicted_direction"),
+        "prediction_confidence": pred.get("prediction_confidence"),
+        "predicted_alpha": pred.get("predicted_alpha"),
+        "sizing_source": "portfolio_optimizer",
+    }

--- a/tests/test_optimizer_cutover.py
+++ b/tests/test_optimizer_cutover.py
@@ -1,0 +1,328 @@
+"""
+Unit tests for executor/optimizer_cutover.py — PR 5 of portfolio-optimizer arc.
+
+Covers:
+  - is_log_usable: happy + every failure mode (no log, sentinel, infeasible,
+    empty would_be_trades)
+  - apply_optimizer_targets_to_orderbook:
+      * BUY → entry record with optimizer-derived shares / dollars / triggers
+      * SELL @ target=0 → urgent_exit EXIT for full held shares
+      * SELL @ target>0 → urgent_exit REDUCE for partial shares
+      * SELL with no current position → skipped
+      * BUY where delta_dollars < price → skipped (shares=0)
+      * ibkr returns None → skipped
+      * Unknown action → skipped
+      * OrderBook dedup (already-pending entry / urgent_exit) — handled by OB
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from executor.optimizer_cutover import (
+    apply_optimizer_targets_to_orderbook,
+    is_log_usable,
+)
+from executor.order_book import OrderBook
+
+
+# ── is_log_usable ──────────────────────────────────────────────────────────────
+
+
+def test_is_log_usable_happy_path():
+    log = {
+        "shadow_status": "ok",
+        "diagnostics": {"status": "optimal"},
+        "would_be_trades": [{"ticker": "SPY", "action": "BUY"}],
+    }
+    assert is_log_usable(log) is True
+
+
+def test_is_log_usable_optimal_inaccurate_also_ok():
+    log = {
+        "shadow_status": "ok",
+        "diagnostics": {"status": "optimal_inaccurate"},
+        "would_be_trades": [{"ticker": "SPY", "action": "BUY"}],
+    }
+    assert is_log_usable(log) is True
+
+
+def test_is_log_usable_none_log():
+    assert is_log_usable(None) is False
+
+
+def test_is_log_usable_sentinel_failed():
+    log = {"shadow_status": "failed", "error": "TypeError"}
+    assert is_log_usable(log) is False
+
+
+def test_is_log_usable_infeasible_diag():
+    log = {
+        "shadow_status": "ok",
+        "diagnostics": {"status": "infeasible_fallback"},
+        "would_be_trades": [{"ticker": "SPY"}],
+    }
+    assert is_log_usable(log) is False
+
+
+def test_is_log_usable_empty_trades():
+    log = {
+        "shadow_status": "ok",
+        "diagnostics": {"status": "optimal"},
+        "would_be_trades": [],
+    }
+    assert is_log_usable(log) is False
+
+
+# ── apply_optimizer_targets_to_orderbook ───────────────────────────────────────
+
+
+def _make_ibkr(prices: dict[str, float]) -> MagicMock:
+    ibkr = MagicMock()
+    ibkr.get_current_price.side_effect = lambda t: prices.get(t)
+    return ibkr
+
+
+def _baseline_kwargs(ob: OrderBook, ibkr, **overrides):
+    base = {
+        "ob": ob,
+        "ibkr": ibkr,
+        "current_positions": {},
+        "price_histories": None,
+        "atr_map": {},
+        "strategy_config": {
+            "intraday_pullback_atr_multiple": 1.5,
+            "intraday_vwap_discount_pct": 0.005,
+        },
+        "vwap_map": {},
+        "signals_raw": {"date": "2026-05-13", "signals": {}},
+        "predictions_by_ticker": {},
+        "market_regime": "neutral",
+        "run_date": "2026-05-13",
+        "predictions_date": "2026-05-13",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_buy_produces_entry_with_optimizer_sizing():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"SPY": 500.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "SPY",
+            "action": "BUY",
+            "delta_dollars": 856_069.23,
+            "delta_weight": 0.83,
+            "target_weight": 0.83,
+            "current_weight": 0.0,
+        }],
+    }
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr, atr_map={"SPY": 0.012}),
+    )
+    assert len(entries) == 1
+    assert len(exits) == 0
+    e = entries[0]
+    assert e["ticker"] == "SPY"
+    assert e["signal"] == "ENTER"
+    assert e["shares"] == 1712  # floor(856069.23 / 500)
+    assert e["dollar_size"] == pytest.approx(856_069.23, rel=1e-6)
+    assert e["position_pct"] == pytest.approx(0.83)
+    assert e["sizing_source"] == "portfolio_optimizer"
+    assert e["sizing_factors"]["optimizer_target_weight"] == 0.83
+    assert e["atr_pct"] == 0.012
+    assert e["triggers"]["pullback_atr_multiple"] == 1.5
+
+
+def test_sell_target_zero_produces_full_exit():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"CME": 200.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "CME",
+            "action": "SELL",
+            "delta_dollars": -30_877.45,
+            "delta_weight": -0.02994,
+            "target_weight": 0.0,
+            "current_weight": 0.02994,
+        }],
+    }
+    current_positions = {"CME": {"shares": 154, "sector": "Financials"}}
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr, current_positions=current_positions),
+    )
+    assert len(entries) == 0
+    assert len(exits) == 1
+    x = exits[0]
+    assert x["ticker"] == "CME"
+    assert x["signal"] == "EXIT"
+    assert x["shares"] == 154  # full held
+    assert x["reason"] == "optimizer_target_zero"
+    assert x["sizing_source"] == "portfolio_optimizer"
+
+
+def test_sell_partial_produces_reduce():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"NVDA": 100.0})
+    # Held 1000 shares @ $100 = $100k; scale down to $60k (sell $40k = 400 shares).
+    log = {
+        "would_be_trades": [{
+            "ticker": "NVDA",
+            "action": "SELL",
+            "delta_dollars": -40_000.0,
+            "delta_weight": -0.04,
+            "target_weight": 0.06,
+            "current_weight": 0.10,
+        }],
+    }
+    current_positions = {"NVDA": {"shares": 1000, "sector": "Information Technology"}}
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr, current_positions=current_positions),
+    )
+    assert len(exits) == 1
+    x = exits[0]
+    assert x["signal"] == "REDUCE"
+    assert x["shares"] == 400
+    assert x["reason"] == "optimizer_scale_down"
+
+
+def test_sell_no_position_is_skipped():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"AAA": 50.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "AAA",
+            "action": "SELL",
+            "delta_dollars": -5_000.0,
+            "target_weight": 0.0,
+            "current_weight": 0.0,
+        }],
+    }
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr),
+    )
+    assert entries == []
+    assert exits == []
+
+
+def test_buy_with_delta_below_price_is_skipped():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"BRK.A": 600_000.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "BRK.A",
+            "action": "BUY",
+            "delta_dollars": 100.0,  # < 1 share
+            "target_weight": 0.001,
+            "current_weight": 0.0,
+        }],
+    }
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr),
+    )
+    assert entries == []
+    assert exits == []
+
+
+def test_ibkr_returns_none_skips_ticker():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({})  # all prices unknown
+    log = {
+        "would_be_trades": [
+            {"ticker": "FOO", "action": "BUY", "delta_dollars": 1000, "target_weight": 0.01, "current_weight": 0},
+            {"ticker": "BAR", "action": "SELL", "delta_dollars": -1000, "target_weight": 0, "current_weight": 0.01},
+        ],
+    }
+    current_positions = {"BAR": {"shares": 10, "sector": "X"}}
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr, current_positions=current_positions),
+    )
+    assert entries == []
+    assert exits == []
+
+
+def test_unknown_action_is_skipped():
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"FOO": 50.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "FOO", "action": "HOLD",
+            "delta_dollars": 0, "target_weight": 0.01, "current_weight": 0.01,
+        }],
+    }
+    entries, exits = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(ob, ibkr),
+    )
+    assert entries == []
+    assert exits == []
+
+
+def test_orderbook_dedup_on_duplicate_buy():
+    """OrderBook dedups entries by ticker — a re-call with same ticker no-ops."""
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"SPY": 500.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "SPY", "action": "BUY",
+            "delta_dollars": 100_000.0, "target_weight": 0.10, "current_weight": 0.0,
+        }],
+    }
+    # First call adds.
+    entries1, _ = apply_optimizer_targets_to_orderbook(log=log, **_baseline_kwargs(ob, ibkr))
+    assert len(entries1) == 1
+    # Second call: our returned list still has the record (we don't read OB
+    # back), but OrderBook.add_entry skips the duplicate. The OB state has 1.
+    apply_optimizer_targets_to_orderbook(log=log, **_baseline_kwargs(ob, ibkr))
+    assert len(ob._data.get("approved_entries", [])) == 1
+
+
+def test_research_metadata_propagated_to_entry():
+    """Signals + predictions metadata should flow through to the entry record."""
+    ob = OrderBook(data={"date": "2026-05-13"})
+    ibkr = _make_ibkr({"CAH": 100.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "CAH", "action": "BUY",
+            "delta_dollars": 56_693.12, "target_weight": 0.07, "current_weight": 0.015,
+        }],
+    }
+    signals_raw = {
+        "date": "2026-05-13",
+        "signals": {
+            "CAH": {
+                "score": 78.5, "conviction": "rising", "rating": "BUY",
+                "sector": "Health Care", "sector_rating": "overweight",
+                "price_target_upside": 0.18,
+            },
+        },
+    }
+    predictions_by_ticker = {
+        "CAH": {
+            "predicted_direction": "UP", "prediction_confidence": 0.62,
+            "predicted_alpha": 0.005, "stance": "quality",
+        },
+    }
+    entries, _ = apply_optimizer_targets_to_orderbook(
+        log=log,
+        **_baseline_kwargs(
+            ob, ibkr,
+            signals_raw=signals_raw,
+            predictions_by_ticker=predictions_by_ticker,
+        ),
+    )
+    e = entries[0]
+    assert e["research_score"] == 78.5
+    assert e["research_conviction"] == "rising"
+    assert e["sector"] == "Health Care"
+    assert e["predicted_direction"] == "UP"
+    assert e["stance"] == "quality"


### PR DESCRIPTION
## Summary

PR 5 of the portfolio-optimizer-260511 arc. Adds the `use_portfolio_optimizer` flag (default **false**) that, when true, routes the order book through the constrained MVO optimizer's `would_be_trades` instead of the legacy 1/n `_plan_entries` path.

- New module `executor/optimizer_cutover.py` translates `would_be_trades` → `ob.add_entry` / `ob.add_urgent_exit` records that match the daemon's expected shape (preserves daemon technical triggers, ATR, research metadata).
- `executor/main.py` skips `_plan_entries` when the flag is true; keeps `_plan_exits_and_reduces` + strategy_exits + drawdown forced exits intact as protective overrides.
- Shadow wrapper still runs (the cutover reuses its log dict — no double-solve).
- On optimizer failure in cutover mode: order book is left empty, loud `logger.error`, operator must investigate. **No silent fallback to the legacy path** — `legacy_sizer_fallback` deferred to a later PR per the plan doc.

## Why now

Today's shadow log (`predictor/optimizer_shadow/2026-05-13.json`) was the first clean N=1 production run after yesterday's #165 fix. Per plan doc `~/Development/alpha-engine-docs/private/portfolio-optimizer-260511.md` PR 5 section + ROADMAP L2206 (P1: portfolio-optimizer PR 5+6 gated), this PR ships the **code** for cutover. The actual flag flip is a separate `alpha-engine-config` PR gated on the pre-flip checklist below.

## Pre-flip checklist (NOT in scope for this PR — config-side flip is separate)

- [ ] Ad-hoc backtester cutover-gate verdict: `pass` (ROADMAP L156-157, `python backtest.py --mode all --date 2026-05-13`, acceptance at `s3://alpha-engine-research/backtest/2026-05-13/portfolio_optimizer_gate.json`)
- [ ] ≥ 2-3 trading days of plausible shadow logs (today = N=1; tomorrow Thu = N=2; Fri = N=3)
- [ ] No optimizer infeasibility errors (today: `diagnostics.status: optimal` ✓)
- [ ] Operator explicit go-ahead

## Composition

- **Skipped when flag=true:** `_plan_entries` (1/n + position_sizer + risk_guard on entries). Optimizer's `eligibility` mask already mirrors risk_guard's filters (already-in-portfolio / score / GBM veto) and `stance_caps` mirror `max_position_pct`.
- **Preserved when flag=true:** all exits, all stops, all health/health-status writes, all shadow-book logging of legacy-path blocks (when not flag=true).
- **Out of scope:** SGOV/BIL physical sleeve plumbing (cash is logical), removing `position_sizer.py` / `risk_guard.py` (PR 6, after one-quarter parallel observation), `legacy_sizer_fallback` config.

## Test plan

- [x] 15 new unit tests in `tests/test_optimizer_cutover.py` cover: `is_log_usable` happy/sentinel/infeasible/empty-trades; BUY → entry with optimizer-derived `shares`/`dollar_size`/`position_pct`/triggers; SELL @ target=0 → full EXIT; SELL @ target>0 → partial REDUCE; no-position SELL skipped; sub-share BUY skipped; `ibkr.get_current_price` None skipped; unknown action skipped; OrderBook dedup-by-ticker honored; signals + predictions metadata propagated.
- [x] Full executor suite green: 776 → 791 tests, all pass.
- [x] Pre-push dry-run hook (`python executor/main.py --dry-run`) passed.
- [ ] After merge + alpha-engine-config flag flip: smoke `ae-trading "cd ~/alpha-engine && source .venv/bin/activate && python executor/main.py --dry-run"` to confirm the cutover path runs end-to-end against live shadow input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)