### PR TITLE
fix(decision_capture): SUPPRESS flag to short-circuit capture in backtester sweep

### DIFF
--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -52,14 +52,25 @@ logger = logging.getLogger(__name__)
 
 
 _ENV_VAR = "ALPHA_ENGINE_DECISION_CAPTURE_ENABLED"
+_SUPPRESS_ENV_VAR = "ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS"
 
 
 def is_decision_capture_enabled() -> bool:
-    """Read the env var fresh on each call (allows toggling in tests).
+    """Read the env vars fresh on each call (allows toggling in tests).
 
     Returns True iff ``ALPHA_ENGINE_DECISION_CAPTURE_ENABLED`` is set to
-    ``"true"`` / ``"1"`` / ``"yes"`` (case-insensitive). Default off.
+    ``"true"`` / ``"1"`` / ``"yes"`` (case-insensitive) AND
+    ``ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS`` is NOT truthy. The
+    suppress flag is set by alpha-engine-backtester's spot_backtest.sh
+    on the spot instance so the simulation hot loop (param_sweep ×
+    N_dates × N_positions) doesn't emit ~50k-200k per-decision S3 PUTs
+    that blow the simulation_pipeline watchdog. Capture artifacts exist
+    for production observability — they have no semantic meaning inside
+    the sweep, and the sweep can't afford their cost. Default both off
+    (capture disabled, suppress not asserted).
     """
+    if os.environ.get(_SUPPRESS_ENV_VAR, "").lower() in ("true", "1", "yes"):
+        return False
     return os.environ.get(_ENV_VAR, "").lower() in ("true", "1", "yes")
 
 

--- a/tests/test_decision_capture.py
+++ b/tests/test_decision_capture.py
@@ -128,6 +128,30 @@ class TestFeatureFlag:
         assert result is None
         s3.put_object.assert_not_called()
 
+    def test_suppress_flag_overrides_enabled(self, monkeypatch):
+        """ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS=true forces capture off
+        even when ALPHA_ENGINE_DECISION_CAPTURE_ENABLED=true. Used by the
+        backtester spot to keep the simulation hot loop from emitting
+        50k-200k per-decision S3 PUTs (sweep can't afford their cost +
+        artifacts are observability for prod, not sweep semantics)."""
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        for v in ("true", "True", "1", "yes", "YES"):
+            monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS", v)
+            assert is_decision_capture_enabled() is False, (
+                f"suppress={v!r} should force capture off even with enable=true"
+            )
+
+    def test_suppress_falsy_or_unset_does_not_disable(self, monkeypatch):
+        """Falsy or absent SUPPRESS leaves the enable flag in charge."""
+        monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_ENABLED", "true")
+        for v in ("false", "0", "no", "", "off"):
+            monkeypatch.setenv("ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS", v)
+            assert is_decision_capture_enabled() is True, (
+                f"suppress={v!r} should not disable when enable=true"
+            )
+        monkeypatch.delenv("ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS", raising=False)
+        assert is_decision_capture_enabled() is True
+
 
 # ── Trigger-kind classifier ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Saturday SF Backtester `adhoc-skipto-backtester-20260513-2333` hit `simulation_pipeline` 2700s watchdog. Faulthandler trace showed the main thread hung in `capture_position_sizer` → S3 `put_object` inside `decide_entries`, called per ticker per date per param_sweep combo (~50k–200k S3 PUTs per sweep).
- Added one-way kill switch `ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS`. When truthy, `is_decision_capture_enabled()` returns False regardless of the upstream `ENABLED` flag. Trading EC2 doesn't set SUPPRESS → production capture path unchanged.
- Pairs with `alpha-engine-backtester` PR that exports `ALPHA_ENGINE_DECISION_CAPTURE_SUPPRESS=true` in `spot_backtest.sh` ENV_SOURCE so the spot's Python process always sees it.

## Test plan
- [x] Local: `pytest tests/test_decision_capture.py::TestFeatureFlag` → 6/6 pass (2 new tests: suppress overrides enabled / suppress falsy or unset doesn't disable)
- [ ] CI on this PR
- [ ] After both PRs merge: re-fire SF skipping to Backtester, watch simulation_pipeline complete inside its 2700s budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)