### PR TITLE
fix(eod_reconcile): macro-aware dispatch for held-position close lookup

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -533,17 +533,35 @@ def run(run_date: str | None = None) -> None:
         else f"NAV=${nav:,.2f} | prior_nav={prior_nav}"
     )
 
-    # ── Load closing prices from ArcticDB universe library ─────────────────
+    # ── Load closing prices from ArcticDB ──────────────────────────────────
     # Hard-fails on any miss: EOD reconcile must reconcile against an
     # authoritative price source, not IB Gateway's delayed intraday data.
-    from executor.price_cache import _open_universe_library
+    #
+    # Macro-routed held positions (SPY/sector ETFs/etc.) live in the
+    # `macro` library, NOT `universe`. The portfolio-optimizer cutover
+    # (2026-05-13) made SPY a held core position; its first EOD on
+    # 2026-05-14 raised NoSuchVersionException because reconcile was
+    # universe-only. Mirror price_cache.load_price_histories' macro-aware
+    # dispatch (executor/price_cache.py:128-145, _MACRO_SYMBOLS).
+    from executor.price_cache import (
+        _open_universe_library,
+        _open_macro_library,
+        _MACRO_SYMBOLS,
+    )
     universe_lib = _open_universe_library(trades_bucket)
+    macro_lib = None  # lazy-open only if a macro-routed held ticker appears
     target_ts = pd.Timestamp(run_date).normalize()
     closing_prices: dict[str, float] = {}
     missing: list[str] = []
     for ticker in positions.keys():
+        if ticker in _MACRO_SYMBOLS:
+            if macro_lib is None:
+                macro_lib = _open_macro_library(trades_bucket)
+            lib = macro_lib
+        else:
+            lib = universe_lib
         try:
-            df = universe_lib.read(ticker).data
+            df = lib.read(ticker).data
         except Exception as e:
             missing.append(f"{ticker} ({e.__class__.__name__})")
             continue

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -504,3 +504,41 @@ class TestSnapshotContract:
         parser.add_argument("--date", default=None)
         args = parser.parse_args([])
         assert args.date is None
+
+
+# ── Held-position close lookup: macro-routed tickers ─────────────────────────
+# 2026-05-14 EOD: portfolio-optimizer cutover (Tue 2026-05-13) introduced SPY
+# as a held core position. The held-position close lookup in run() reads from
+# universe_lib only; SPY lives in macro_lib, so universe_lib.read("SPY")
+# raised NoSuchVersionException and the whole EOD reconcile crashed. The fix
+# mirrors price_cache.load_price_histories' macro-aware dispatch.
+
+
+def test_eod_reconcile_uses_macro_aware_dispatch_for_held_positions():
+    """Pin the macro-aware dispatch in run()'s held-position close lookup.
+
+    Source-level pin: a future PR that removes the dispatch and reverts
+    to universe-only reads would re-introduce the 2026-05-14 EOD outage
+    the moment the optimizer holds SPY (or any sector ETF — XLB/XLC/XLE
+    /XLF/XLI/XLK/XLP/XLRE/XLU/XLV/XLY).
+    """
+    from pathlib import Path
+
+    src = (Path(__file__).parent.parent / "executor" / "eod_reconcile.py").read_text()
+
+    assert "_MACRO_SYMBOLS" in src, (
+        "eod_reconcile.run() must import _MACRO_SYMBOLS from price_cache "
+        "and dispatch held-position reads between universe_lib and "
+        "macro_lib — universe-only reads crash on SPY (held under "
+        "portfolio-optimizer cutover, 2026-05-13)."
+    )
+    assert "_open_macro_library" in src, (
+        "eod_reconcile.run() must lazy-open macro_lib for held tickers "
+        "in _MACRO_SYMBOLS — without this, SPY/sector-ETF held positions "
+        "raise NoSuchVersionException against universe_lib."
+    )
+    assert "if ticker in _MACRO_SYMBOLS" in src, (
+        "Held-position read loop must branch on _MACRO_SYMBOLS membership "
+        "to route reads between universe_lib and macro_lib (mirrors "
+        "price_cache.load_price_histories:128-145)."
+    )


### PR DESCRIPTION
## Summary
- 2026-05-14 EOD pipeline failure surface #2 (after `alpha-engine-data#238` fixed daily_append column order): `EODReconcile` crashed with `RuntimeError: ArcticDB closing-price lookup failed for 1 held ticker(s) on 2026-05-14: ['SPY (NoSuchVersionException)']`.
- Root cause: `run()` opens `universe_lib` only and reads every held position from it. SPY lives in `macro_lib`. Yesterday's portfolio-optimizer cutover (`alpha-engine-config#172`, flipped 2026-05-13) made SPY a held core position via the enhanced-index design (~63% SPY core); today's EOD is the first one to read a macro-routed held ticker.
- Fix: mirror `price_cache.load_price_histories`' macro-aware dispatch (`executor/price_cache.py:128-145`, `_MACRO_SYMBOLS`). Lazy-open `macro_lib` only when a macro-routed held ticker appears.

## Why this only surfaced today
Pre-optimizer-cutover, held positions were always individual stocks (universe_lib). The enhanced-index design holds **SPY as ~63% of NAV** + active overweights + 3% cash sleeve; SPY is the first held ticker that doesn't live in `universe_lib`. Yesterday's snapshot was captured under the pre-cutover positions.

## Verification
- SPY in `macro_lib`: `last_idx 2026-05-14`, `Close $748.17` ✓
- SPY in `universe_lib`: `NoSuchVersionException E_NO_SUCH_VERSION read_dataframe_version: version matching query 'latest' not found for symbol 'SPY'` ✓
- Snapshot for today already captured cleanly (NAV=\$1,035,718.99, 3 positions); only the held-position close lookup was blocking reconcile.
- Full test suite: **874 passed** (was 873; +1 source-level dispatch pin).

## Coverage of `_MACRO_SYMBOLS`
Already includes SPY + 11 sector ETFs (XLB/XLC/XLE/XLF/XLI/XLK/XLP/XLRE/XLU/XLV/XLY) + GLD/USO + 4 index symbols. No new symbol-list maintenance required as the optimizer's allowed sleeve evolves.

## Test plan
- [x] `pytest tests/test_eod_reconcile.py` (64 passed including the new dispatch pin)
- [x] `pytest tests/` (full suite 874 passed)
- [ ] Tonight: in-place patch on `i-018e…329bf`, manually rerun `executor/eod_reconcile.py --date 2026-05-14`, then stop the trading instance.
- [ ] Tomorrow's EOD first-pass on the merged code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)