### PR TITLE
fix(daemon): add EnvironmentFile to systemd unit — close PR 9g env gap

### DIFF
--- a/infrastructure/systemd/alpha-engine-daemon.service
+++ b/infrastructure/systemd/alpha-engine-daemon.service
@@ -20,6 +20,15 @@ Environment=PYTHONPATH=/home/ec2-user/alpha-engine
 Environment=AWS_REGION=us-east-1
 Environment=ALPHA_ENGINE_JSON_LOGS=1
 Environment=FLOW_DOCTOR_ENABLED=1
+# Secrets (EMAIL_SENDER, GMAIL_APP_PASSWORD, ANTHROPIC_API_KEY, ...) — the
+# RunDaemon SSM step launches this unit via systemd, which (unlike the SF's
+# RunMorningPlanner command) does not `source` the env file. PR 9g (#182)
+# deleted the ssm_secrets import-time shim that previously populated these
+# for the daemon, so flow-doctor's ${EMAIL_SENDER} resolution crash-looped
+# the daemon (2026-05-15). Mirror the morning-planner path until the
+# .env-deprecation arc's SSM substrate fully covers systemd entrypoints.
+# Leading `-` tolerates the file's eventual removal (no hard failure).
+EnvironmentFile=-/home/ec2-user/.alpha-engine.env
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## 2026-05-15 weekday-SF recovery — daemon crash loop

PR 9g (#182, .env-deprecation) deleted the `ssm_secrets` import-time shim that was the **daemon's only env-population path**. The daemon is launched via systemd (`RunDaemon` = `systemctl restart alpha-engine-daemon.service`), which — unlike the SF's `RunMorningPlanner` SSM command (`set -a && source /home/ec2-user/.alpha-engine.env`) — has no env source. flow-doctor's `${EMAIL_SENDER}` resolution then crash-looped the daemon:

```
flow_doctor.core.errors.ConfigError: Unresolved environment variable(s)
in flow-doctor config: EMAIL_SENDER
```

The morning planner survived only because its SSM command explicitly sources `.alpha-engine.env`. **This would have broken the next clean weekday SF (Mon 5/18) regardless** — the 5/15 recovery just surfaced it early.

## Fix

Add `EnvironmentFile=-/home/ec2-user/.alpha-engine.env` to the daemon unit, mirroring the working morning-planner path. Leading `-` tolerates the file's eventual removal once the .env-deprecation SSM substrate fully covers systemd entrypoints.

## Follow-up

Tracked separately: complete the .env-deprecation arc for systemd entrypoints (load secrets via `alpha_engine_lib.secrets.get_secret()` into os.environ before flow-doctor init), then the operator-owed `rm ~/.alpha-engine.env` can proceed. Until then the runtime still depends on `.alpha-engine.env` (SF `RunMorningPlanner` also sources it).

Live recovery: same line patched into `/etc/systemd/system/` on ae-trading + daemon-reload + restart (market-hours recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)