### PR TITLE
fix(executor): exclude macro-routed tickers from morning-planner ATR set

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -41,6 +41,7 @@ from executor.signal_reader import get_actionable_signals, read_signals_with_fal
 from executor.strategies.config import load_strategy_config
 from executor.strategies.exit_manager import evaluate_exits, SECTOR_ETF_MAP
 from executor.price_cache import (
+    _MACRO_SYMBOLS,
     load_atr_14_pct,
     load_daily_vwap,
     load_feature_coverage,
@@ -1100,8 +1101,19 @@ def run(
         # missing ticker or stale data — feedback_hard_fail_until_stable.
         # Scope: signal tickers (ENTER) + held positions (for trailing stops).
         #
-        # ETF tickers are intentionally excluded — they're used for sector-relative
-        # exit veto via price_histories, not for ATR-based execution.
+        # Macro-routed tickers (SPY/sector ETFs/VIX/etc., see _MACRO_SYMBOLS)
+        # are intentionally excluded. They're used for sector-relative exit
+        # veto via price_histories, not ATR-based execution, and they live in
+        # the Close-only `macro` ArcticDB library which has no atr_14_pct
+        # feature column. The portfolio-optimizer cutover (2026-05-13) made
+        # SPY a held core position via the enhanced-index design (~63% SPY
+        # core); without this filter `current_positions` injects SPY into the
+        # ATR set and load_atr_14_pct hard-fails with NoSuchVersionException
+        # (universe-only read). Same root-cause family as eod_reconcile #181,
+        # but the right remedy for ATR is exclusion (macro lib has no ATR),
+        # not macro-lib dispatch. The SPY core is rebalanced by the optimizer,
+        # not ATR trailing stops; _write_stops_and_finalize's atr_map.get(t)
+        # already skips-with-warning when a held position has no ATR.
         #
         # ``atr_map`` kwarg mirrors the vwap_map injection pattern — backtester
         # precomputes once per simulate pipeline, skipping millions of
@@ -1109,7 +1121,7 @@ def run(
         # atr_map=None and takes the load_atr_14_pct path unchanged.
         atr_tickers = [s["ticker"] for s in signals.get("enter", [])]
         atr_tickers += list(current_positions.keys())
-        atr_tickers = sorted(set(atr_tickers))
+        atr_tickers = sorted(set(atr_tickers) - _MACRO_SYMBOLS)
         if atr_map is None:
             if atr_tickers:
                 atr_map = load_atr_14_pct(

--- a/tests/test_executor_run_precompute_kwargs.py
+++ b/tests/test_executor_run_precompute_kwargs.py
@@ -253,3 +253,48 @@ def test_run_accepts_injected_maps_via_kwargs():
             inspect.Parameter.KEYWORD_ONLY,
             inspect.Parameter.POSITIONAL_OR_KEYWORD,
         ), f"{name} must be keyword-callable, got kind={kind}"
+
+
+# ── Macro-symbol exclusion from the ATR set ─────────────────────────────────
+
+
+def test_atr_tickers_excludes_macro_symbols():
+    """The 2026-05-15 weekday SF morning-planner failure: the
+    portfolio-optimizer cutover (2026-05-13) made SPY a held core
+    position, so ``current_positions`` injected SPY into ``atr_tickers``.
+    SPY lives in the Close-only ``macro`` ArcticDB library (no
+    atr_14_pct column) and is absent from ``universe`` →
+    ``load_atr_14_pct`` hard-failed with NoSuchVersionException, taking
+    down the whole planner before the daemon could start.
+
+    Same root-cause family as eod_reconcile #181, but the correct
+    remedy for ATR is *exclusion* (macro lib has no ATR feature), not
+    macro-lib dispatch. Lock the ``- _MACRO_SYMBOLS`` set-difference so
+    a refactor can't silently re-admit SPY/ETFs to the ATR set.
+    """
+    src = _source()
+    assert "_MACRO_SYMBOLS" in src, (
+        "main.py must import _MACRO_SYMBOLS to exclude macro-routed "
+        "held positions (SPY core etc.) from the ATR lookup."
+    )
+    assert "set(atr_tickers) - _MACRO_SYMBOLS" in src, (
+        "atr_tickers must subtract _MACRO_SYMBOLS — without it the "
+        "SPY-as-held-core optimizer cutover re-breaks the morning "
+        "planner via load_atr_14_pct NoSuchVersionException "
+        "(2026-05-15 weekday SF failure)."
+    )
+
+
+def test_main_imports_macro_symbols_from_price_cache():
+    """``_MACRO_SYMBOLS`` is the single source of truth for macro-routed
+    tickers (defined in price_cache.py, also consumed by
+    load_price_histories + eod_reconcile #181). Pin the import so the
+    exclusion set never drifts from the dispatch set.
+    """
+    from executor.price_cache import _MACRO_SYMBOLS
+
+    assert "SPY" in _MACRO_SYMBOLS
+    assert executor_main._MACRO_SYMBOLS is _MACRO_SYMBOLS, (
+        "executor.main must reuse price_cache._MACRO_SYMBOLS, not "
+        "redefine its own macro set (drift risk)."
+    )


### PR DESCRIPTION
## 2026-05-15 weekday SF morning-planner failure

`RunMorningPlanner` crashed before `RunDaemon` could start (no trading 5/15):

```
RuntimeError: load_atr_14_pct failed validation — executor morning planner
cannot proceed without a trustworthy ATR for every signal ticker.
Requested 28 tickers, resolved 27. Problems: missing_symbol=['SPY (NoSuchVersionException)']
```

### Root cause

The portfolio-optimizer cutover (alpha-engine-config#172, flipped 2026-05-13) made **SPY a held core position** via the enhanced-index design (~63% SPY core). `main.py` builds `atr_tickers` from signal ENTER tickers **+ `current_positions.keys()`**. The first weekday SF whose held set actually includes SPY (5/14 morning had no SPY position yet — it was established by the 5/14 EOD optimizer rebalance) injected SPY into `load_atr_14_pct`.

SPY lives in the Close-only `macro` ArcticDB library (no `atr_14_pct` feature) and is absent from `universe`, so `universe.read('SPY')` → `NoSuchVersionException` → the hard-fail validation gate took down the whole planner.

Same root-cause family as eod_reconcile #181 (SPY-as-held-core / optimizer cutover), but the correct remedy for ATR is **exclusion**, not macro-lib dispatch:
- the macro lib has no `atr_14_pct` column (dispatch would just fail on `missing_feature`)
- the SPY core is rebalanced by the portfolio optimizer, not ATR trailing stops
- `_write_stops_and_finalize`'s `atr_map.get(t)` already skips-with-warning when a held position has no ATR → exclusion is behaviour-neutral for stop logic
- matches the call site's pre-existing documented intent ("ETF tickers are intentionally excluded ... not for ATR-based execution")

### Fix

Subtract `price_cache._MACRO_SYMBOLS` (single source of truth, also consumed by `load_price_histories` + eod_reconcile #181) from `atr_tickers`.

### Tests

Full suite **876 passed** (was 874, +2 source-level exclusion pins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)