### PR TITLE
fix(executor): bump alpha-engine-lib v0.16.0 → v0.17.0 — close PR 9g env gap upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,11 @@ requests~=2.32
 # v0.16.0 adds load_latest_eval_artifact + list_eval_artifacts for the
 # canonical eval-artifact partition shape (YYMMDDHHMM run_id + sidecar);
 # required by signal_reader.read_regime_substrate (Stage D' Wire 2).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.16.0
+# v0.17.0 seeds flow-doctor ${VAR} secrets via get_secret() inside
+# setup_logging()/_attach_flow_doctor() before flow_doctor.init() reads
+# os.environ — closes the PR 9g systemd-entrypoint env gap upstream for
+# all repos (replaces the executor-local secrets_bootstrap.py approach).
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.17.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
## Summary

Closes the **P0** PR 9g (.env-deprecation) systemd-entrypoint env gap via the **upstream lib fix** rather than executor-local code. Supersedes the original `executor/secrets_bootstrap.py` version of this PR.

### Why the rework

flow-doctor resolves every `${VAR}` in `flow-doctor.yaml` from `os.environ` eagerly inside `flow_doctor.init()`, before any lazy `get_secret()` runs. This mismatch is **structural and identical in every repo** — not executor-specific. `alpha_engine_lib.logging.setup_logging()` → `_attach_flow_doctor()` is the single chokepoint every repo reaches flow-doctor through, and lib already owns it and has `get_secret()`.

The original executor-local `secrets_bootstrap.py` would need duplicating across 6+ repos, each with a hand-maintained `_FLOW_DOCTOR_SECRETS` list + yaml-sync AST test — and the `${VAR}` sets differ per repo, so that's 6 independent drift surfaces. The upstream fix (**alpha-engine-lib PR #48**, parses the var set from the yaml itself) closes the gap system-wide with zero per-repo code.

### This PR

One change: bump the lib pin `v0.16.0 → v0.17.0` (+ a comment explaining why). The `secrets_bootstrap.py` + 4 entrypoint wirings + `test_secrets_bootstrap.py` from the previous revision of this branch are dropped — that logic now lives in lib.

### Dependency / gating

⚠️ **Cannot merge until alpha-engine-lib PR #48 is merged and `v0.17.0` is auto-tagged** — the git+https pin won't resolve (and CI/dry-run will fail to install) until the tag exists. Merge order: lib #48 → tag v0.17.0 → this PR.

### Scope boundary

Does **not** retire the #187 `EnvironmentFile=-` bridge or the SF `source` line. That stays as belt-and-suspenders until the operator deletes `.alpha-engine.env` on a canary and one weekday + one Saturday SF run clean (ROADMAP P0 closure step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)