### PR TITLE
feat(regime): Stage D' Wire 3 — regime-aware drawdown tiers

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -118,6 +118,21 @@ regime_sizing_scale: 0.05        # per-σ sensitivity; +1σ → 1.05× tilt
 regime_sizing_floor: 0.70        # clamp lower bound on the multiplier
 regime_sizing_ceil:  1.30        # clamp upper bound on the multiplier
 
+# ── Regime-aware drawdown tiers (Stage D' Wire 3, regime-v3-260514) ─────────
+# Off by default; ships dormant. When ON, the SOFT graduated-drawdown tier
+# thresholds are scaled by ``1.0 + intensity_z * regime_drawdown_scale``
+# clamped to ``[regime_drawdown_floor, regime_drawdown_ceil]``. Risk-off
+# regimes (intensity_z < 0) tighten thresholds → tiers fire at smaller
+# drawdowns (preserves capital in stress); risk-on (z > 0) loosens →
+# tolerates more drawdown before throttling. The hard ``drawdown_circuit_breaker``
+# is NOT regime-scaled — absolute capital-preservation floor. Operator
+# flips ``regime_drawdown_enabled: true`` after 4+ weeks of substrate
+# observation alongside Wire 2.
+regime_drawdown_enabled: false   # gate-off by default; flip after observation window
+regime_drawdown_scale: 0.10      # per-σ sensitivity on the threshold magnitude
+regime_drawdown_floor: 0.60      # clamp lower bound (max tightening = 40%)
+regime_drawdown_ceil:  1.40      # clamp upper bound (max loosening = 40%)
+
 # ── IBKR connection ─────────────────────────────────────────────────────────
 ibkr_host: "127.0.0.1"
 ibkr_port: 4002                  # 4002 = paper trading, 4001 = live

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -61,6 +61,8 @@ logger = logging.getLogger(__name__)
 
 def decide_drawdown_response(
     portfolio_nav: float, peak_nav: float, config: dict,
+    *,
+    regime_intensity_z: float | None = None,
 ) -> tuple[float, str]:
     """Compute drawdown-tier sizing multiplier + reason.
 
@@ -68,8 +70,16 @@ def decide_drawdown_response(
     underlying ``compute_drawdown_multiplier`` (in ``risk_guard``) is
     already pure — this name appears in the live shell + backtester so
     both paths read symmetrically.
+
+    ``regime_intensity_z`` (Stage D' Wire 3) optionally scales the
+    soft tier thresholds — see ``risk_guard.compute_drawdown_multiplier``
+    docstring for the semantics. Default ``None`` keeps the legacy
+    threshold table.
     """
-    return compute_drawdown_multiplier(portfolio_nav, peak_nav, config)
+    return compute_drawdown_multiplier(
+        portfolio_nav, peak_nav, config,
+        regime_intensity_z=regime_intensity_z,
+    )
 
 
 def enrich_positions(
@@ -843,6 +853,7 @@ def decide_entries(
             config=config,
             price_histories=price_histories,
             events=check_events,
+            regime_intensity_z=regime_intensity_z,
         )
         # Merge per-ticker risk-guard events into the plan-level log,
         # stamping the lineage fields that risk_guard doesn't know about

--- a/executor/main.py
+++ b/executor/main.py
@@ -967,14 +967,48 @@ def run(
                 pos["catalyst_date"] = stance_info.get("catalyst_date")
             logger.info(f"Entry dates resolved for {len(entry_dates)}/{len(current_positions)} positions")
     
+        # ── 2b'. Resolve regime substrate ONCE per planning cycle ──────────────
+        # Used by Wire 2 (position_sizer regime multiplier) AND Wire 3
+        # (regime-aware drawdown tiers). Gated by either flag so the
+        # read is skipped entirely when both wires are off — avoids
+        # per-cycle S3 GET when neither feature is active. Returns None
+        # on any failure mode; both wires degrade to legacy behavior
+        # under None.
+        regime_intensity_z: float | None = None
+        if (
+            (config.get("regime_sizing_enabled", False)
+             or config.get("regime_drawdown_enabled", False))
+            and not simulate
+        ):
+            try:
+                from executor.signal_reader import (
+                    extract_intensity_z,
+                    read_regime_substrate,
+                )
+                substrate = read_regime_substrate(signals_bucket)
+                regime_intensity_z = extract_intensity_z(substrate)
+                logger.info(
+                    "regime wires enabled | intensity_z=%s",
+                    f"{regime_intensity_z:.3f}" if regime_intensity_z is not None else "None",
+                )
+            except Exception as _rs_err:
+                logger.warning(
+                    "regime substrate read failed (%s) — falling back to legacy behavior",
+                    _rs_err,
+                )
+                regime_intensity_z = None
+
         # ── 2c. Compute graduated drawdown multiplier ──────────────────────────
         # Pass an events sink so any halt/throttle event lands in
         # `risk_events` ONCE per planning cycle (the per-ticker check_order
         # call deliberately does NOT propagate events to its inner
         # compute_drawdown_multiplier — see risk_guard.py:check_order).
+        # ``regime_intensity_z`` resolved above is threaded in so Wire 3
+        # scales the soft tier thresholds when the wire is enabled.
         dd_events: list[dict] = []
         dd_multiplier, dd_reason = compute_drawdown_multiplier(
             portfolio_nav, peak_nav, config, events=dd_events,
+            regime_intensity_z=regime_intensity_z,
         )
         if dd_multiplier < 1.0:
             logger.info(f"Drawdown tier active: {dd_reason}")
@@ -1210,33 +1244,8 @@ def run(
             blocked_entries: list[dict] = []
             plan_risk_events: list[dict] = []
         else:
-            # Stage D' Wire 2: optionally load regime substrate so
-            # position_sizer can apply a regime-conditional multiplier.
-            # Gated by config so the read is skipped entirely when the
-            # wire is off — avoids a per-cycle S3 GET when the feature
-            # is disabled. Returns None when substrate is unavailable
-            # (fresh deploy, sidecar miss, etc.) — sizing falls back to
-            # 1.0× under the helper's guard.
-            regime_intensity_z = None
-            if config.get("regime_sizing_enabled", False) and not simulate:
-                try:
-                    from executor.signal_reader import (
-                        extract_intensity_z,
-                        read_regime_substrate,
-                    )
-                    substrate = read_regime_substrate(signals_bucket)
-                    regime_intensity_z = extract_intensity_z(substrate)
-                    logger.info(
-                        "regime_sizing_enabled=True | intensity_z=%s",
-                        f"{regime_intensity_z:.3f}" if regime_intensity_z is not None else "None",
-                    )
-                except Exception as _rs_err:
-                    logger.warning(
-                        "regime substrate read failed (%s) — falling back to 1.0× sizing",
-                        _rs_err,
-                    )
-                    regime_intensity_z = None
-
+            # ``regime_intensity_z`` resolved once at §2b' above — threaded
+            # into both Wire 2 (position_sizer) and Wire 3 (compute_drawdown_multiplier).
             n_entered, entry_orders, blocked_entries, plan_risk_events = _plan_entries(
                 enter_signals=enter_signals,
                 signals_raw=signals_raw,

--- a/executor/risk_guard.py
+++ b/executor/risk_guard.py
@@ -36,6 +36,37 @@ def _emit(events: list[dict] | None, event: dict) -> None:
         events.append(event)
 
 
+def regime_conditional_threshold_scale(
+    intensity_z: float | None,
+    *,
+    scale: float = 0.10,
+    floor: float = 0.60,
+    ceil: float = 1.40,
+) -> float:
+    """Map regime intensity_z to a threshold-scaling factor for drawdown tiers.
+
+    Direction convention matches ``position_sizer.regime_conditional_size_multiplier``:
+    positive z = risk-on (looser drawdown response), negative = risk-off
+    (tighter — fire sooner). Returns 1.0 when ``intensity_z`` is None
+    (substrate unavailable) so the tiers behave as if the wire were off.
+
+    Math: ``1.0 + intensity_z * scale`` clamped to ``[floor, ceil]``.
+    Applied to the SOFT tier thresholds only — the hard circuit-breaker
+    threshold (``drawdown_circuit_breaker``) is intentionally NOT
+    regime-scaled to preserve the absolute capital-preservation floor.
+
+    Example with scale=0.10, threshold=-0.05 (5% drawdown):
+      * intensity_z=-2 (risk-off): scale=0.80, threshold=-0.040 — tier
+        fires at 4% drawdown (sooner — preserves capital in stress).
+      * intensity_z=+2 (risk-on):  scale=1.20, threshold=-0.060 — tier
+        fires at 6% drawdown (later — tolerates noise in calm regimes).
+    """
+    if intensity_z is None:
+        return 1.0
+    raw = 1.0 + float(intensity_z) * float(scale)
+    return max(float(floor), min(float(ceil), raw))
+
+
 def check_correlation(
     ticker: str,
     current_positions: dict[str, dict],
@@ -139,6 +170,7 @@ def compute_drawdown_multiplier(
     peak_nav: float,
     config: dict,
     events: list[dict] | None = None,
+    regime_intensity_z: float | None = None,
 ) -> tuple[float, str]:
     """
     Compute position sizing multiplier based on current drawdown tier.
@@ -150,6 +182,18 @@ def compute_drawdown_multiplier(
     When `events` is supplied, appends a structured `halt` event on
     circuit-breaker fire or a `throttle` event when an active tier is
     reducing sizing below 1.0. No event is emitted at full sizing.
+
+    Regime-aware tier thresholds (Stage D' Wire 3, regime-v3-260514):
+        When ``regime_drawdown_enabled`` is True in config AND
+        ``regime_intensity_z`` is non-None, the SOFT tier thresholds are
+        multiplied by ``regime_conditional_threshold_scale(intensity_z)``.
+        Risk-off regimes (z<0) tighten the thresholds → tiers fire at
+        smaller drawdowns (preserves capital in stress). Risk-on (z>0)
+        loosens them → tiers tolerate more drawdown before throttling.
+
+        The hard circuit_breaker is NOT regime-scaled — the absolute
+        capital-preservation floor stays constant regardless of regime.
+        Default ``regime_drawdown_enabled=False`` ships the wire dormant.
     """
     if peak_nav <= 0:
         return 1.0, "no peak NAV recorded"
@@ -157,6 +201,19 @@ def compute_drawdown_multiplier(
     drawdown = (portfolio_nav - peak_nav) / peak_nav  # negative number
 
     strategy_cfg = load_strategy_config(config)
+
+    # Resolve the regime threshold-scale once for this call. When the
+    # wire is OFF or intensity_z is missing, falls through to 1.0
+    # (no behavioral change vs. pre-Wire-3 baseline).
+    if config.get("regime_drawdown_enabled", False):
+        regime_threshold_scale = regime_conditional_threshold_scale(
+            regime_intensity_z,
+            scale=config.get("regime_drawdown_scale", 0.10),
+            floor=config.get("regime_drawdown_floor", 0.60),
+            ceil=config.get("regime_drawdown_ceil", 1.40),
+        )
+    else:
+        regime_threshold_scale = 1.0
 
     if not strategy_cfg.get("graduated_drawdown_enabled", True):
         # Fall back to original binary circuit breaker
@@ -178,19 +235,25 @@ def compute_drawdown_multiplier(
 
     # Tiers are sorted by threshold ascending (most negative last).
     # Walk through tiers; the last tier whose threshold is breached applies.
+    # Soft thresholds are regime-scaled; circuit_breaker below is NOT.
     active_multiplier = 1.0
     active_desc = f"drawdown {drawdown:.1%} — full sizing"
     active_threshold: float | None = None
     active_tier_desc: str | None = None
 
     for threshold, multiplier, description in tiers:
-        if drawdown <= threshold:
+        scaled_threshold = float(threshold) * regime_threshold_scale
+        if drawdown <= scaled_threshold:
             active_multiplier = multiplier
-            active_desc = f"drawdown {drawdown:.1%} — {description} (multiplier={multiplier})"
-            active_threshold = float(threshold)
+            active_desc = (
+                f"drawdown {drawdown:.1%} — {description} "
+                f"(multiplier={multiplier})"
+            )
+            active_threshold = scaled_threshold
             active_tier_desc = description
 
-    # Hard halt at the deepest configured tier (circuit breaker preserved)
+    # Hard halt at the deepest configured tier (circuit breaker preserved).
+    # NOT regime-scaled — absolute capital-preservation floor.
     hard_halt = -config.get("drawdown_circuit_breaker", 0.08)
     if drawdown <= hard_halt:
         reason = f"circuit breaker: {drawdown:.1%} from peak (limit {hard_halt:.1%})"
@@ -213,6 +276,12 @@ def compute_drawdown_multiplier(
             "context": {
                 "multiplier": float(active_multiplier),
                 "tier_description": active_tier_desc,
+                "regime_threshold_scale": float(regime_threshold_scale),
+                "regime_intensity_z": (
+                    float(regime_intensity_z)
+                    if regime_intensity_z is not None
+                    else None
+                ),
             },
         })
 
@@ -232,6 +301,7 @@ def check_order(
     config: dict,
     price_histories: dict[str, pd.DataFrame] | None = None,
     events: list[dict] | None = None,
+    regime_intensity_z: float | None = None,
 ) -> tuple[bool, str]:
     """
     Validate an order against all risk rules.
@@ -298,6 +368,7 @@ def check_order(
     #    per ticker checked.
     dd_multiplier, dd_reason = compute_drawdown_multiplier(
         portfolio_nav, peak_nav, config,
+        regime_intensity_z=regime_intensity_z,
     )
     if dd_multiplier <= 0.0:
         return False, f"Drawdown halt: {dd_reason}"

--- a/tests/test_regime_stage_d_prime_wire_3_drawdown_tiers.py
+++ b/tests/test_regime_stage_d_prime_wire_3_drawdown_tiers.py
@@ -1,0 +1,368 @@
+"""Stage D' Wire 3 — regime-aware drawdown tiers.
+
+Pins:
+
+1. ``regime_conditional_threshold_scale`` math: linear ``1 + z*scale``
+   clamped to ``[floor, ceil]``; ``None`` → 1.0.
+2. ``compute_drawdown_multiplier`` honors ``regime_drawdown_enabled``
+   flag; default OFF preserves legacy threshold behavior.
+3. Risk-off (z<0) tightens SOFT tier thresholds → tier fires at
+   smaller drawdown; risk-on (z>0) loosens.
+4. Hard ``drawdown_circuit_breaker`` is NOT regime-scaled — absolute
+   capital-preservation floor preserved.
+5. Throttle event context carries ``regime_threshold_scale`` +
+   ``regime_intensity_z`` for downstream observability.
+
+See ``~/Development/alpha-engine-docs/private/regime-v3-260514.md``
+§6 Stage D' Wire 3 for the architectural framing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from executor.risk_guard import (
+    compute_drawdown_multiplier,
+    regime_conditional_threshold_scale,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# regime_conditional_threshold_scale — pure math
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestRegimeConditionalThresholdScale:
+    def test_none_returns_unity(self):
+        """Substrate-unavailable path: None → 1.0 (legacy thresholds)."""
+        assert regime_conditional_threshold_scale(None) == 1.0
+
+    def test_zero_intensity_returns_unity(self):
+        """Neutral regime (z=0) → 1.0 (no scaling)."""
+        assert regime_conditional_threshold_scale(0.0) == 1.0
+
+    def test_negative_z_returns_below_unity(self):
+        """Risk-off (z<0) → scale<1.0 → thresholds tighten."""
+        # 1.0 + (-1.0)*0.10 = 0.90
+        assert regime_conditional_threshold_scale(-1.0) == pytest.approx(0.90)
+
+    def test_positive_z_returns_above_unity(self):
+        """Risk-on (z>0) → scale>1.0 → thresholds loosen."""
+        # 1.0 + 1.0*0.10 = 1.10
+        assert regime_conditional_threshold_scale(1.0) == pytest.approx(1.10)
+
+    def test_clamped_to_floor(self):
+        """Extreme negative z → clamped to floor (default 0.60)."""
+        # 1.0 + (-10.0)*0.10 = 0.00, clamped to 0.60
+        assert regime_conditional_threshold_scale(-10.0) == 0.60
+
+    def test_clamped_to_ceil(self):
+        """Extreme positive z → clamped to ceil (default 1.40)."""
+        # 1.0 + 10.0*0.10 = 2.00, clamped to 1.40
+        assert regime_conditional_threshold_scale(10.0) == 1.40
+
+    def test_custom_scale(self):
+        """``scale`` parameter controls sensitivity per σ."""
+        assert regime_conditional_threshold_scale(1.0, scale=0.20) == pytest.approx(1.20)
+        assert regime_conditional_threshold_scale(-1.0, scale=0.20) == pytest.approx(0.80)
+
+    def test_custom_floor_and_ceil(self):
+        """``floor`` and ``ceil`` parameters tighten the clamp."""
+        # ceil=1.1 clamps +5σ down
+        assert regime_conditional_threshold_scale(5.0, ceil=1.1) == 1.1
+        # floor=0.9 clamps -5σ up
+        assert regime_conditional_threshold_scale(-5.0, floor=0.9) == 0.9
+
+
+# ─────────────────────────────────────────────────────────────────────
+# compute_drawdown_multiplier — regime-aware tier behavior
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _config(**overrides):
+    """Config with graduated drawdown tiers at -2% / -4% / -6%, hard halt at -8%."""
+    cfg = {
+        "drawdown_circuit_breaker": 0.08,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": True,
+                "tiers": [
+                    (-0.02, 1.00, "0% to -2%: full sizing"),
+                    (-0.04, 0.50, "-2% to -4%: half sizing"),
+                    (-0.06, 0.25, "-4% to -6%: quarter sizing"),
+                ],
+            },
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+class TestRegimeDrawdownDisabledByDefault:
+    """Without ``regime_drawdown_enabled`` set, intensity_z has zero
+    effect — Wire 3 ships dormant. -4.5% drawdown chosen because
+    baseline z=0 fires tier-2 (0.50) — clear before/after differential."""
+
+    def test_zero_z_baseline(self):
+        config = _config()
+        # -4.5% drawdown: tier-1 at -0.02 + tier-2 at -0.04 both fire → 0.50
+        mult, _ = compute_drawdown_multiplier(
+            95_500, 100_000, config, regime_intensity_z=0.0,
+        )
+        assert mult == 0.50
+
+    def test_negative_z_does_not_tighten_when_flag_off(self):
+        """Pre-flag: even strong risk-off doesn't change thresholds."""
+        config = _config()
+        mult, _ = compute_drawdown_multiplier(
+            95_500, 100_000, config, regime_intensity_z=-3.0,
+        )
+        # Same as baseline
+        assert mult == 0.50
+
+    def test_positive_z_does_not_loosen_when_flag_off(self):
+        """Pre-flag: strong risk-on doesn't loosen thresholds either."""
+        config = _config()
+        mult, _ = compute_drawdown_multiplier(
+            95_500, 100_000, config, regime_intensity_z=3.0,
+        )
+        # Without the flag, would-have-loosened scenario still fires tier-2
+        assert mult == 0.50
+
+
+class TestRegimeDrawdownEnabledTightensInRiskOff:
+    """Flag ON + risk-off → soft tiers fire at SMALLER drawdowns."""
+
+    def test_risk_off_tightens_tier_1_threshold(self):
+        """At -1.8% drawdown + z=-2.0 (scale=0.10, tier1=-0.02):
+        scaled threshold = -0.02 * (1.0 + (-2.0)*0.10) = -0.02 * 0.80 = -0.016
+        Drawdown -0.018 <= -0.016 → tier-1 fires (multiplier=1.00).
+        Pre-Wire-3 baseline: -0.018 > -0.020 → no tier fires."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, desc = compute_drawdown_multiplier(
+            98_200, 100_000, config, regime_intensity_z=-2.0,
+        )
+        # Tier 1 is multiplier=1.00 in our test config, so no observable
+        # change in mult — pin via test below at deeper drawdown.
+        assert mult == 1.00  # still full sizing under tier 1
+
+    def test_risk_off_tightens_tier_2_threshold(self):
+        """At -3.5% drawdown + z=-2.0 (scale=0.10, tier2=-0.04):
+        scaled threshold = -0.04 * 0.80 = -0.032
+        Drawdown -0.035 <= -0.032 → tier-2 fires (multiplier=0.50).
+        Pre-Wire-3 baseline: -0.035 > -0.040 → only tier-1 fires (1.00)."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, _ = compute_drawdown_multiplier(
+            96_500, 100_000, config, regime_intensity_z=-2.0,
+        )
+        assert mult == 0.50
+
+        # Baseline comparison: same drawdown with z=0 → tier 1
+        baseline_mult, _ = compute_drawdown_multiplier(
+            96_500, 100_000, config, regime_intensity_z=0.0,
+        )
+        # -3.5% > -4% → only tier 1 boundary (-2%) crossed → 1.00
+        assert baseline_mult == 1.00
+
+    def test_risk_off_tightens_tier_3_threshold(self):
+        """At -5% drawdown + z=-2.0 (scale=0.10, tier3=-0.06):
+        scaled threshold = -0.06 * 0.80 = -0.048
+        Drawdown -0.050 <= -0.048 → tier-3 fires (multiplier=0.25).
+        Pre-Wire-3 baseline: -0.050 > -0.060 → tier-2 fires (0.50)."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, _ = compute_drawdown_multiplier(
+            95_000, 100_000, config, regime_intensity_z=-2.0,
+        )
+        assert mult == 0.25
+
+        baseline_mult, _ = compute_drawdown_multiplier(
+            95_000, 100_000, config, regime_intensity_z=0.0,
+        )
+        assert baseline_mult == 0.50
+
+
+class TestRegimeDrawdownEnabledLoosensInRiskOn:
+    """Flag ON + risk-on → soft tiers fire at LARGER drawdowns."""
+
+    def test_risk_on_loosens_tier_2_threshold(self):
+        """At -3.5% drawdown + z=+2.0:
+        scaled tier2 threshold = -0.04 * 1.20 = -0.048
+        Drawdown -0.035 > -0.048 → tier-2 does NOT fire (only tier 1 → 1.00)."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, _ = compute_drawdown_multiplier(
+            96_500, 100_000, config, regime_intensity_z=2.0,
+        )
+        # Loosened — tier-2 (0.50) does NOT fire; only tier-1 (1.00) applies
+        assert mult == 1.00
+
+    def test_risk_on_tier_3_skipped(self):
+        """At -5% drawdown + z=+2.0:
+        scaled tier3 = -0.06 * 1.20 = -0.072; tier3 does NOT fire.
+        scaled tier2 = -0.04 * 1.20 = -0.048; tier2 fires (0.50).
+        Baseline z=0: tier2 fires at -0.04, tier3 doesn't (since -0.05 > -0.06)."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, _ = compute_drawdown_multiplier(
+            95_000, 100_000, config, regime_intensity_z=2.0,
+        )
+        assert mult == 0.50
+
+
+class TestHardHaltNotRegimeScaled:
+    """Hard ``drawdown_circuit_breaker`` is absolute — risk-on regime
+    cannot avoid the hard halt; risk-off cannot trigger it earlier."""
+
+    def test_hard_halt_fires_at_circuit_breaker_in_risk_on(self):
+        """At -8% drawdown + z=+5.0 (very risk-on):
+        Even though soft tiers loosen by 1.40, hard halt at -0.08 fires."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, desc = compute_drawdown_multiplier(
+            92_000, 100_000, config, regime_intensity_z=5.0,
+        )
+        assert mult == 0.0
+        assert "circuit breaker" in desc.lower()
+
+    def test_hard_halt_not_triggered_before_circuit_breaker_in_risk_off(self):
+        """At -7% drawdown + z=-5.0 (very risk-off):
+        Soft tiers tightened to floor=0.60 still fire (tier-3 hits early),
+        but hard halt at -0.08 doesn't trigger (drawdown < hard halt threshold)."""
+        config = _config(regime_drawdown_enabled=True)
+        mult, _ = compute_drawdown_multiplier(
+            93_000, 100_000, config, regime_intensity_z=-5.0,
+        )
+        # NOT 0.0 — hard halt is absolute and -7% > -8%
+        assert mult > 0.0
+        # tier-3 fires aggressively under risk-off scaling → 0.25
+        assert mult == 0.25
+
+
+class TestStructuredEventContext:
+    """Throttle events carry regime context for downstream analytics."""
+
+    def test_throttle_event_includes_regime_threshold_scale(self):
+        config = _config(regime_drawdown_enabled=True)
+        events: list[dict] = []
+        compute_drawdown_multiplier(
+            96_500, 100_000, config,
+            events=events,
+            regime_intensity_z=-2.0,
+        )
+        throttle = [e for e in events if e["event_type"] == "throttle"]
+        assert len(throttle) == 1
+        ctx = throttle[0]["context"]
+        assert ctx["regime_threshold_scale"] == pytest.approx(0.80)
+        assert ctx["regime_intensity_z"] == -2.0
+
+    def test_throttle_event_threshold_is_scaled_value(self):
+        """Persisted ``threshold`` should be the SCALED threshold (the
+        one actually compared against), not the raw config value, so
+        backtester replays can reproduce the decision."""
+        config = _config(regime_drawdown_enabled=True)
+        events: list[dict] = []
+        compute_drawdown_multiplier(
+            96_500, 100_000, config,
+            events=events,
+            regime_intensity_z=-2.0,
+        )
+        throttle = [e for e in events if e["event_type"] == "throttle"]
+        assert len(throttle) == 1
+        # tier-2 with scale 0.80: -0.04 * 0.80 = -0.032
+        assert throttle[0]["threshold"] == pytest.approx(-0.032)
+
+    def test_throttle_event_z_none_when_substrate_missing(self):
+        """When z=None, threshold_scale=1.0 — same as flag-off behavior.
+        Use -4.5% drawdown so tier-2 fires under both paths and emits a
+        throttle event."""
+        config = _config(regime_drawdown_enabled=True)
+        events: list[dict] = []
+        compute_drawdown_multiplier(
+            95_500, 100_000, config,
+            events=events,
+            regime_intensity_z=None,
+        )
+        throttle = [e for e in events if e["event_type"] == "throttle"]
+        assert len(throttle) == 1
+        assert throttle[0]["context"]["regime_intensity_z"] is None
+        # threshold_scale=1.0 when z=None
+        assert throttle[0]["context"]["regime_threshold_scale"] == 1.0
+
+    def test_hard_halt_event_has_no_regime_scale_context(self):
+        """Hard halt is regime-independent — event context shouldn't
+        carry regime_threshold_scale (the threshold there isn't scaled)."""
+        config = _config(regime_drawdown_enabled=True)
+        events: list[dict] = []
+        compute_drawdown_multiplier(
+            92_000, 100_000, config,
+            events=events,
+            regime_intensity_z=-2.0,
+        )
+        halts = [e for e in events if e["event_type"] == "halt"]
+        assert len(halts) == 1
+        # Hard halt threshold is the un-scaled config value
+        assert halts[0]["threshold"] == -0.08
+
+
+class TestConfigDrivenCurveParams:
+    """``regime_drawdown_scale`` / ``_floor`` / ``_ceil`` from config flow
+    through to the threshold-scale helper."""
+
+    def test_custom_scale_doubles_sensitivity(self):
+        """At -3.0% drawdown + z=-1.0, default scale 0.10:
+          scaled tier2 = -0.04 * 0.90 = -0.036 → -0.030 > -0.036 → tier-1
+        With scale 0.20:
+          scaled tier2 = -0.04 * 0.80 = -0.032 → -0.030 > -0.032 → tier-1
+        Both don't fire tier-2 at -3.0%. Use -3.4% drawdown to differentiate."""
+        config = _config(
+            regime_drawdown_enabled=True,
+            regime_drawdown_scale=0.20,
+        )
+        # -3.4% drawdown
+        mult, _ = compute_drawdown_multiplier(
+            96_600, 100_000, config, regime_intensity_z=-1.0,
+        )
+        # scale=0.20, z=-1: tier2 scaled to -0.04*0.80 = -0.032
+        # drawdown -0.034 <= -0.032 → tier-2 fires (0.50)
+        assert mult == 0.50
+
+    def test_custom_floor(self):
+        """Custom floor 0.95 limits maximum tightening to 5%."""
+        config = _config(
+            regime_drawdown_enabled=True,
+            regime_drawdown_floor=0.95,
+        )
+        # z=-10 would normally clamp to default 0.60; with floor=0.95
+        # scale stays at 0.95
+        mult, _ = compute_drawdown_multiplier(
+            96_500, 100_000, config, regime_intensity_z=-10.0,
+        )
+        # tier-2 scaled to -0.04 * 0.95 = -0.038
+        # -0.035 > -0.038 → tier-2 doesn't fire → tier-1 (1.00)
+        assert mult == 1.00
+
+
+class TestNoneIntensityZPreservesLegacy:
+    """When wire is enabled but substrate read returned None,
+    threshold scale falls through to 1.0 (legacy thresholds preserved)."""
+
+    def test_none_z_acts_as_unity_scale(self):
+        config = _config(regime_drawdown_enabled=True)
+        # -3% drawdown, baseline z=0 hits tier-1 (1.00)
+        mult, _ = compute_drawdown_multiplier(
+            97_000, 100_000, config, regime_intensity_z=None,
+        )
+        # Same as baseline behavior: -0.03 > -0.04 tier-2 → only tier-1 fires
+        assert mult == 1.00
+
+
+class TestNonGraduatedFallbackUnaffected:
+    """When ``graduated_drawdown.enabled=False``, regime scaling is
+    bypassed (the binary circuit-breaker fallback is regime-independent).
+    """
+
+    def test_binary_circuit_breaker_ignores_regime(self):
+        config = _config(regime_drawdown_enabled=True)
+        config["strategy"]["graduated_drawdown"]["enabled"] = False
+        # -7% drawdown, binary breaker at -8% → no halt
+        mult, _ = compute_drawdown_multiplier(
+            93_000, 100_000, config, regime_intensity_z=-5.0,
+        )
+        # Binary breaker says full sizing until -8% threshold
+        assert mult == 1.0


### PR DESCRIPTION
## Summary

**Wire 3 of 5** of the Stage D' regime-as-gate arc per [`regime-v3-260514.md`](../alpha-engine-docs/private/regime-v3-260514.md) §6. Makes the SOFT graduated-drawdown tier thresholds regime-aware: **risk-off** regimes tighten thresholds (fire sooner — preserves capital in stress); **risk-on** loosens (tolerates more drawdown before throttling). Composes with Wire 2 ([#178](https://github.com/cipher813/alpha-engine/pull/178)) by sharing the same regime substrate read.

### Curve

`scaled_threshold = base_threshold * (1.0 + intensity_z * scale)` clamped to `[floor, ceil]`.

Defaults `scale=0.10 / floor=0.60 / ceil=1.40`. Example with tier-2 base = -4%:

| `intensity_z` | scaled threshold | tier-2 fires at... |
|---|---|---|
| -3.0 (extreme bear) | clamped 0.60 → -2.4% drawdown | -2.4% (much sooner) |
| -1.0 (1σ risk-off) | 0.90 → -3.6% | -3.6% |
|  0.0 (neutral) | 1.00 → -4.0% | -4.0% (legacy) |
| +1.0 (1σ risk-on) | 1.10 → -4.4% | -4.4% |
| +3.0 (extreme bull) | clamped 1.40 → -5.6% | -5.6% (later) |
| None (substrate unavail) | 1.00 → -4.0% | legacy preserved |

### Hard halt is preserved

`drawdown_circuit_breaker` (default -8%) is **NOT** regime-scaled. The absolute capital-preservation floor stays constant regardless of regime. Risk-on cannot delay the circuit breaker; risk-off cannot trigger it earlier than the configured threshold. This is the deliberate asymmetry — regime tilts soft thresholds, hard halt is a non-negotiable last line of defense.

### Files

| File | Change |
|---|---|
| `executor/risk_guard.py` | New `regime_conditional_threshold_scale` helper; `compute_drawdown_multiplier` gains `regime_intensity_z` kwarg; soft tier thresholds scaled per regime; throttle events stamp `regime_threshold_scale` + `regime_intensity_z` in context; `check_order` threads through |
| `executor/deciders.py` | `decide_drawdown_response` + `decide_entries` thread `regime_intensity_z` to check_order and the inner drawdown call |
| `executor/main.py` | Substrate read hoisted out of `_plan_entries` (Wire 2's location) up to §2b' so the same `intensity_z` is shared between Wire 2 (sizing) and Wire 3 (drawdown tiers). Read gated by EITHER wire flag (zero per-cycle S3 GET when both off) |
| `config/risk.yaml.example` | New `regime_drawdown_*` knobs (all gated off by default) |

### Gate discipline

`regime_drawdown_enabled` defaults **False**. The substrate read is gated by `regime_sizing_enabled OR regime_drawdown_enabled`, so when both wires are off there is zero S3 GET per planning cycle. Operator flips to True via `alpha-engine-config/executor/risk.yaml` after 4+ weeks of substrate observation through the dashboard's Regime page (Stage A PR 3). Per the doc's per-wire gating discipline.

### Tests (+26 new + 850 total passing)

- `regime_conditional_threshold_scale` math (None / 0 / +z / -z / clamp at floor and ceil / custom scale-floor-ceil)
- **Wire OFF by default**: even strong z=±3 has zero effect when flag is off (regression guard)
- **Risk-off tightens**: tier-1 / tier-2 / tier-3 thresholds, each with baseline z=0 comparison showing differential
- **Risk-on loosens**: tier-2 loosened past → only tier-1 fires; tier-3 skipped
- **Hard halt NOT regime-scaled**: fires under extreme risk-on z=+5; doesn't pre-fire under risk-off
- Structured throttle event includes `regime_threshold_scale` + `regime_intensity_z`; persisted `threshold` is the scaled value (the one actually compared against)
- `z=None` preserves legacy behavior (scale=1.0)
- Hard-halt events have no `regime_threshold_scale` context (regime-independent)
- Config-driven curve params (`regime_drawdown_scale/_floor/_ceil`) flow through
- Binary circuit-breaker fallback (`graduated_drawdown.enabled=False`) is regime-independent

### Wire 4-5 follow-ups (separate PRs)

- **Wire 4**: Predictor veto threshold as f(regime) (alpha-engine-predictor)
- **Wire 5**: Entry score threshold regime-conditional (executor)

Wires 4-5 are parallelizable; each independently shippable per the doc's per-wire gating discipline.

Reference: `~/Development/alpha-engine-docs/private/regime-v3-260514.md` §6 Stage D'

🤖 Generated with [Claude Code](https://claude.com/claude-code)