### PR TITLE
feat(regime): Stage D' Wire 5 — regime-conditional entry score threshold (Stage D' arc complete)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -133,6 +133,21 @@ regime_drawdown_scale: 0.10      # per-σ sensitivity on the threshold magnitude
 regime_drawdown_floor: 0.60      # clamp lower bound (max tightening = 40%)
 regime_drawdown_ceil:  1.40      # clamp upper bound (max loosening = 40%)
 
+# ── Regime-conditional entry score threshold (Stage D' Wire 5, regime-v3-260514) ─
+# Off by default; ships dormant. When ON, ``min_score_to_enter`` is adjusted by
+# ``-intensity_z * regime_min_score_scale`` clamped to
+# ``[-regime_min_score_cap, +regime_min_score_cap]`` then to
+# ``[regime_min_score_floor, regime_min_score_ceil]``. Risk-off regimes
+# (intensity_z < 0) RAISE the threshold → more selective (only the best
+# ideas qualify); risk-on (z > 0) LOWER → more inclusive (don't miss
+# the tailwind). Operator flips ``regime_min_score_enabled: true`` after
+# 4+ weeks of substrate observation alongside Wires 2-4.
+regime_min_score_enabled: false  # gate-off by default; flip after observation window
+regime_min_score_scale: 2.0      # per-σ point shift in score threshold
+regime_min_score_cap: 10.0       # max absolute adjustment in score points
+regime_min_score_floor: 50.0     # clamp lower bound on adjusted threshold
+regime_min_score_ceil:  90.0     # clamp upper bound on adjusted threshold
+
 # ── IBKR connection ─────────────────────────────────────────────────────────
 ibkr_host: "127.0.0.1"
 ibkr_port: 4002                  # 4002 = paper trading, 4001 = live

--- a/executor/risk_guard.py
+++ b/executor/risk_guard.py
@@ -36,6 +36,49 @@ def _emit(events: list[dict] | None, event: dict) -> None:
         events.append(event)
 
 
+def regime_conditional_min_score(
+    intensity_z: float | None,
+    *,
+    base_min_score: float,
+    scale: float = 2.0,
+    cap: float = 10.0,
+    floor: float = 50.0,
+    ceil: float = 90.0,
+) -> float:
+    """Stage D' Wire 5 — regime-conditional entry score threshold.
+
+    Adjusts ``min_score_to_enter`` based on the predictor regime substrate's
+    composite intensity_z. Direction: risk-off RAISES the threshold (more
+    selective — only the best ideas survive); risk-on LOWERS the threshold
+    (more inclusive — don't miss the tailwind).
+
+    Why opposite-sign vs Wire 4 (veto)?
+      Both wires gate entries; both go in the same SEMANTIC direction
+      ("tighter in stress, looser in tailwind") — but their underlying
+      thresholds move in opposite directions to achieve that effect.
+      Veto: HIGHER threshold → harder to veto → MORE entries allowed.
+      Entry score: LOWER threshold → easier to qualify → MORE entries.
+
+    Math: ``adjustment = -intensity_z * scale`` clamped to ``[-cap, +cap]``,
+    then ``base + adjustment`` clamped to ``[floor, ceil]``. Defaults
+    (scale=2.0, cap=10.0) give:
+      * z=-2 → adjustment +4.0 (base 70 → 74)
+      * z=-5 → adjustment +10.0 capped (base 70 → 80)
+      * z=0  → adjustment  0.0 (base unchanged)
+      * z=+2 → adjustment -4.0 (base 70 → 66)
+      * z=None → adjustment 0.0 (legacy preserved)
+
+    Floor 50.0 / ceil 90.0 prevent pathological tails from disabling
+    the gate entirely or making it unreachable.
+    """
+    base = float(base_min_score)
+    if intensity_z is None:
+        return base
+    raw_adjustment = -float(intensity_z) * float(scale)
+    capped_adjustment = max(-float(cap), min(float(cap), raw_adjustment))
+    return max(float(floor), min(float(ceil), base + capped_adjustment))
+
+
 def regime_conditional_threshold_scale(
     intensity_z: float | None,
     *,
@@ -345,14 +388,33 @@ def check_order(
 
     # ── ENTER rules ───────────────────────────────────────────────────────────
 
-    # 1. Score minimum
+    # 1. Score minimum (Stage D' Wire 5: optionally regime-conditional)
     score = signal.get("score") or 0
-    min_score = config.get("min_score_to_enter", 70)
+    base_min_score = config.get("min_score_to_enter", 70)
+    if config.get("regime_min_score_enabled", False):
+        min_score = regime_conditional_min_score(
+            regime_intensity_z,
+            base_min_score=base_min_score,
+            scale=config.get("regime_min_score_scale", 2.0),
+            cap=config.get("regime_min_score_cap", 10.0),
+            floor=config.get("regime_min_score_floor", 50.0),
+            ceil=config.get("regime_min_score_ceil", 90.0),
+        )
+    else:
+        min_score = base_min_score
     if score < min_score:
         reason = f"Score {score:.1f} < minimum {min_score}"
         _emit(events, {**base_event_ctx,
             "event_type": "veto", "rule": "min_score",
             "reason": reason, "value": float(score), "threshold": float(min_score),
+            "context": {
+                "base_min_score": float(base_min_score),
+                "regime_intensity_z": (
+                    float(regime_intensity_z)
+                    if regime_intensity_z is not None
+                    else None
+                ),
+            },
         })
         return False, reason
 

--- a/tests/test_regime_stage_d_prime_wire_5_entry_score_threshold.py
+++ b/tests/test_regime_stage_d_prime_wire_5_entry_score_threshold.py
@@ -1,0 +1,401 @@
+"""Stage D' Wire 5 — regime-conditional entry score threshold.
+
+Pins:
+
+1. ``regime_conditional_min_score`` math: ``base + (-z*scale)`` clamped to
+   ``[base-cap, base+cap]`` then to ``[floor, ceil]``; ``None`` → base.
+2. ``check_order`` honors ``regime_min_score_enabled`` flag; default OFF
+   preserves legacy ``min_score_to_enter`` behavior.
+3. Risk-off (z<0) RAISES threshold (more selective — fewer entries);
+   risk-on (z>0) LOWERS (more inclusive — more entries).
+4. min_score veto event context carries ``base_min_score`` +
+   ``regime_intensity_z`` for downstream observability.
+
+See ``~/Development/alpha-engine-docs/private/regime-v3-260514.md``
+§6 Stage D' Wire 5 for the architectural framing.
+"""
+from __future__ import annotations
+
+import pytest
+
+from executor.risk_guard import (
+    check_order,
+    regime_conditional_min_score,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# regime_conditional_min_score — pure math
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestRegimeConditionalMinScore:
+    def test_none_returns_base(self):
+        """Substrate-unavailable path: None → base (legacy preserved)."""
+        assert regime_conditional_min_score(None, base_min_score=70) == 70.0
+
+    def test_zero_intensity_returns_base(self):
+        """Neutral regime (z=0) → base (no adjustment)."""
+        assert regime_conditional_min_score(0.0, base_min_score=70) == 70.0
+
+    def test_negative_z_raises_threshold(self):
+        """Risk-off (z<0) → threshold goes UP (more selective)."""
+        # z=-1, scale=2.0 → adjustment = +2.0; base 70 → 72
+        assert regime_conditional_min_score(-1.0, base_min_score=70) == 72.0
+
+    def test_positive_z_lowers_threshold(self):
+        """Risk-on (z>0) → threshold goes DOWN (more inclusive)."""
+        # z=+1, scale=2.0 → adjustment = -2.0; base 70 → 68
+        assert regime_conditional_min_score(1.0, base_min_score=70) == 68.0
+
+    def test_capped_to_max_adjustment(self):
+        """Extreme negative z → adjustment clamped to +cap (default 10.0)."""
+        # z=-100 → raw adj +200, capped to +10; base 70 → 80
+        assert regime_conditional_min_score(-100.0, base_min_score=70) == 80.0
+
+    def test_capped_to_min_adjustment(self):
+        """Extreme positive z → adjustment clamped to -cap (default -10.0)."""
+        # z=+100 → raw adj -200, capped to -10; base 70 → 60
+        assert regime_conditional_min_score(100.0, base_min_score=70) == 60.0
+
+    def test_clamped_to_floor(self):
+        """Even within cap range, hard floor=50.0 prevents disabling gate."""
+        # Cap doesn't bite here — but floor does
+        # base=55, z=-100 → cap +10 → 65 (no floor issue)
+        # base=45, z=-100 → cap +10 → 55 (no floor)
+        # base=45, z=+0 → adj 0 → 45 → clamped UP to 50
+        assert regime_conditional_min_score(0.0, base_min_score=45) == 50.0
+
+    def test_clamped_to_ceil(self):
+        """Hard ceiling=90.0 prevents unreachable threshold."""
+        # base=95, z=0 → 95 → clamped DOWN to 90
+        assert regime_conditional_min_score(0.0, base_min_score=95) == 90.0
+
+    def test_custom_scale(self):
+        """``scale`` parameter controls per-σ sensitivity."""
+        # z=-1, scale=5.0 → adjustment +5; base 70 → 75
+        assert regime_conditional_min_score(
+            -1.0, base_min_score=70, scale=5.0,
+        ) == 75.0
+
+    def test_custom_cap(self):
+        """``cap`` parameter tightens adjustment clamp."""
+        # z=-100 → raw +200; cap=3 → +3; base 70 → 73
+        assert regime_conditional_min_score(
+            -100.0, base_min_score=70, cap=3.0,
+        ) == 73.0
+
+    def test_custom_floor_and_ceil(self):
+        """``floor`` and ``ceil`` parameters override the default range."""
+        # base=70, z=0, floor=72 → clamped UP to 72
+        assert regime_conditional_min_score(
+            0.0, base_min_score=70, floor=72.0,
+        ) == 72.0
+        # base=70, z=0, ceil=68 → clamped DOWN to 68
+        assert regime_conditional_min_score(
+            0.0, base_min_score=70, ceil=68.0,
+        ) == 68.0
+
+
+# ─────────────────────────────────────────────────────────────────────
+# check_order integration — Wire 5 gate behavior
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _base_config(**overrides):
+    """Minimal config that lets all rules below the score gate pass for
+    the synthetic ticker — they're not the subject of these tests."""
+    cfg = {
+        "min_score_to_enter": 70,
+        "max_position_pct": 0.10,
+        "bear_max_position_pct": 0.10,
+        "max_sector_pct": 0.50,
+        "max_equity_pct": 0.95,
+        "drawdown_circuit_breaker": 0.50,
+        "correlation_block_enabled": False,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": False,
+                "tiers": [],
+            },
+        },
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _enter_signal(score=80):
+    return {
+        "score": score,
+        "conviction": "stable",
+        "price_target_upside": 0.15,
+        "signal": "ENTER",
+    }
+
+
+class TestWire5DisabledByDefault:
+    """Without ``regime_min_score_enabled``, intensity_z has zero effect."""
+
+    def test_score_at_base_threshold_passes(self):
+        config = _base_config()  # min_score 70, wire OFF
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="neutral",
+            signal=_enter_signal(score=70),
+            config=config,
+            regime_intensity_z=-3.0,  # would raise threshold if enabled
+        )
+        # Wire off: 70 >= 70 passes
+        assert approved is True
+
+    def test_negative_z_does_not_tighten_when_flag_off(self):
+        config = _base_config()
+        approved, reason = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=71),  # would FAIL if z raised threshold above 71
+            config=config,
+            regime_intensity_z=-3.0,
+        )
+        assert approved is True
+
+
+class TestWire5EnabledRiskOffRaisesThreshold:
+    """Flag ON + risk-off → score gate fires at HIGHER threshold."""
+
+    def test_risk_off_raises_threshold_above_base(self):
+        """Score 71 passes base 70 but fails regime-adjusted 76 (z=-3)."""
+        config = _base_config(regime_min_score_enabled=True)
+        approved, reason = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=71),
+            config=config,
+            regime_intensity_z=-3.0,
+        )
+        # z=-3, scale=2.0 → +6; base 70 → 76. 71 < 76 → veto.
+        assert approved is False
+        assert "minimum 76" in reason
+
+    def test_risk_off_score_clears_higher_threshold(self):
+        """Score 80 passes even the risk-off-tightened threshold."""
+        config = _base_config(regime_min_score_enabled=True)
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=80),
+            config=config,
+            regime_intensity_z=-3.0,
+        )
+        # 80 >= 76 (adjusted) → passes
+        assert approved is True
+
+
+class TestWire5EnabledRiskOnLowersThreshold:
+    """Flag ON + risk-on → score gate fires at LOWER threshold."""
+
+    def test_risk_on_admits_score_below_base(self):
+        """Score 67 fails base 70 but passes regime-adjusted 64 (z=+3)."""
+        config = _base_config(regime_min_score_enabled=True)
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bull",
+            signal=_enter_signal(score=67),
+            config=config,
+            regime_intensity_z=3.0,
+        )
+        # z=+3, scale=2.0 → -6; base 70 → 64. 67 >= 64 → passes.
+        assert approved is True
+
+    def test_risk_on_still_rejects_far_below(self):
+        """Risk-on doesn't open the floodgates — score 50 still fails."""
+        config = _base_config(regime_min_score_enabled=True)
+        approved, reason = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bull",
+            signal=_enter_signal(score=50),
+            config=config,
+            regime_intensity_z=3.0,
+        )
+        # 50 < 64 (adjusted) → veto
+        assert approved is False
+
+
+class TestWire5NoneFallsBackToBase:
+    """Wire enabled but substrate read returned None → use base unchanged."""
+
+    def test_z_none_uses_base_threshold(self):
+        config = _base_config(regime_min_score_enabled=True)
+        # Score 70 should pass base 70 when z=None falls through
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="neutral",
+            signal=_enter_signal(score=70),
+            config=config,
+            regime_intensity_z=None,
+        )
+        assert approved is True
+
+
+class TestWire5StructuredEventContext:
+    """min_score veto events carry the base + regime context."""
+
+    def test_event_includes_base_and_intensity_z(self):
+        config = _base_config(regime_min_score_enabled=True)
+        events: list[dict] = []
+        check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=71),
+            config=config,
+            events=events,
+            regime_intensity_z=-3.0,
+        )
+        vetoes = [e for e in events if e.get("rule") == "min_score"]
+        assert len(vetoes) == 1
+        ctx = vetoes[0]["context"]
+        assert ctx["base_min_score"] == 70.0
+        assert ctx["regime_intensity_z"] == -3.0
+        # Threshold stamped on event is the SCALED value, not the raw base
+        assert vetoes[0]["threshold"] == 76.0
+
+    def test_event_z_none_when_substrate_missing(self):
+        """Event context records z=None when substrate is unavailable."""
+        config = _base_config(regime_min_score_enabled=True)
+        events: list[dict] = []
+        check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="neutral",
+            signal=_enter_signal(score=50),  # fails base 70
+            config=config,
+            events=events,
+            regime_intensity_z=None,
+        )
+        vetoes = [e for e in events if e.get("rule") == "min_score"]
+        assert len(vetoes) == 1
+        assert vetoes[0]["context"]["regime_intensity_z"] is None
+        assert vetoes[0]["threshold"] == 70.0  # base, unchanged
+
+
+class TestWire5ConfigParamsFlow:
+    """Custom scale/cap/floor/ceil from config flow through to helper."""
+
+    def test_custom_scale_amplifies_adjustment(self):
+        """At z=-2 with scale=5.0, adjustment = +10 (base 70 → 80)."""
+        config = _base_config(
+            regime_min_score_enabled=True,
+            regime_min_score_scale=5.0,
+        )
+        approved, reason = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=79),
+            config=config,
+            regime_intensity_z=-2.0,
+        )
+        # Adjusted threshold = 80; 79 < 80 → veto
+        assert approved is False
+        assert "minimum 80" in reason
+
+    def test_custom_cap_limits_adjustment(self):
+        """At z=-100 with cap=3, adjustment is +3 (base 70 → 73)."""
+        config = _base_config(
+            regime_min_score_enabled=True,
+            regime_min_score_cap=3.0,
+        )
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="ENTER",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=74),
+            config=config,
+            regime_intensity_z=-100.0,
+        )
+        # Adjusted threshold = 73; 74 >= 73 → passes
+        assert approved is True
+
+
+class TestWire5ExitsAndReducesBypassGate:
+    """EXIT and REDUCE actions skip ALL risk rules including score gate."""
+
+    def test_exit_bypasses_regime_score_gate(self):
+        config = _base_config(regime_min_score_enabled=True)
+        approved, _ = check_order(
+            ticker="AAPL",
+            action="EXIT",
+            dollar_size=1000,
+            portfolio_nav=100_000,
+            peak_nav=100_000,
+            current_positions={},
+            sector="Technology",
+            market_regime="bear",
+            signal=_enter_signal(score=10),  # absurdly low
+            config=config,
+            regime_intensity_z=-3.0,
+        )
+        assert approved is True


### PR DESCRIPTION
## Summary

**Wire 5 of 5 — the FINAL wire** of the Stage D' regime-as-gate arc per [`regime-v3-260514.md`](../alpha-engine-docs/private/regime-v3-260514.md) §6. Adds a regime-aware adjustment to `min_score_to_enter` in `risk_guard.check_order`: **risk-off raises** the threshold (more selective — only the best ideas qualify); **risk-on lowers** it (more inclusive — don't miss the tailwind).

### Curve

`adjusted = base + clamp(-intensity_z * scale, [-cap, +cap])` then clamped to `[floor, ceil]`. Defaults `scale=2.0 / cap=10.0 / floor=50.0 / ceil=90.0`.

| `intensity_z` | adjustment | net threshold (base 70) |
|---|---|---|
| -5.0 | clamped to +10 | 80 |
| -3.0 | +6 | 76 |
| -1.0 | +2 | 72 |
|  0.0 (neutral) | 0 | 70 (base) |
| +1.0 | -2 | 68 |
| +3.0 | -6 | 64 |
| +5.0 | clamped to -10 | 60 |
| None (substrate unavail) | 0 | base (legacy preserved) |

### Why opposite-sign vs Wire 4 (veto)?

Both wires gate entries; both follow the same SEMANTIC direction (*tighter in stress, looser in tailwind*) — but their underlying thresholds move in opposite directions to achieve that effect:

| Wire | Threshold direction in risk-on |
|---|---|
| Wire 4 (veto confidence) | **HIGHER** → harder to veto → more entries allowed |
| Wire 5 (entry score) | **LOWER** → easier to qualify → more entries allowed |

### Files

| File | Change |
|---|---|
| `executor/risk_guard.py` | New `regime_conditional_min_score` helper; `check_order` reads `regime_min_score_enabled / _scale / _cap / _floor / _ceil` from config and applies the regime-adjusted threshold; min_score veto events stamp `base_min_score` + `regime_intensity_z` context; persisted `threshold` is the scaled value |
| `config/risk.yaml.example` | New `regime_min_score_*` knobs (all gated off by default) |

### Threading reuse (zero new plumbing)

`check_order` already accepted `regime_intensity_z` (Wire 3 added it for the inner drawdown call). Wire 5 reuses that same threading — no new arg flow through `main.py` or `deciders.py`. The substrate read hoisted to §2b' (Wire 3) now serves all three executor wires (sizing, drawdown, min_score). The substrate read is gated by ANY of the three flags, so cycles with all off pay zero S3 GET overhead.

### Gate discipline

`regime_min_score_enabled` defaults **False**. Operator flips ON via `alpha-engine-config/executor/risk.yaml` after 4+ weeks of substrate observation through the dashboard's Regime page (Stage A PR 3) alongside Wires 2-4.

### Tests (+23 new + 873 total passing)

- `regime_conditional_min_score` math (None / 0 / +z / -z / cap at +adj / cap at -adj / floor clamp / ceil clamp / custom scale-cap-floor-ceil)
- **Wire OFF by default**: even z=-3 has zero effect (regression guard)
- **Risk-off raises**: score 71 fails at adjusted 76; score 80 still passes
- **Risk-on lowers**: score 67 passes at adjusted 64; score 50 still rejected (no floodgates)
- `z=None` → base unchanged (substrate-unavailable path)
- Structured event context: includes `base_min_score` + `regime_intensity_z`; persisted `threshold` is the SCALED value
- `z=None` event: `regime_intensity_z=None`; `threshold=base` unchanged
- Custom `regime_min_score_scale` and `_cap` from config flow through
- EXIT/REDUCE bypass the gate (regression guard for the early-return in check_order)

## Stage D' arc COMPLETE 🏁

All 5 wires shipped:

| Wire | PR | What |
|---|---|---|
| 1 | [research#188](https://github.com/cipher813/alpha-engine-research/pull/188) ✅ | sector teams allowed to emit 0 picks |
| 2 | [executor#178](https://github.com/cipher813/alpha-engine/pull/178) ✅ | position sizing regime multiplier |
| 3 | [executor#179](https://github.com/cipher813/alpha-engine/pull/179) ✅ | regime-aware drawdown tiers |
| 4 | [predictor#160](https://github.com/cipher813/alpha-engine-predictor/pull/160) ✅ | regime-conditional veto threshold |
| 5 | **this PR** | regime-conditional entry score threshold |

Stages A (substrate writer) + B (graph topology serialization) + C (macro agent + 3-tier eval) + D (META_FEATURE) all shipped in prior arcs; Stage D' completes the GATE side of the institutional **gate+feature** framing. The system now has both a continuous quantitative regime feature (Stage D, feeding the L2 Ridge) AND five regime-aware gating surfaces (Stage D', sector picks + sizing + drawdown + veto + entry score) — all sharing the same predictor substrate (`s3://.../regime/latest.json`) and all defaulting to dormant pending the 4-week per-wire observation windows.

Reference: `~/Development/alpha-engine-docs/private/regime-v3-260514.md` §6 Stage D'

🤖 Generated with [Claude Code](https://claude.com/claude-code)