### PR TITLE
feat(regime): F2 executor forced-bear posture override (gated, parallel-observe)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -133,6 +133,23 @@ regime_drawdown_scale: 0.10      # per-σ sensitivity on the threshold magnitude
 regime_drawdown_floor: 0.60      # clamp lower bound (max tightening = 40%)
 regime_drawdown_ceil:  1.40      # clamp upper bound (max loosening = 40%)
 
+# ── Forced-bear circuit-breaker (Stage F2, regime-fast-signal-260515) ──────
+# Off by default; ships dormant + parallel-observe. The daily BOCPD
+# fast signal (s3://.../regime/fast_signal/latest.json, produced by
+# alpha-engine-predictor) latches ``forced_bear`` on a confirmed midweek
+# regime break. When ON, the planner's effective ``market_regime``
+# becomes "bear" for ALL gating reads (sizing Wire 2, drawdown Wire 3,
+# entry-score Wire 5, bear_* risk.yaml overrides) — no separate halt
+# knob, forced_bear == bear. Bear caps are hard ceilings so the
+# most-protective of {continuous wires, bear floor} binds (no
+# double-count). The fast signal is READ every cycle regardless of this
+# flag (parallel-observe); only the regime override is gated. Operator
+# flips ``regime_forced_bear_enabled: true`` after the F1 backfill
+# calibration clears its gate (positive lead vs smoothed-HMM + sane
+# whipsaw) AND the F2 parallel-observe window shows the counterfactual
+# would have helped the skilled-risk basket.
+regime_forced_bear_enabled: false  # gate-off by default; flip after F1+F2 gates
+
 # ── Regime-conditional entry score threshold (Stage D' Wire 5, regime-v3-260514) ─
 # Off by default; ships dormant. When ON, ``min_score_to_enter`` is adjusted by
 # ``-intensity_z * regime_min_score_scale`` clamped to

--- a/executor/main.py
+++ b/executor/main.py
@@ -995,6 +995,53 @@ def run(
                 )
                 regime_intensity_z = None
 
+        # ── 2b''. Resolve daily fast-signal forced-bear latch (F2) ─────────────
+        # regime-fast-signal-260515.md Stage F2. The daily BOCPD
+        # circuit-breaker (alpha-engine-predictor regime_fast_signal
+        # stage) latches forced_bear on a confirmed midweek regime
+        # break. When acting, the planner's EFFECTIVE market_regime
+        # becomes "bear" for ALL gating reads — sizing (Wire 2), drawdown
+        # tiers (Wire 3), entry-score gate, and the existing
+        # ``market_regime == "bear"`` risk.yaml overrides
+        # (bear_max_position_pct etc.). No separate halt knob: forced_bear
+        # == bear, the system already knows what bear means. Bear caps
+        # are hard ceilings so the most-protective of {continuous wires,
+        # bear floor} naturally binds (guardrail 3, no double-count).
+        #
+        # The read is UNGATED (always in non-simulate) so the F2
+        # parallel-observe window has data even with the flag off; the
+        # behavior (regime override) is gated on
+        # ``regime_forced_bear_enabled`` (default false). One S3 GET per
+        # planning cycle — negligible (planner runs ~1×/morning).
+        if not simulate:
+            try:
+                from executor.signal_reader import (
+                    extract_forced_bear,
+                    read_fast_signal,
+                )
+                _fb = extract_forced_bear(read_fast_signal(signals_bucket))
+                if _fb and config.get("regime_forced_bear_enabled", False):
+                    logger.warning(
+                        "FORCED-BEAR active — overriding effective "
+                        "market_regime '%s' → 'bear' for this planning "
+                        "cycle (research regime preserved for audit). "
+                        "Source: daily BOCPD fast signal.",
+                        market_regime,
+                    )
+                    market_regime = "bear"
+                elif _fb:
+                    logger.info(
+                        "regime_forced_bear OBSERVE (flag off): fast "
+                        "signal latched forced_bear=True; would override "
+                        "market_regime '%s' → 'bear'. No behavior change.",
+                        market_regime,
+                    )
+            except Exception as _fb_err:
+                logger.warning(
+                    "fast-signal read failed (%s) — forced-bear not "
+                    "applied; legacy regime behavior preserved.", _fb_err,
+                )
+
         # ── 2c. Compute graduated drawdown multiplier ──────────────────────────
         # Pass an events sink so any halt/throttle event lands in
         # `risk_events` ONCE per planning cycle (the per-ticker check_order

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -59,6 +59,42 @@ def extract_intensity_z(substrate: dict | None) -> float | None:
     return None
 
 
+REGIME_FAST_SIGNAL_PREFIX = "regime/fast_signal"
+
+
+def read_fast_signal(s3_bucket: str) -> dict | None:
+    """Read the latest daily fast-signal artifact (Stage F2).
+
+    Mirror of ``read_regime_substrate``. Wraps
+    ``load_latest_eval_artifact`` on ``s3://{bucket}/regime/fast_signal/
+    latest.json`` — the observe-only daily BOCPD circuit-breaker output
+    produced by alpha-engine-predictor's ``regime_fast_signal``
+    inference stage (regime-fast-signal-260515.md). Returns the parsed
+    payload (``forced_bear``, ``intensity_z``, ``change_confidence``,
+    ``warmup``, …) or ``None`` if unavailable. ``None`` ⇒ the executor
+    treats forced_bear as False (legacy behavior preserved).
+    """
+    s3 = boto3.client("s3")
+    return load_latest_eval_artifact(
+        s3, bucket=s3_bucket, prefix=REGIME_FAST_SIGNAL_PREFIX,
+    )
+
+
+def extract_forced_bear(fast_signal: dict | None) -> bool:
+    """Pull the ``forced_bear`` latch out of a fast-signal payload.
+
+    Returns ``False`` when the payload is None, malformed, or still in
+    ``warmup`` (a warming detector must never assert a regime break —
+    the producer already suppresses forced_bear during warmup, this is
+    defence-in-depth against schema drift / a stale artifact).
+    """
+    if not isinstance(fast_signal, dict):
+        return False
+    if fast_signal.get("warmup") is True:
+        return False
+    return fast_signal.get("forced_bear") is True
+
+
 def read_predictions(s3_bucket: str) -> tuple[dict[str, dict], str | None]:
     """
     Read predictor/predictions/latest.json from S3.

--- a/tests/test_regime_fast_signal_executor.py
+++ b/tests/test_regime_fast_signal_executor.py
@@ -1,0 +1,69 @@
+"""Executor-side Stage F2 — read_fast_signal + extract_forced_bear.
+
+regime-fast-signal-260515.md. Mirrors the Wire-2 substrate-helper
+schema-defense tests. The main.py forced-bear override itself is
+exercised via the existing planner integration paths; here we pin the
+two pure helpers + the read wrapper.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from executor.signal_reader import (
+    REGIME_FAST_SIGNAL_PREFIX,
+    extract_forced_bear,
+    read_fast_signal,
+)
+
+
+class TestExtractForcedBear:
+    def test_true_when_latched_and_not_warmup(self):
+        assert extract_forced_bear(
+            {"forced_bear": True, "warmup": False}
+        ) is True
+
+    def test_false_when_not_latched(self):
+        assert extract_forced_bear(
+            {"forced_bear": False, "warmup": False}
+        ) is False
+
+    def test_warmup_suppresses_even_if_latched(self):
+        # Defence-in-depth: a warming detector must never assert a break
+        # even if a stale/odd artifact carries forced_bear=True.
+        assert extract_forced_bear(
+            {"forced_bear": True, "warmup": True}
+        ) is False
+
+    def test_none_payload_is_false(self):
+        assert extract_forced_bear(None) is False
+
+    def test_non_dict_is_false(self):
+        assert extract_forced_bear("nope") is False
+        assert extract_forced_bear(42) is False
+
+    def test_missing_forced_bear_key_is_false(self):
+        assert extract_forced_bear({"intensity_z": -2.0}) is False
+
+    def test_non_bool_forced_bear_is_false(self):
+        # Strict identity check — only literal True latches.
+        assert extract_forced_bear({"forced_bear": 1}) is False
+        assert extract_forced_bear({"forced_bear": "true"}) is False
+
+
+class TestReadFastSignal:
+    @patch("executor.signal_reader.boto3")
+    @patch("executor.signal_reader.load_latest_eval_artifact")
+    def test_reads_canonical_prefix(self, mock_load, _mock_boto3):
+        mock_load.return_value = {"forced_bear": True, "warmup": False}
+        out = read_fast_signal("alpha-engine-research")
+        assert out == {"forced_bear": True, "warmup": False}
+        _, kwargs = mock_load.call_args
+        assert kwargs["bucket"] == "alpha-engine-research"
+        assert kwargs["prefix"] == REGIME_FAST_SIGNAL_PREFIX == "regime/fast_signal"
+
+    @patch("executor.signal_reader.boto3")
+    @patch("executor.signal_reader.load_latest_eval_artifact", return_value=None)
+    def test_none_artifact_propagates(self, _mock_load, _mock_boto3):
+        assert read_fast_signal("b") is None
+        # composes with extract_forced_bear → safe False
+        assert extract_forced_bear(read_fast_signal("b")) is False


### PR DESCRIPTION
## Stage F2 — executor half of `regime-fast-signal-260515.md`

The daily BOCPD circuit-breaker latches `forced_bear` on a confirmed midweek regime break; this wires the executor to flip into `bear` posture in lockstep with the predictor veto (PR #166). **Gated `regime_forced_bear_enabled` (default false) + parallel-observe — no behavior change until the F1+F2 gates clear.**

### Changes
- **`signal_reader.read_fast_signal()` + `extract_forced_bear()`** — mirror of `read_regime_substrate`/`extract_intensity_z`, reading `regime/fast_signal/latest.json`. Warmup-suppressed + schema-defensive (only literal `True` + non-warmup latches).
- **`main.py` §2b''** — fast signal read **every** non-simulate planning cycle (so the F2 observation window has data even with the flag off); the `market_regime := "bear"` override is gated on the flag. Forced_bear == bear: reuses the existing, tested bear plumbing (sizing W2, drawdown W3, entry-score W5, `bear_*` risk.yaml caps). Bear caps are hard ceilings → most-protective binds, no double-count with the continuous wires (guardrail 3). Research regime preserved for audit; flag-off path logs the counterfactual.
- **`config/risk.yaml.example`** — `regime_forced_bear_enabled: false`, mirroring the Stage D' Wire 2/3 gate-off pattern.

### Verification
`883 passed` full executor suite (zero-tolerance). 9 new tests. Defensively wrapped (try/except, gated, fail-safe to no-op) so a fast-signal read failure never affects planning.

### Composition
Pairs with predictor PR #166 — both gating surfaces flip together on a confirmed break. No alpha-engine-config PR (flag lives in `risk.yaml.example` per the established Stage D' pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)