### PR TITLE
feat(executor): per-ticker order-book rationale artifact

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -1457,6 +1457,53 @@ def run(
             except Exception as e:
                 logger.warning("Failed to write order book: %s", e)
 
+        # ── 6b. Per-ticker order-book rationale artifact ────────────────────────
+        # Audit-stable record answering "why is ticker X in state S
+        # today" for the whole considered universe (incl. excluded /
+        # vetoed). Pure join + serialize over structures already
+        # materialized above — no new instrumentation. Non-blocking:
+        # the planner must never fail over an audit artifact (same
+        # posture as the shadow optimizer + data manifest below).
+        if not simulate and not dry_run and signals_bucket:
+            try:
+                import boto3
+
+                from alpha_engine_lib.dates import now_dual
+                from alpha_engine_lib.eval_artifacts import new_eval_run_id
+                from executor.order_book_rationale import (
+                    build_order_book_rationale,
+                    write_order_book_rationale,
+                )
+
+                _dual = now_dual()
+                _rationale = build_order_book_rationale(
+                    signals=signals,
+                    predictions_by_ticker=predictions_by_ticker,
+                    order_book_data=ob.data,
+                    blocked_entries=blocked_entries,
+                    risk_events=plan_risk_events,
+                    market_regime=market_regime,
+                    run_date=run_date,
+                    signal_date=(
+                        signals_raw.get("date", run_date)
+                        if signals_raw else run_date
+                    ),
+                    prediction_date=predictions_date,
+                    calendar_date=_dual.calendar_date,
+                    trading_day=_dual.trading_day,
+                    run_id=new_eval_run_id(),
+                )
+                write_order_book_rationale(
+                    _rationale,
+                    s3_client=boto3.client("s3"),
+                    bucket=signals_bucket,
+                )
+            except Exception as _rat_err:
+                logger.warning(
+                    "Order-book rationale write failed (non-blocking): %s",
+                    _rat_err,
+                )
+
         # ── 7. Backup and disconnect ─────────────────────────────────────────
         if not dry_run and not simulate:
             backup_to_s3(db_path, run_date, trades_bucket)

--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -1,0 +1,383 @@
+"""
+order_book_rationale.py — Per-ticker daily order-book decision record.
+
+The order-book state for a ticker on a given day (approved entry /
+urgent exit / reduce / held / risk-blocked / predictor-vetoed) is the
+*output* of a multi-stage decision chain: research signal read →
+predictor veto → risk-guard rules → position sizer → intraday entry
+trigger. The individual inputs are each observable (``signals.json``,
+``predictions/{date}.json``, the ``risk_events`` SQLite table, the
+order book JSON) but no single per-ticker artifact answers
+*"why is ticker X in state S today?"* for the **whole considered
+universe** — including the tickers that did *not* make it in (the
+"why didn't Y enter" question is as operationally important as the
+"why did X enter" one).
+
+This module builds that record. It is a pure join + serialize over
+structures already materialized by the morning planner — it adds **no
+new instrumentation**. It reuses the ``risk_events`` rule slugs
+(alpha-engine #139), the signal/prediction lineage columns
+(alpha-engine #138), and the ``entries_with_meta`` sizing breakdown
+the order book already carries.
+
+The artifact is written in the canonical ``alpha_engine_lib.eval_artifacts``
+shape (``{prefix}/{run_id}.json`` dated forensic artifact + a
+``{prefix}/latest.json`` operator-UX sidecar) so the dashboard reads it
+with the same ``load_latest_eval_artifact`` / ``list_eval_artifacts``
+helpers every other eval-style artifact uses, and same-day re-runs are
+preserved for audit.
+
+The record is reproducible from the artifact alone — it carries the
+research sub-scores, predictor outputs, the risk slug + threshold that
+excluded a ticker, the full sizing-factor breakdown, and the intraday
+trigger config. Nothing in it requires re-opening S3 or querying
+SQLite to interpret.
+
+Producer of the consumer-facing transparency surface tracked in
+ROADMAP "Per-ticker daily order-book rationale record + console tab".
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1.0.0"
+
+# Default S3 prefix. Lives under ``trades/`` alongside the order book
+# itself (``trades/order_book/{date}.json``) so the rationale and the
+# book it explains are co-located in the audit namespace.
+DEFAULT_S3_PREFIX = "trades/order_book_rationale"
+
+# Terminal-state vocabulary. Ordered most-actioned → least so listings
+# and the console table surface entries/exits before held/no-action.
+STATE_APPROVED_ENTRY = "approved_entry"
+STATE_URGENT_EXIT = "urgent_exit"
+STATE_REDUCE = "reduce"
+STATE_PREDICTOR_VETOED = "predictor_vetoed"
+STATE_RISK_BLOCKED = "risk_blocked"
+STATE_HELD = "held"
+STATE_NO_ACTION = "no_action"
+
+_STATE_ORDER = {
+    STATE_APPROVED_ENTRY: 0,
+    STATE_URGENT_EXIT: 1,
+    STATE_REDUCE: 2,
+    STATE_PREDICTOR_VETOED: 3,
+    STATE_RISK_BLOCKED: 4,
+    STATE_HELD: 5,
+    STATE_NO_ACTION: 6,
+}
+
+# risk_events rules emitted when the *predictor* (not research/risk)
+# drove the rejection — these map to STATE_PREDICTOR_VETOED so the
+# console can answer "blocked by the ML layer" distinctly from
+# "blocked by a hard risk rule". Sourced from deciders.py emit sites.
+_PREDICTOR_RULES = {"stance_gate", "momentum_gate"}
+
+
+def _research_block(sig: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Project the research signal fields the record exposes."""
+    if not sig:
+        return {}
+    return {
+        "signal": sig.get("signal"),
+        "score": sig.get("score"),
+        "conviction": sig.get("conviction"),
+        "rating": sig.get("rating"),
+        "sector": sig.get("sector"),
+        "sector_rating": sig.get("sector_rating"),
+        "price_target_upside": sig.get("price_target_upside"),
+        "thesis_summary": sig.get("thesis_summary"),
+    }
+
+
+def _predictor_block(pred: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Project the predictor fields the record exposes."""
+    if not pred:
+        return {}
+    return {
+        "predicted_direction": pred.get("predicted_direction"),
+        "prediction_confidence": pred.get("prediction_confidence"),
+        "predicted_alpha": pred.get("predicted_alpha"),
+        "stance": pred.get("stance"),
+        "catalyst_date": pred.get("catalyst_date"),
+    }
+
+
+def build_order_book_rationale(
+    *,
+    signals: Mapping[str, Any],
+    predictions_by_ticker: Mapping[str, Any],
+    order_book_data: Mapping[str, Any],
+    blocked_entries: Sequence[Mapping[str, Any]],
+    risk_events: Sequence[Mapping[str, Any]],
+    market_regime: str,
+    run_date: str,
+    signal_date: str | None,
+    prediction_date: str | None,
+    calendar_date: str,
+    trading_day: str,
+    run_id: str,
+) -> dict[str, Any]:
+    """Join the morning-planner decision structures into a per-ticker record.
+
+    Pure function — no I/O, no clock reads (``run_id`` /
+    ``calendar_date`` / ``trading_day`` are injected so the caller owns
+    the dating discipline and tests are deterministic).
+
+    Args:
+        signals: output of ``signal_reader.get_actionable_signals`` —
+            ``{"enter": [...], "exit": [...], "reduce": [...],
+            "hold": [...]}`` lists of per-ticker research signal dicts.
+            This is the *considered universe*.
+        predictions_by_ticker: ``{ticker: prediction_dict}`` from the
+            predictor inference artifact.
+        order_book_data: the finalized ``OrderBook._data`` dict
+            (``approved_entries`` carry ``entries_with_meta`` payloads
+            incl. ``sizing_factors`` + ``triggers``; ``urgent_exits``
+            carry exit/reduce/cover records).
+        blocked_entries: ``plan.blocked`` — per-ENTER rejections with a
+            free-text ``block_reason``.
+        risk_events: ``plan.risk_events`` — structured rule log with
+            ``event_type`` / ``rule`` / ``value`` / ``threshold``.
+        market_regime: effective regime for the run.
+        run_date / signal_date / prediction_date: lineage dates.
+        calendar_date / trading_day: dual-tracked dates (LdP).
+        run_id: ``YYMMDDHHMM`` from ``new_eval_run_id``.
+
+    Returns:
+        Serializable payload dict (canonical eval_artifacts shape).
+    """
+    enter = {s.get("ticker"): s for s in signals.get("enter", []) if s.get("ticker")}
+    held = {s.get("ticker"): s for s in signals.get("hold", []) if s.get("ticker")}
+    exited = {s.get("ticker"): s for s in signals.get("exit", []) if s.get("ticker")}
+    reduced = {s.get("ticker"): s for s in signals.get("reduce", []) if s.get("ticker")}
+
+    approved = {
+        e.get("ticker"): e
+        for e in order_book_data.get("approved_entries", [])
+        if e.get("ticker")
+    }
+    # Urgent-exit records keyed by ticker (last write wins — dedup is
+    # the order book's job; we only read the final state).
+    urgent: dict[str, dict] = {}
+    for rec in order_book_data.get("urgent_exits", []):
+        t = rec.get("ticker")
+        if t:
+            urgent[t] = rec
+
+    blocked = {
+        b.get("ticker"): b for b in blocked_entries if b.get("ticker")
+    }
+    # First risk_event per ticker is the one that excluded it (decider
+    # emits at the first failing gate then `continue`s).
+    first_event: dict[str, dict] = {}
+    for ev in risk_events:
+        t = ev.get("ticker")
+        if t and t not in first_event:
+            first_event[t] = ev
+
+    considered = (
+        set(enter) | set(held) | set(exited) | set(reduced)
+        | set(approved) | set(urgent) | set(blocked) | set(first_event)
+    )
+
+    records: list[dict[str, Any]] = []
+    for ticker in considered:
+        sig = (
+            enter.get(ticker) or held.get(ticker)
+            or exited.get(ticker) or reduced.get(ticker)
+        )
+        pred = predictions_by_ticker.get(ticker)
+        ev = first_event.get(ticker)
+        ob_entry = approved.get(ticker)
+        ob_exit = urgent.get(ticker)
+
+        chain: list[dict[str, Any]] = []
+        exclusion: dict[str, Any] | None = None
+
+        # Stage 1 — research signal read.
+        chain.append({
+            "stage": "signal_read",
+            "result": (sig or {}).get("signal") or "none",
+            "detail": (
+                f"composite {sig.get('score')}"
+                if sig and sig.get("score") is not None else None
+            ),
+        })
+
+        # Stage 2 — predictor (direction/confidence; veto attribution
+        # comes from the risk_event slug at stage 3).
+        if pred:
+            chain.append({
+                "stage": "predictor",
+                "result": pred.get("predicted_direction") or "none",
+                "detail": (
+                    f"conf {pred.get('prediction_confidence')}"
+                    if pred.get("prediction_confidence") is not None else None
+                ),
+            })
+
+        # Terminal-state resolution + stage 3+ chain.
+        if ob_exit is not None:
+            sigtype = (ob_exit.get("signal") or "").upper()
+            state = STATE_REDUCE if sigtype == "REDUCE" else STATE_URGENT_EXIT
+            chain.append({
+                "stage": "exit_path",
+                "result": sigtype or "EXIT",
+                "detail": ob_exit.get("reason") or ob_exit.get("detail"),
+            })
+        elif ob_entry is not None:
+            state = STATE_APPROVED_ENTRY
+            chain.append({"stage": "risk_guard", "result": "pass"})
+            sf = ob_entry.get("sizing_factors") or {}
+            chain.append({
+                "stage": "position_sizer",
+                "result": (
+                    f"{ob_entry.get('position_pct', 0) * 100:.2f}% NAV"
+                    if ob_entry.get("position_pct") is not None else "sized"
+                ),
+                "sizing_factors": sf,
+                "shares": ob_entry.get("shares"),
+                "dollar_size": ob_entry.get("dollar_size"),
+            })
+            chain.append({
+                "stage": "entry_trigger",
+                "result": "pending",
+                "triggers": ob_entry.get("triggers") or {},
+            })
+        elif ev is not None or ticker in blocked:
+            rule = (ev or {}).get("rule")
+            state = (
+                STATE_PREDICTOR_VETOED
+                if rule in _PREDICTOR_RULES
+                or (ev or {}).get("event_type") == "override"
+                else STATE_RISK_BLOCKED
+            )
+            exclusion = {
+                "event_type": (ev or {}).get("event_type"),
+                "rule": rule,
+                "value": (ev or {}).get("value"),
+                "threshold": (ev or {}).get("threshold"),
+                "reason": (
+                    (ev or {}).get("reason")
+                    or blocked.get(ticker, {}).get("block_reason")
+                ),
+            }
+            chain.append({
+                "stage": "risk_guard",
+                "result": "blocked",
+                "rule": rule,
+                "value": exclusion["value"],
+                "threshold": exclusion["threshold"],
+                "detail": exclusion["reason"],
+            })
+        elif ticker in held:
+            state = STATE_HELD
+        else:
+            state = STATE_NO_ACTION
+
+        records.append({
+            "ticker": ticker,
+            "terminal_state": state,
+            "research": _research_block(sig),
+            "predictor": _predictor_block(pred),
+            "decision_chain": chain,
+            "exclusion": exclusion,
+            "order_book": ob_entry or ob_exit or None,
+        })
+
+    records.sort(key=lambda r: (_STATE_ORDER.get(r["terminal_state"], 9), r["ticker"]))
+
+    summary: dict[str, int] = {"n_considered": len(records)}
+    for r in records:
+        summary[f"n_{r['terminal_state']}"] = summary.get(
+            f"n_{r['terminal_state']}", 0
+        ) + 1
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": run_id,
+        "calendar_date": calendar_date,
+        "trading_day": trading_day,
+        "run_date": run_date,
+        "signal_date": signal_date,
+        "prediction_date": prediction_date,
+        "market_regime": market_regime,
+        "summary": summary,
+        "tickers": records,
+    }
+
+
+def write_order_book_rationale(
+    payload: Mapping[str, Any],
+    *,
+    s3_client: Any,
+    bucket: str,
+    prefix: str = DEFAULT_S3_PREFIX,
+    write_latest: bool = True,
+) -> dict[str, str]:
+    """Publish the rationale payload to S3 in canonical eval_artifacts shape.
+
+    Writes ``{prefix}/{run_id}.json`` (forensic dated artifact, always)
+    and ``{prefix}/latest.json`` (operator-UX sidecar pointer, when
+    ``write_latest``). Mirrors ``regime.substrate.write_regime_substrate``
+    — the single source of truth for the sidecar body shape so the
+    dashboard's ``load_latest_eval_artifact`` resolves it identically.
+
+    Returns dict with ``artifact_key`` and (when written) ``latest_key``.
+    """
+    from alpha_engine_lib.eval_artifacts import (
+        eval_artifact_key,
+        eval_latest_key,
+    )
+
+    run_id = payload["run_id"]
+    artifact_key = eval_artifact_key(prefix, run_id)
+
+    s3_client.put_object(
+        Bucket=bucket,
+        Key=artifact_key,
+        Body=json.dumps(payload, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    result = {"artifact_key": artifact_key}
+
+    if write_latest:
+        latest_key = eval_latest_key(prefix)
+        sidecar = {
+            "run_id": run_id,
+            "artifact_key": artifact_key,
+            "calendar_date": payload["calendar_date"],
+            "trading_day": payload["trading_day"],
+            "schema_version": payload["schema_version"],
+            "market_regime": payload.get("market_regime"),
+            "n_considered": payload.get("summary", {}).get("n_considered"),
+            "written_at": datetime.now(timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z"),
+        }
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=latest_key,
+            Body=json.dumps(sidecar).encode("utf-8"),
+            ContentType="application/json",
+        )
+        result["latest_key"] = latest_key
+        logger.info(
+            "[order_book_rationale] wrote run_id=%s → s3://%s/%s (latest=%s)",
+            run_id, bucket, artifact_key, latest_key,
+        )
+    else:
+        logger.info(
+            "[order_book_rationale] wrote run_id=%s → s3://%s/%s (latest skipped)",
+            run_id, bucket, artifact_key,
+        )
+
+    return result

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -1,0 +1,312 @@
+"""Tests for executor.order_book_rationale.
+
+Covers the pure builder's terminal-state resolution across the full
+considered universe, the decision-chain construction, the summary
+counts, and the canonical eval_artifacts write (dated artifact +
+sidecar, round-trippable via the lib's load_latest_eval_artifact).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from executor.order_book_rationale import (
+    DEFAULT_S3_PREFIX,
+    SCHEMA_VERSION,
+    STATE_APPROVED_ENTRY,
+    STATE_HELD,
+    STATE_NO_ACTION,
+    STATE_PREDICTOR_VETOED,
+    STATE_REDUCE,
+    STATE_RISK_BLOCKED,
+    STATE_URGENT_EXIT,
+    build_order_book_rationale,
+    write_order_book_rationale,
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+def _sig(ticker, signal, **kw):
+    base = {
+        "ticker": ticker,
+        "signal": signal,
+        "score": 72.0,
+        "conviction": "rising",
+        "rating": "BUY",
+        "sector": "Technology",
+        "sector_rating": "overweight",
+        "price_target_upside": 0.18,
+        "thesis_summary": f"{ticker} thesis",
+    }
+    base.update(kw)
+    return base
+
+
+def _entry_with_meta(ticker):
+    return {
+        "ticker": ticker,
+        "signal": "ENTER",
+        "shares": 100,
+        "current_price": 50.0,
+        "dollar_size": 5000.0,
+        "position_pct": 0.041,
+        "triggers": {"pullback_pct": 0.012, "vwap": 49.5, "support_level": 48.0},
+        "sizing_factors": {
+            "sector_adj": 1.2,
+            "conviction_adj": 1.05,
+            "upside_adj": 1.0,
+            "dd_multiplier": 1.0,
+        },
+        "predicted_direction": "UP",
+        "prediction_confidence": 0.62,
+        "status": "pending",
+    }
+
+
+@pytest.fixture
+def scenario():
+    """A run spanning every terminal state.
+
+    AAPL → approved entry, MSFT → urgent exit, TSLA → reduce,
+    NVDA → risk-blocked (min_score), AMD → predictor-vetoed
+    (stance_gate), KO → held, XOM → considered but no action.
+    """
+    signals = {
+        "enter": [_sig("AAPL", "ENTER"), _sig("NVDA", "ENTER", score=40.0),
+                  _sig("AMD", "ENTER")],
+        "exit": [_sig("MSFT", "EXIT"), _sig("XOM", "EXIT")],
+        "reduce": [_sig("TSLA", "REDUCE")],
+        "hold": [_sig("KO", "HOLD")],
+    }
+    predictions = {
+        "AAPL": {"predicted_direction": "UP", "prediction_confidence": 0.62,
+                 "predicted_alpha": 0.03, "stance": "momentum",
+                 "catalyst_date": "2026-05-20"},
+        "AMD": {"predicted_direction": "DOWN", "prediction_confidence": 0.71},
+    }
+    order_book = {
+        "date": "2026-05-15",
+        "approved_entries": [_entry_with_meta("AAPL")],
+        "urgent_exits": [
+            {"ticker": "MSFT", "signal": "EXIT", "shares": 50,
+             "reason": "research_exit"},
+            {"ticker": "TSLA", "signal": "REDUCE", "shares": 20,
+             "reason": "trim"},
+        ],
+        "active_stops": [],
+        "executed_today": [],
+    }
+    blocked = [
+        {"ticker": "NVDA", "block_reason": "score 40.0 < min 55.0"},
+        {"ticker": "AMD", "block_reason": "stance gate: DOWN veto"},
+    ]
+    risk_events = [
+        {"ticker": "NVDA", "event_type": "veto", "rule": "min_score",
+         "value": 40.0, "threshold": 55.0, "reason": "below min score"},
+        {"ticker": "AMD", "event_type": "veto", "rule": "stance_gate",
+         "value": 0.71, "threshold": 0.6, "reason": "predictor DOWN veto"},
+    ]
+    return dict(
+        signals=signals,
+        predictions_by_ticker=predictions,
+        order_book_data=order_book,
+        blocked_entries=blocked,
+        risk_events=risk_events,
+        market_regime="neutral",
+        run_date="2026-05-15",
+        signal_date="2026-05-15",
+        prediction_date="2026-05-15",
+        calendar_date="2026-05-15",
+        trading_day="2026-05-15",
+        run_id="2605151400",
+    )
+
+
+# ── builder: terminal-state resolution ───────────────────────────────────
+
+
+def test_every_terminal_state_resolved(scenario):
+    payload = build_order_book_rationale(**scenario)
+    by_ticker = {r["ticker"]: r["terminal_state"] for r in payload["tickers"]}
+    assert by_ticker["AAPL"] == STATE_APPROVED_ENTRY
+    assert by_ticker["MSFT"] == STATE_URGENT_EXIT
+    assert by_ticker["TSLA"] == STATE_REDUCE
+    assert by_ticker["NVDA"] == STATE_RISK_BLOCKED
+    assert by_ticker["AMD"] == STATE_PREDICTOR_VETOED
+    assert by_ticker["KO"] == STATE_HELD
+    assert by_ticker["XOM"] == STATE_NO_ACTION
+
+
+def test_considered_universe_is_union_of_all_sources(scenario):
+    payload = build_order_book_rationale(**scenario)
+    tickers = {r["ticker"] for r in payload["tickers"]}
+    assert tickers == {"AAPL", "MSFT", "TSLA", "NVDA", "AMD", "KO", "XOM"}
+    assert payload["summary"]["n_considered"] == 7
+
+
+def test_excluded_ticker_carries_specific_gate(scenario):
+    payload = build_order_book_rationale(**scenario)
+    nvda = next(r for r in payload["tickers"] if r["ticker"] == "NVDA")
+    assert nvda["exclusion"]["rule"] == "min_score"
+    assert nvda["exclusion"]["value"] == 40.0
+    assert nvda["exclusion"]["threshold"] == 55.0
+    # The risk_guard stage in the chain mirrors the slug.
+    rg = next(s for s in nvda["decision_chain"] if s["stage"] == "risk_guard")
+    assert rg["result"] == "blocked"
+    assert rg["rule"] == "min_score"
+
+
+def test_predictor_veto_distinguished_from_hard_risk(scenario):
+    payload = build_order_book_rationale(**scenario)
+    amd = next(r for r in payload["tickers"] if r["ticker"] == "AMD")
+    assert amd["terminal_state"] == STATE_PREDICTOR_VETOED
+    assert amd["exclusion"]["rule"] == "stance_gate"
+
+
+def test_approved_entry_chain_has_sizing_and_trigger(scenario):
+    payload = build_order_book_rationale(**scenario)
+    aapl = next(r for r in payload["tickers"] if r["ticker"] == "AAPL")
+    stages = {s["stage"] for s in aapl["decision_chain"]}
+    assert {"signal_read", "predictor", "risk_guard", "position_sizer",
+            "entry_trigger"} <= stages
+    sizer = next(s for s in aapl["decision_chain"]
+                 if s["stage"] == "position_sizer")
+    assert sizer["sizing_factors"]["sector_adj"] == 1.2
+    assert sizer["shares"] == 100
+    trig = next(s for s in aapl["decision_chain"]
+                if s["stage"] == "entry_trigger")
+    assert trig["triggers"]["vwap"] == 49.5
+
+
+def test_research_and_predictor_blocks_projected(scenario):
+    payload = build_order_book_rationale(**scenario)
+    aapl = next(r for r in payload["tickers"] if r["ticker"] == "AAPL")
+    assert aapl["research"]["score"] == 72.0
+    assert aapl["research"]["sector_rating"] == "overweight"
+    assert aapl["predictor"]["predicted_direction"] == "UP"
+    assert aapl["predictor"]["catalyst_date"] == "2026-05-20"
+    # KO has no prediction → empty predictor block, not a crash.
+    ko = next(r for r in payload["tickers"] if r["ticker"] == "KO")
+    assert ko["predictor"] == {}
+
+
+def test_summary_counts_match_records(scenario):
+    payload = build_order_book_rationale(**scenario)
+    s = payload["summary"]
+    assert s[f"n_{STATE_APPROVED_ENTRY}"] == 1
+    assert s[f"n_{STATE_URGENT_EXIT}"] == 1
+    assert s[f"n_{STATE_REDUCE}"] == 1
+    assert s[f"n_{STATE_RISK_BLOCKED}"] == 1
+    assert s[f"n_{STATE_PREDICTOR_VETOED}"] == 1
+    assert s[f"n_{STATE_HELD}"] == 1
+    assert s[f"n_{STATE_NO_ACTION}"] == 1
+
+
+def test_records_sorted_actioned_first(scenario):
+    payload = build_order_book_rationale(**scenario)
+    states = [r["terminal_state"] for r in payload["tickers"]]
+    assert states[0] == STATE_APPROVED_ENTRY
+    assert states[-1] == STATE_NO_ACTION
+
+
+def test_payload_is_audit_stable_and_serializable(scenario):
+    payload = build_order_book_rationale(**scenario)
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["run_id"] == "2605151400"
+    assert payload["trading_day"] == "2026-05-15"
+    # Reproducible from the artifact alone → must round-trip JSON.
+    assert json.loads(json.dumps(payload, default=str)) == json.loads(
+        json.dumps(payload, default=str)
+    )
+
+
+def test_empty_run_produces_empty_but_valid_payload():
+    payload = build_order_book_rationale(
+        signals={"enter": [], "exit": [], "reduce": [], "hold": []},
+        predictions_by_ticker={},
+        order_book_data={"approved_entries": [], "urgent_exits": []},
+        blocked_entries=[],
+        risk_events=[],
+        market_regime="bear",
+        run_date="2026-05-15",
+        signal_date="2026-05-15",
+        prediction_date=None,
+        calendar_date="2026-05-15",
+        trading_day="2026-05-15",
+        run_id="2605151400",
+    )
+    assert payload["summary"]["n_considered"] == 0
+    assert payload["tickers"] == []
+    assert payload["prediction_date"] is None
+
+
+# ── writer: canonical eval_artifacts shape ───────────────────────────────
+
+
+class _StubS3:
+    """Minimal in-memory S3 supporting put_object + get_object."""
+
+    def __init__(self):
+        self.store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[(Bucket, Key)] = Body
+
+    def get_object(self, *, Bucket, Key):
+        body = self.store[(Bucket, Key)]
+
+        class _Body:
+            def read(self_inner):
+                return body
+
+        return {"Body": _Body()}
+
+
+def test_write_creates_dated_artifact_and_sidecar(scenario):
+    payload = build_order_book_rationale(**scenario)
+    s3 = _StubS3()
+    result = write_order_book_rationale(
+        payload, s3_client=s3, bucket="alpha-engine-research"
+    )
+    assert result["artifact_key"] == (
+        f"{DEFAULT_S3_PREFIX}/2605151400.json"
+    )
+    assert result["latest_key"] == f"{DEFAULT_S3_PREFIX}/latest.json"
+    sidecar = json.loads(
+        s3.store[("alpha-engine-research", result["latest_key"])]
+    )
+    # Sidecar must carry artifact_key so load_latest_eval_artifact resolves.
+    assert sidecar["artifact_key"] == result["artifact_key"]
+    assert sidecar["run_id"] == "2605151400"
+    assert sidecar["n_considered"] == 7
+
+
+def test_write_latest_false_skips_sidecar(scenario):
+    payload = build_order_book_rationale(**scenario)
+    s3 = _StubS3()
+    result = write_order_book_rationale(
+        payload, s3_client=s3, bucket="b", write_latest=False
+    )
+    assert "latest_key" not in result
+    assert ("b", f"{DEFAULT_S3_PREFIX}/latest.json") not in s3.store
+
+
+def test_round_trip_via_lib_loader(scenario):
+    """The artifact resolves through the lib's canonical reader —
+    proves the dashboard's load_latest_eval_artifact path works."""
+    from alpha_engine_lib.eval_artifacts import load_latest_eval_artifact
+
+    payload = build_order_book_rationale(**scenario)
+    s3 = _StubS3()
+    write_order_book_rationale(
+        payload, s3_client=s3, bucket="alpha-engine-research"
+    )
+    loaded = load_latest_eval_artifact(
+        s3, bucket="alpha-engine-research", prefix=DEFAULT_S3_PREFIX
+    )
+    assert loaded["run_id"] == payload["run_id"]
+    assert loaded["summary"]["n_considered"] == 7


### PR DESCRIPTION
## What

Producer half of the ROADMAP Observability P1 *"Per-ticker daily order-book rationale record + console tab"*.

Emits a per-ticker daily decision-chain record for the **whole considered universe** alongside the order book — answering *"why is ticker X in state S today?"* including the tickers that did **not** enter (the "why didn't Y enter" question is as important as "why did X"). Terminal states: `approved_entry` / `urgent_exit` / `reduce` / `held` / `risk_blocked` / `predictor_vetoed` / `no_action`.

## How

- **`executor/order_book_rationale.py`** — pure `build_order_book_rationale()` joins `signals` + `predictions` + final order book + `blocked` + `risk_events` into a per-ticker record with the ordered decision chain (signal_read → predictor → risk_guard → position_sizer → entry_trigger), the research/predictor sub-scores, and the specific exclusion slug + threshold for vetoed/blocked tickers. `write_order_book_rationale()` publishes in canonical `alpha_engine_lib.eval_artifacts` shape (`{run_id}.json` + `latest.json` sidecar), mirroring `regime.substrate.write_regime_substrate` exactly.
- **`executor/main.py`** — wired in after `_write_stops_and_finalize`, **non-blocking** (same posture as the shadow optimizer + data manifest — the planner must never fail over an audit artifact). Works for both the legacy planner and the portfolio-optimizer cutover path since the final order book is the common terminal artifact.
- No new instrumentation — pure join + serialize over structures already materialized (`entries_with_meta` sizing_factors, #139 risk_events slugs, #138 lineage dates). Substrate was ~80% present per the ROADMAP entry.

## Audit-stable

The record is reproducible from the artifact alone — research sub-scores, predictor outputs, risk slug+threshold, full sizing-factor breakdown, intraday trigger config. No need to re-open S3 or query SQLite to interpret.

## Tests

+13 tests (`tests/test_order_book_rationale.py`) covering every terminal state, considered-universe union, decision-chain contents, summary counts, sort order, empty-run, canonical write + sidecar shape, and a round-trip through the lib's `load_latest_eval_artifact` (proves the dashboard read path). Full executor suite **898 passed**.

## Consumer

Dashboard console page (Item 4) + the reusable archive component (template for Item 5) follow in alpha-engine-dashboard. Artifact prefix: `s3://alpha-engine-research/trades/order_book_rationale/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)