### PR TITLE
docs(config): add descriptive-only banner to risk.yaml.example

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -1,3 +1,19 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# DESCRIPTIVE / DOCUMENTATION ONLY
+#
+# Production reads the live config from alpha-engine-config/executor/risk.yaml
+# at runtime (boot-pull syncs it to the trading EC2). Edits to this file
+# affect ONLY:
+#   1. New-environment bootstrap (setup-trading-ec2.sh seeds config/risk.yaml
+#      from this template if no local override exists), and
+#   2. Public-repo schema documentation (this is the readable spec for the
+#      executor's config surface).
+#
+# Edits here have ZERO effect on the live system. To change a runtime value
+# or add a flag that needs to take effect, the change MUST land in
+# alpha-engine-config (separate private repo).
+# ─────────────────────────────────────────────────────────────────────────────
+
 # Alpha Engine — Executor Risk Parameters
 # Copy this file to config/risk.yaml and customise all values below.
 # config/risk.yaml is gitignored and should never be committed.


### PR DESCRIPTION
## Summary

Adds a banner to the top of `config/risk.yaml.example` warning that edits here have ZERO runtime effect — production reads `alpha-engine-config/executor/risk.yaml`. The `.example` file is descriptive-only: it bootstraps new environments via `setup-trading-ec2.sh` + serves as public-repo schema docs for the executor's config surface.

Motivated by a recurring lapse pattern (memory `feedback_yaml_example_descriptive_only_live_config_in_config_repo` already captures the rule; I keep editing `.example` files anyway). Putting the banner at the top of each file makes the warning impossible to miss.

Companion banners in 5 other repos shipping as separate PRs.

## Test plan

- [x] YAML still parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] No runtime behaviour change — banner is YAML comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)