### PR TITLE
feat(iam): grant executor-role scoped ssm:SendCommand (spot_train SSM migration PR1)

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-send.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-send.json
@@ -1,0 +1,32 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SendCommandRunShellScriptDocument",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ssm:us-east-1:711398986525:document/AWS-RunShellScript"
+    },
+    {
+      "Sid": "SendCommandToAlphaEngineTaggedInstances",
+      "Effect": "Allow",
+      "Action": "ssm:SendCommand",
+      "Resource": "arn:aws:ec2:us-east-1:711398986525:instance/*",
+      "Condition": {
+        "StringLike": {
+          "ssm:resourceTag/Name": "alpha-engine-*"
+        }
+      }
+    },
+    {
+      "Sid": "ReadCommandInvocationAndInstanceInfo",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetCommandInvocation",
+        "ssm:ListCommandInvocations",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
**PR 1 of the spot_train SSH/SCP→SSM migration** (canonical plan: `alpha-engine-docs/private/spot-train-260512.md`). Paired with **alpha-engine-predictor PR 2** (the `spot_train.sh` rewrite).

### Why
Verification before shipping found the plan doc's PR 1 **under-specified the IAM**: it only added the spot *agent-side* `AmazonSSMManagedInstanceCore` (already live). But the **dispatcher** (ae-dashboard, shared `alpha-engine-executor-role`) running the new `spot_train.sh` calls `aws ssm send-command` — and that role had **no `ssm:SendCommand` grant**. Without this, PR 2 fails `AccessDenied` at the first `run_ssm` and tomorrow's Saturday predictor-training breaks.

### What
New least-privilege, **additive** inline policy `alpha-engine-ssm-send` (no existing policy modified):
- `ssm:SendCommand` scoped to the `AWS-RunShellScript` document
- `ssm:SendCommand` on instances scoped by `ssm:resourceTag/Name` `StringLike alpha-engine-*` (our spots)
- `ssm:GetCommandInvocation` / `ListCommandInvocations` / `DescribeInstanceInformation` (no resource-level support → `*`)

### ⚠️ Lockstep apply required
`check-drift.py` enforces codified↔live parity, and tomorrow's Saturday SF needs the grant live. **This must be applied to live IAM in lockstep with merge:**
```
cd alpha-engine && bash infrastructure/iam/apply.sh --role alpha-engine-executor-role --policy alpha-engine-ssm-send
```
Rollback: `aws iam delete-role-policy --role-name alpha-engine-executor-role --policy-name alpha-engine-ssm-send` + `git revert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)