### PR TITLE
feat(regime): Stage D' Wire 2 — position sizing regime multiplier

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -105,6 +105,19 @@ coverage_derate_floor: 0.25      # never derate below 25% of normal size (backte
 coverage_admission_enabled: true        # hard-refuse buy_candidates below min_coverage_for_admission
 min_coverage_for_admission: 0.30        # feature-coverage floor for NEW entries (backtester-tunable: [0.20, 0.30, 0.50])
 
+# ── Regime-conditional sizing (Stage D' Wire 2, regime-v3-260514) ───────────
+# Off by default; ships dormant. When ON, position_sizer multiplies the raw
+# weight by ``1.0 + intensity_z * regime_sizing_scale`` clamped to
+# ``[regime_sizing_floor, regime_sizing_ceil]``. intensity_z comes from
+# alpha-engine-predictor's regime substrate (s3://.../regime/latest.json);
+# follows risk-on convention (positive=risk-on → upweight, negative=risk-off
+# → downweight). Operator flips ``regime_sizing_enabled: true`` after 4+
+# weeks of substrate observation via the dashboard's Regime page.
+regime_sizing_enabled: false     # gate-off by default; flip after observation window
+regime_sizing_scale: 0.05        # per-σ sensitivity; +1σ → 1.05× tilt
+regime_sizing_floor: 0.70        # clamp lower bound on the multiplier
+regime_sizing_ceil:  1.30        # clamp upper bound on the multiplier
+
 # ── IBKR connection ─────────────────────────────────────────────────────────
 ibkr_host: "127.0.0.1"
 ibkr_port: 4002                  # 4002 = paper trading, 4001 = live

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -401,6 +401,7 @@ def decide_entries(
     earnings_by_ticker: dict,
     run_date: str,
     predictions_date: str | None = None,
+    regime_intensity_z: float | None = None,
 ) -> EntryPlan:
     """Pure decision pipeline for ENTER signals.
 
@@ -716,6 +717,7 @@ def decide_entries(
             days_to_earnings=earnings_by_ticker.get(ticker),
             feature_coverage=coverage_map.get(ticker),
             stance=pred_data.get("stance"),
+            regime_intensity_z=regime_intensity_z,
         )
 
         # Emit executor:position_sizer DecisionArtifact (L2308 PR 2).

--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -374,6 +374,7 @@ def build_position_sizer_payload(
         "earnings_adj": sizing_result.get("earnings_adj"),
         "coverage_adj": sizing_result.get("coverage_adj"),
         "stance_adj": sizing_result.get("stance_adj"),
+        "regime_adj": sizing_result.get("regime_adj"),
         "sized_outcome": sized_outcome,
         "sized_outcome_reason": sized_outcome_reason,
     }

--- a/executor/main.py
+++ b/executor/main.py
@@ -433,6 +433,7 @@ def _plan_entries(
     dry_run: bool,
     simulate: bool,
     predictions_date: str | None = None,
+    regime_intensity_z: float | None = None,
 ) -> tuple[int, list[dict], list[dict], list[dict]]:
     """Live-shell wrapper around ``executor.deciders.decide_entries``.
 
@@ -485,6 +486,7 @@ def _plan_entries(
         earnings_by_ticker=earnings_by_ticker,
         run_date=run_date,
         predictions_date=predictions_date,
+        regime_intensity_z=regime_intensity_z,
     )
 
     # Dispatch decisions to side-effecting layer.
@@ -1208,6 +1210,33 @@ def run(
             blocked_entries: list[dict] = []
             plan_risk_events: list[dict] = []
         else:
+            # Stage D' Wire 2: optionally load regime substrate so
+            # position_sizer can apply a regime-conditional multiplier.
+            # Gated by config so the read is skipped entirely when the
+            # wire is off — avoids a per-cycle S3 GET when the feature
+            # is disabled. Returns None when substrate is unavailable
+            # (fresh deploy, sidecar miss, etc.) — sizing falls back to
+            # 1.0× under the helper's guard.
+            regime_intensity_z = None
+            if config.get("regime_sizing_enabled", False) and not simulate:
+                try:
+                    from executor.signal_reader import (
+                        extract_intensity_z,
+                        read_regime_substrate,
+                    )
+                    substrate = read_regime_substrate(signals_bucket)
+                    regime_intensity_z = extract_intensity_z(substrate)
+                    logger.info(
+                        "regime_sizing_enabled=True | intensity_z=%s",
+                        f"{regime_intensity_z:.3f}" if regime_intensity_z is not None else "None",
+                    )
+                except Exception as _rs_err:
+                    logger.warning(
+                        "regime substrate read failed (%s) — falling back to 1.0× sizing",
+                        _rs_err,
+                    )
+                    regime_intensity_z = None
+
             n_entered, entry_orders, blocked_entries, plan_risk_events = _plan_entries(
                 enter_signals=enter_signals,
                 signals_raw=signals_raw,
@@ -1232,6 +1261,7 @@ def run(
                 dry_run=dry_run,
                 simulate=simulate,
                 predictions_date=predictions_date,
+                regime_intensity_z=regime_intensity_z,
             )
         orders.extend(entry_orders)
 

--- a/executor/position_sizer.py
+++ b/executor/position_sizer.py
@@ -24,6 +24,37 @@ _DEFAULT_SECTOR_ADJ = {
 }
 
 
+def regime_conditional_size_multiplier(
+    intensity_z: float | None,
+    *,
+    scale: float = 0.05,
+    floor: float = 0.70,
+    ceil: float = 1.30,
+) -> float:
+    """Map regime composite intensity_z to a sizing multiplier.
+
+    intensity_z follows the risk-on convention from the predictor's
+    regime substrate (alpha-engine-predictor/regime/composite.py): positive
+    values = risk-on conditions, negative = risk-off. Sizing follows the
+    same direction — upweight in risk-on, downweight in risk-off.
+
+    Linear with clamping: ``1.0 + intensity_z * scale`` then clamped to
+    ``[floor, ceil]``. ``scale=0.05`` means a +1σ risk-on reading yields
+    a 1.05× tilt, a -1σ risk-off reading a 0.95× tilt — small enough
+    that it composes with the other (multiplicative) adjustments without
+    dominating, large enough to register vs sector_adj (1.05/0.85).
+    Clamp prevents pathological tails from blowing past max_position_pct.
+
+    Returns 1.0 when ``intensity_z`` is None (substrate unavailable) —
+    preserves legacy behavior so a substrate read failure does not
+    silently change sizing.
+    """
+    if intensity_z is None:
+        return 1.0
+    raw = 1.0 + float(intensity_z) * float(scale)
+    return max(float(floor), min(float(ceil), raw))
+
+
 def compute_position_size(
     ticker: str,
     portfolio_nav: float,
@@ -40,6 +71,7 @@ def compute_position_size(
     days_to_earnings: int | None = None,
     feature_coverage: float | None = None,
     stance: str | None = None,
+    regime_intensity_z: float | None = None,
 ) -> dict:
     """
     Compute position size for a new ENTER order.
@@ -171,11 +203,28 @@ def compute_position_size(
     else:
         coverage_adj = 1.0
 
+    # Regime sizing adjustment (Stage D' Wire 2, regime-v3-260514). Reads
+    # the composite intensity_z from the regime substrate (predictor-side,
+    # see regime/composite.py — positive=risk-on, negative=risk-off).
+    # Default OFF so the wire ships dormant; operator flips ON via
+    # risk.yaml ``regime_sizing_enabled`` after observing 4 weeks of
+    # SF runs with intensity_z surfaced through the dashboard. Composes
+    # multiplicatively with the other adjustments.
+    if config.get("regime_sizing_enabled", False):
+        regime_adj = regime_conditional_size_multiplier(
+            regime_intensity_z,
+            scale=config.get("regime_sizing_scale", 0.05),
+            floor=config.get("regime_sizing_floor", 0.70),
+            ceil=config.get("regime_sizing_ceil", 1.30),
+        )
+    else:
+        regime_adj = 1.0
+
     max_pct = config.get("max_position_pct", 0.05)
     raw_weight = (base_weight * sector_adj * conviction_adj * upside_adj
                   * drawdown_multiplier * atr_adj * confidence_adj
                   * staleness_adj * earnings_adj * coverage_adj
-                  * stance_adj)
+                  * stance_adj * regime_adj)
     position_weight = min(raw_weight, max_pct)
 
     # ATR volatility cap: ensure ATR constraint is not overridden by other
@@ -198,7 +247,7 @@ def compute_position_size(
         f"dd_mult={drawdown_multiplier} atr_adj={atr_adj} "
         f"confidence_adj={confidence_adj} staleness_adj={staleness_adj} "
         f"earnings_adj={earnings_adj} coverage_adj={coverage_adj} "
-        f"stance_adj={stance_adj} "
+        f"stance_adj={stance_adj} regime_adj={regime_adj} "
         f"→ {position_weight:.3f} NAV = ${dollar_size:.0f} = {shares} shares"
     )
 
@@ -216,4 +265,5 @@ def compute_position_size(
         "earnings_adj": earnings_adj,
         "coverage_adj": coverage_adj,
         "stance_adj": stance_adj,
+        "regime_adj": regime_adj,
     }

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -11,9 +11,52 @@ from datetime import date, timedelta
 import boto3
 from botocore.exceptions import ClientError
 
+from alpha_engine_lib.eval_artifacts import load_latest_eval_artifact
 from alpha_engine_lib.universe import filter_to_universe
 
 logger = logging.getLogger(__name__)
+
+REGIME_SUBSTRATE_PREFIX = "regime"
+
+
+def read_regime_substrate(s3_bucket: str) -> dict | None:
+    """Read the latest regime substrate artifact via canonical sidecar.
+
+    Wraps ``alpha_engine_lib.eval_artifacts.load_latest_eval_artifact``
+    pointed at ``s3://{bucket}/regime/latest.json``. Returns the parsed
+    payload dict (composite.intensity_z, hmm.posterior, bocpd.run_length_z,
+    guardrails, run_id) or ``None`` if the artifact is unavailable.
+
+    Substrate is produced weekly by alpha-engine-predictor's regime
+    Lambda (Saturday SF ``RegimeSubstrate`` state) — see
+    ``regime-v3-260514.md`` §6 Stage A. Returning None on read failure
+    is the contract: the executor's regime-aware sizing defaults to a
+    1.0× multiplier when intensity_z is unavailable (legacy behavior
+    preserved).
+    """
+    s3 = boto3.client("s3")
+    return load_latest_eval_artifact(
+        s3, bucket=s3_bucket, prefix=REGIME_SUBSTRATE_PREFIX,
+    )
+
+
+def extract_intensity_z(substrate: dict | None) -> float | None:
+    """Pull ``composite.intensity_z`` out of a regime substrate payload.
+
+    Returns ``None`` if ``substrate`` is None, missing the ``composite``
+    block, or its ``intensity_z`` is non-numeric. The substrate writer
+    (predictor regime/substrate.py) guarantees the shape on success;
+    this helper just defends against schema drift + None propagation.
+    """
+    if not isinstance(substrate, dict):
+        return None
+    composite = substrate.get("composite")
+    if not isinstance(composite, dict):
+        return None
+    val = composite.get("intensity_z")
+    if isinstance(val, (int, float)) and not isinstance(val, bool):
+        return float(val)
+    return None
 
 
 def read_predictions(s3_bucket: str) -> tuple[dict[str, dict], str | None]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,10 @@ requests~=2.32
 # model_metadata + full_prompt_context, enabling deterministic executor
 # decision capture (L2308 — executor:entry_triggers / position_sizer /
 # risk_guard / exit_rules artifacts emitted from daemon + planner).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.14.0
+# v0.16.0 adds load_latest_eval_artifact + list_eval_artifacts for the
+# canonical eval-artifact partition shape (YYMMDDHHMM run_id + sidecar);
+# required by signal_reader.read_regime_substrate (Stage D' Wire 2).
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.16.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/tests/test_regime_stage_d_prime_wire_2_position_sizing.py
+++ b/tests/test_regime_stage_d_prime_wire_2_position_sizing.py
@@ -1,0 +1,395 @@
+"""Stage D' Wire 2 — position sizing regime multiplier.
+
+Pins three contracts:
+
+1. ``regime_conditional_size_multiplier`` math: linear ``1 + z*scale``
+   clamped to ``[floor, ceil]``; ``None`` → 1.0.
+2. ``compute_position_size`` honors ``regime_sizing_enabled`` config
+   flag; default OFF (1.0× regime_adj when omitted).
+3. ``read_regime_substrate`` + ``extract_intensity_z`` round-trip on
+   the canonical eval-artifact payload shape; tolerate None / malformed.
+
+See ``~/Development/alpha-engine-docs/private/regime-v3-260514.md``
+§6 Stage D' Wire 2 for the architectural framing.
+"""
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from unittest.mock import patch
+
+import pytest
+
+from executor.position_sizer import (
+    compute_position_size,
+    regime_conditional_size_multiplier,
+)
+from executor.signal_reader import (
+    REGIME_SUBSTRATE_PREFIX,
+    extract_intensity_z,
+    read_regime_substrate,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# regime_conditional_size_multiplier — pure math
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestRegimeConditionalSizeMultiplier:
+    def test_none_returns_unity(self):
+        """Substrate-unavailable path: regime_intensity_z=None → 1.0."""
+        assert regime_conditional_size_multiplier(None) == 1.0
+
+    def test_zero_intensity_returns_unity(self):
+        """Neutral regime (z=0) → 1.0 (centered at neutral)."""
+        assert regime_conditional_size_multiplier(0.0) == 1.0
+
+    def test_positive_intensity_upweights(self):
+        """Risk-on (z>0) → multiplier > 1.0."""
+        # 1.0 + 1.0 * 0.05 = 1.05
+        assert regime_conditional_size_multiplier(1.0) == pytest.approx(1.05)
+
+    def test_negative_intensity_downweights(self):
+        """Risk-off (z<0) → multiplier < 1.0."""
+        # 1.0 + (-1.0) * 0.05 = 0.95
+        assert regime_conditional_size_multiplier(-1.0) == pytest.approx(0.95)
+
+    def test_clamped_to_ceil(self):
+        """Extreme positive z → clamped to ceil (default 1.30)."""
+        # 1.0 + 10.0 * 0.05 = 1.50, clamped to 1.30
+        assert regime_conditional_size_multiplier(10.0) == 1.30
+
+    def test_clamped_to_floor(self):
+        """Extreme negative z → clamped to floor (default 0.70)."""
+        # 1.0 + (-10.0) * 0.05 = 0.50, clamped to 0.70
+        assert regime_conditional_size_multiplier(-10.0) == 0.70
+
+    def test_custom_scale(self):
+        """``scale`` parameter controls sensitivity per σ."""
+        assert regime_conditional_size_multiplier(1.0, scale=0.10) == pytest.approx(1.10)
+        assert regime_conditional_size_multiplier(-1.0, scale=0.10) == pytest.approx(0.90)
+
+    def test_custom_floor_and_ceil(self):
+        """``floor`` and ``ceil`` parameters tighten the clamp."""
+        # ceil=1.1 clamps the +5σ upside down
+        assert regime_conditional_size_multiplier(5.0, ceil=1.1) == 1.1
+        # floor=0.9 clamps the -5σ downside up
+        assert regime_conditional_size_multiplier(-5.0, floor=0.9) == 0.9
+
+    def test_int_intensity_z_coerced_to_float(self):
+        """Integer intensity_z values still work (defensive type coercion)."""
+        # 1.0 + 2 * 0.05 = 1.10
+        assert regime_conditional_size_multiplier(2) == pytest.approx(1.10)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# compute_position_size integration — regime multiplier stacks in
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _baseline_config(**overrides):
+    """Minimal config that isolates regime_adj — disables all the other
+    optional adjustments so test arithmetic reads cleanly."""
+    cfg = {
+        "max_position_pct": 0.10,
+        "conviction_decline_adj": 0.70,
+        "min_price_target_upside": 0.05,
+        "upside_fail_adj": 0.70,
+        "min_position_dollar": 0,
+        "sector_adj": {
+            "overweight": 1.05,
+            "market_weight": 1.00,
+            "underweight": 0.85,
+        },
+        "atr_sizing_enabled": False,
+        "confidence_sizing_enabled": False,
+        "staleness_discount_enabled": False,
+        "earnings_sizing_enabled": False,
+        "coverage_sizing_enabled": False,
+        "stance_sizing_enabled": False,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _baseline_signal(**overrides):
+    sig = {"score": 80, "conviction": "stable", "price_target_upside": 0.15}
+    sig.update(overrides)
+    return sig
+
+
+class TestComputePositionSizeRegimeAdj:
+    def test_regime_disabled_by_default(self):
+        """Without ``regime_sizing_enabled`` set, regime_adj is 1.0 even
+        when a non-trivial intensity_z is passed — gate is OFF by default."""
+        # 25 entries → base 0.04, no other adjustments, max=0.10
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(),
+            regime_intensity_z=2.0,  # would multiply by 1.10 if enabled
+        )
+        assert result["regime_adj"] == 1.0
+        assert result["position_pct"] == pytest.approx(0.04)
+
+    def test_regime_enabled_with_positive_z_upweights(self):
+        """Risk-on regime + flag ON → position grows by scale fraction."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=1.0,
+        )
+        # 0.04 * 1.05 = 0.042
+        assert result["regime_adj"] == pytest.approx(1.05)
+        assert result["position_pct"] == pytest.approx(0.042)
+
+    def test_regime_enabled_with_negative_z_downweights(self):
+        """Risk-off regime + flag ON → position shrinks."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=-2.0,
+        )
+        # 1.0 + -2.0 * 0.05 = 0.90; 0.04 * 0.90 = 0.036
+        assert result["regime_adj"] == pytest.approx(0.90)
+        assert result["position_pct"] == pytest.approx(0.036)
+
+    def test_regime_none_intensity_falls_back_to_unity(self):
+        """Substrate unavailable (intensity_z=None) → regime_adj=1.0
+        even with flag ON. Preserves legacy behavior when substrate
+        loader returns None (sidecar miss, fresh deploy, etc.)."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=None,
+        )
+        assert result["regime_adj"] == 1.0
+        assert result["position_pct"] == pytest.approx(0.04)
+
+    def test_regime_clamped_at_ceiling_under_extreme_z(self):
+        """Extreme positive intensity_z still respects the ceil clamp."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=20.0,  # would give 2.0× sans clamp
+        )
+        # Clamped to ceil=1.30; 0.04 * 1.30 = 0.052
+        assert result["regime_adj"] == 1.30
+        assert result["position_pct"] == pytest.approx(0.052)
+
+    def test_regime_clamped_at_floor_under_extreme_negative_z(self):
+        """Extreme negative intensity_z still respects the floor clamp."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=-20.0,  # would give 0.0× sans clamp
+        )
+        # Clamped to floor=0.70; 0.04 * 0.70 = 0.028
+        assert result["regime_adj"] == 0.70
+        assert result["position_pct"] == pytest.approx(0.028)
+
+    def test_regime_stacks_multiplicatively_with_sector_adj(self):
+        """regime_adj composes with sector_adj — both apply in product."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="overweight",  # 1.05x
+            current_price=150.0,
+            config=_baseline_config(regime_sizing_enabled=True),
+            regime_intensity_z=1.0,  # 1.05x
+        )
+        # 0.04 * 1.05 (sector) * 1.05 (regime) = 0.0441
+        assert result["sector_adj"] == 1.05
+        assert result["regime_adj"] == pytest.approx(1.05)
+        assert result["position_pct"] == pytest.approx(0.0441)
+
+    def test_regime_adj_in_returned_payload(self):
+        """``regime_adj`` is always emitted in the result dict — schema
+        contract for downstream observability (decision_capture, etc.)."""
+        enter_signals = [{"ticker": "AAPL"}]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(),
+        )
+        # Flag off, intensity_z not provided — schema key still present.
+        assert "regime_adj" in result
+        assert result["regime_adj"] == 1.0
+
+    def test_custom_regime_curve_params_from_config(self):
+        """``regime_sizing_scale`` / ``_floor`` / ``_ceil`` config keys
+        flow through to the multiplier helper."""
+        enter_signals = [{"ticker": f"T{i}"} for i in range(25)]
+        result = compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=enter_signals,
+            signal=_baseline_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=_baseline_config(
+                regime_sizing_enabled=True,
+                regime_sizing_scale=0.10,  # 2x default sensitivity
+            ),
+            regime_intensity_z=1.0,
+        )
+        # 1.0 + 1.0 * 0.10 = 1.10; 0.04 * 1.10 = 0.044
+        assert result["regime_adj"] == pytest.approx(1.10)
+        assert result["position_pct"] == pytest.approx(0.044)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# extract_intensity_z — schema-defense
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestExtractIntensityZ:
+    def test_valid_substrate_returns_float(self):
+        sub = {"composite": {"intensity_z": 0.75}, "hmm": {}, "bocpd": {}}
+        assert extract_intensity_z(sub) == 0.75
+
+    def test_int_intensity_z_coerced_to_float(self):
+        sub = {"composite": {"intensity_z": 1}}
+        result = extract_intensity_z(sub)
+        assert isinstance(result, float)
+        assert result == 1.0
+
+    def test_none_substrate_returns_none(self):
+        assert extract_intensity_z(None) is None
+
+    def test_non_dict_substrate_returns_none(self):
+        assert extract_intensity_z("not a dict") is None
+        assert extract_intensity_z(42) is None
+
+    def test_missing_composite_returns_none(self):
+        assert extract_intensity_z({"hmm": {}}) is None
+
+    def test_non_dict_composite_returns_none(self):
+        assert extract_intensity_z({"composite": "stringified"}) is None
+
+    def test_missing_intensity_z_returns_none(self):
+        assert extract_intensity_z({"composite": {"posterior": []}}) is None
+
+    def test_non_numeric_intensity_z_returns_none(self):
+        """Defensive — schema drift / corrupt artifact body."""
+        assert extract_intensity_z({"composite": {"intensity_z": "high"}}) is None
+        assert extract_intensity_z({"composite": {"intensity_z": None}}) is None
+
+    def test_bool_intensity_z_rejected(self):
+        """Python's ``isinstance(True, int)`` is True — guard against it."""
+        assert extract_intensity_z({"composite": {"intensity_z": True}}) is None
+
+
+# ─────────────────────────────────────────────────────────────────────
+# read_regime_substrate — boto3 mocking, sidecar resolution
+# ─────────────────────────────────────────────────────────────────────
+
+
+class _FakeBody:
+    def __init__(self, payload: dict):
+        self._buf = BytesIO(json.dumps(payload).encode())
+
+    def read(self):
+        return self._buf.read()
+
+
+class _FakeS3:
+    def __init__(self, objects: dict[str, dict]):
+        # objects: {key: payload-dict-or-Exception}
+        self._objects = objects
+
+    def get_object(self, *, Bucket, Key):  # noqa: N803 boto3 keyword
+        v = self._objects.get(Key)
+        if v is None:
+            raise FileNotFoundError(Key)
+        if isinstance(v, Exception):
+            raise v
+        return {"Body": _FakeBody(v)}
+
+
+class TestReadRegimeSubstrate:
+    def test_canonical_sidecar_resolution(self):
+        """Happy path: sidecar → artifact body."""
+        fake_s3 = _FakeS3({
+            "regime/latest.json": {
+                "artifact_key": "regime/2605120930/substrate.json"
+            },
+            "regime/2605120930/substrate.json": {
+                "composite": {"intensity_z": 1.23},
+                "hmm": {"posterior": [0.1, 0.2, 0.7]},
+            },
+        })
+        with patch("executor.signal_reader.boto3") as mock_boto3:
+            mock_boto3.client.return_value = fake_s3
+            substrate = read_regime_substrate("alpha-engine-research")
+
+        assert substrate is not None
+        assert substrate["composite"]["intensity_z"] == 1.23
+        # Round-trip with the helper
+        assert extract_intensity_z(substrate) == 1.23
+
+    def test_missing_sidecar_returns_none(self):
+        """No latest.json → None, no exception."""
+        fake_s3 = _FakeS3({})  # nothing at all
+        with patch("executor.signal_reader.boto3") as mock_boto3:
+            mock_boto3.client.return_value = fake_s3
+            substrate = read_regime_substrate("alpha-engine-research")
+        assert substrate is None
+
+    def test_sidecar_without_artifact_key_returns_none(self):
+        """Malformed sidecar → None."""
+        fake_s3 = _FakeS3({
+            "regime/latest.json": {"some_other_field": "x"},
+        })
+        with patch("executor.signal_reader.boto3") as mock_boto3:
+            mock_boto3.client.return_value = fake_s3
+            substrate = read_regime_substrate("alpha-engine-research")
+        assert substrate is None
+
+    def test_prefix_constant_is_regime(self):
+        """Pin the S3 prefix — must match the predictor regime
+        Lambda's writer location."""
+        assert REGIME_SUBSTRATE_PREFIX == "regime"


### PR DESCRIPTION
## Summary

**Wire 2 of 5** of the Stage D' regime-as-gate arc per [`regime-v3-260514.md`](../alpha-engine-docs/private/regime-v3-260514.md) §6. Stage D shipped intensity_z as a META_FEATURE ([predictor #159](https://github.com/cipher813/alpha-engine-predictor/pull/159)); Stage D' completes the SOTA/institutional **gate + feature** framing by wiring regime into the GATING surfaces. Wire 1 ([research #188](https://github.com/cipher813/alpha-engine-research/pull/188)) allowed sector teams to emit 0 picks under regime-conditional gating; this PR makes the picks that DO survive get sized by regime intensity.

### Curve

`base_weight * (1.0 + intensity_z * scale)` clamped to `[floor, ceil]`.

`intensity_z` follows the predictor's risk-on convention from `regime/composite.py` (positive = risk-on → upweight, negative = risk-off → downweight). Defaults `scale=0.05 / floor=0.70 / ceil=1.30` — small enough to compose with the other 10+ multiplicative adjustments without dominating, large enough to register vs `sector_adj` (1.05 / 0.85). Clamps guard pathological z-tails.

| `intensity_z` | `regime_adj` (default scale) |
|---|---|
| -3.0 (extreme bear) | clamped to 0.70 |
| -1.0 (1σ risk-off) | 0.95 |
|  0.0 (neutral) | 1.00 |
| +1.0 (1σ risk-on) | 1.05 |
| +3.0 (extreme bull) | clamped to 1.30 |
| None (substrate unavail) | 1.00 (legacy preserved) |

### Files

| File | Change |
|---|---|
| `executor/position_sizer.py` | New `regime_conditional_size_multiplier` helper; `compute_position_size` gains `regime_intensity_z` kwarg + `regime_sizing_enabled/_scale/_floor/_ceil` config keys + `regime_adj` in returned payload |
| `executor/signal_reader.py` | New `read_regime_substrate` (wraps lib v0.16.0 `load_latest_eval_artifact` at `regime/latest.json`) + `extract_intensity_z` schema-defense helper |
| `executor/deciders.py` | `decide_entries` threads `regime_intensity_z` through to the sizer |
| `executor/main.py` | `_plan_entries` shell loads substrate when `regime_sizing_enabled=True` (skipped when off — no per-cycle S3 GET); threads `regime_intensity_z` end-to-end |
| `executor/decision_capture.py` | `capture_position_sizer` agent_output adds `regime_adj` so backtester grading can decompose performance against the regime tilt |
| `config/risk.yaml.example` | New `regime_sizing_*` knobs (all gated off by default) |
| `requirements.txt` | Lib pin bump v0.14.0 → v0.16.0 for `load_latest_eval_artifact` per the cross-repo lockstep rule |

### Gate discipline

`regime_sizing_enabled` defaults **False**. The substrate read is also gated by this flag, so when off there is zero per-cycle S3 GET overhead. Operator flips to True via `alpha-engine-config/executor/risk.yaml` after 4+ weeks of substrate observation via the dashboard's Regime page (Stage A PR 3). Per the doc's per-wire gating discipline.

### Tests (+31 new + 824 total passing)

- `regime_conditional_size_multiplier` math (None / 0 / +z / -z / clamp at ceil and floor / custom scale-floor-ceil / int coercion)
- `compute_position_size` integration (flag off-by-default — extant `regime_intensity_z` arg is no-op; on with +z upweights; on with -z downweights; None → unity even with flag on; clamp at ceil under extreme z; clamp at floor under extreme negative z; stacks multiplicatively with sector_adj; regime_adj always in payload; config-driven curve params flow through)
- `extract_intensity_z` schema-defense (valid float / int coerced / None substrate / non-dict substrate / missing composite / non-dict composite / missing intensity_z / non-numeric / bool rejected)
- `read_regime_substrate` boto3-mocked sidecar resolution (happy path / missing sidecar → None / sidecar without artifact_key → None / `REGIME_SUBSTRATE_PREFIX` pin)

### Wire 3-5 follow-ups (separate PRs)

- **Wire 3**: Risk guard regime-aware drawdown tiers (executor)
- **Wire 4**: Predictor veto threshold as f(regime) (alpha-engine-predictor)
- **Wire 5**: Entry score threshold regime-conditional (executor)

Wires 3-5 are parallelizable; each independently shippable per the doc's per-wire gating discipline.

Reference: `~/Development/alpha-engine-docs/private/regime-v3-260514.md` §6 Stage D'

🤖 Generated with [Claude Code](https://claude.com/claude-code)