### PR TITLE
feat(executor): label SPY/index-ETF core as "Broad Market / Index" at source

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -149,6 +149,31 @@ def _load_constituents_sector_map(bucket: str) -> dict[str, str]:
         return {}
 
 
+# Broad-market index/ETF core positions are not GICS sector constituents.
+# Since the portfolio-optimizer cutover (use_portfolio_optimizer: true,
+# 2026-05-13) SPY is held as the enhanced-index core position. SPY has no
+# `sector` field in signals.json, no entry_trade.sector, and is not in the
+# S&P 500+400 constituents map, so the normal lookup chain misses it and it
+# renders as a bare "—"/"Unknown" on the public site — reads as missing data
+# rather than "this is the broad-market core." Tag it explicitly so every
+# downstream consumer (public site, private console, sector attribution)
+# inherits a meaningful label. New core ETFs the optimizer may substitute
+# get added to ``_INDEX_ETF_TICKERS``.
+_INDEX_ETF_SECTOR = "Broad Market / Index"
+_INDEX_ETF_TICKERS = frozenset({"SPY", "VOO", "IVV", "SPLG"})
+
+
+def _index_etf_sector(ticker: str) -> str | None:
+    """Return the broad-market sector label for index/ETF core positions.
+
+    Returns ``"Broad Market / Index"`` for known broad-market ETFs held as
+    the enhanced-index core (SPY and S&P 500 trackers the optimizer may
+    substitute), else ``None`` so the caller falls through to the normal
+    signals.json / entry-trade / S&P-constituents lookup chain.
+    """
+    return _INDEX_ETF_SECTOR if ticker in _INDEX_ETF_TICKERS else None
+
+
 def _load_predictions_from_s3(bucket: str) -> tuple[dict, str | None]:
     """Load latest predictions from S3. Returns ({ticker: pred_dict}, warning_msg) on failure."""
     s3 = boto3.client("s3")
@@ -440,6 +465,10 @@ def run(run_date: str | None = None) -> None:
     )
 
     # Enrich positions with sector. Lookup chain:
+    #   0. index/ETF core (SPY etc.) → "Broad Market / Index" — not a GICS
+    #      constituent, so it must short-circuit before the sector lookups
+    #      (an index ETF must never be mislabeled with a sector even if it
+    #      somehow appears in a lookup table).
     #   1. signals.json today (universe + buy_candidates)
     #   2. trades.db entry_trade.sector
     #   3. S&P 500+400 constituents.json (latest weekly snapshot) — catches
@@ -447,7 +476,7 @@ def run(run_date: str | None = None) -> None:
     #      today's research universe (e.g. dividend-reinvestment remnants).
     # A missing sector is an observability failure (blank rows in sector
     # attribution), not a hard error — log loudly and continue with "Unknown"
-    # only when all three sources miss.
+    # only when all sources miss.
     signals_bucket = config.get("signals_bucket", "alpha-engine-research")
     try:
         sig_data, _ = _load_signals_from_s3(signals_bucket, run_date)
@@ -459,6 +488,10 @@ def run(run_date: str | None = None) -> None:
         constituents_lookup: dict[str, str] | None = None
         for ticker in positions:
             if positions[ticker].get("sector"):
+                continue
+            etf_sector = _index_etf_sector(ticker)
+            if etf_sector:
+                positions[ticker]["sector"] = etf_sector
                 continue
             if ticker in sector_lookup:
                 positions[ticker]["sector"] = sector_lookup[ticker]

--- a/tests/test_index_etf_sector.py
+++ b/tests/test_index_etf_sector.py
@@ -1,0 +1,48 @@
+"""Tests for the index/ETF sector-label helper in executor/eod_reconcile.py.
+
+Locks the contract that broad-market ETF core positions (SPY etc., held as
+the enhanced-index core since the 2026-05-13 portfolio-optimizer cutover)
+resolve to "Broad Market / Index" rather than falling through the GICS
+lookup chain to a bare "—"/"Unknown" that reads as missing data.
+"""
+
+from executor.eod_reconcile import (
+    _INDEX_ETF_SECTOR,
+    _INDEX_ETF_TICKERS,
+    _index_etf_sector,
+)
+
+
+class TestIndexEtfSector:
+    def test_spy_resolves_to_broad_market(self):
+        assert _index_etf_sector("SPY") == "Broad Market / Index"
+
+    def test_all_known_index_etfs_resolve(self):
+        for ticker in _INDEX_ETF_TICKERS:
+            assert _index_etf_sector(ticker) == _INDEX_ETF_SECTOR
+
+    def test_regular_constituent_returns_none(self):
+        # AAPL must fall through to the normal signals.json / entry-trade /
+        # constituents lookup chain — not be short-circuited here.
+        assert _index_etf_sector("AAPL") is None
+
+    def test_cash_sentinel_returns_none(self):
+        # The synthetic CASH row is handled by the renderer, not here.
+        assert _index_etf_sector("CASH") is None
+
+    def test_empty_ticker_returns_none(self):
+        assert _index_etf_sector("") is None
+
+    def test_spy_label_is_not_a_gics_sector(self):
+        # Guard against someone "normalizing" the label into a real sector
+        # bucket — it must stay visibly distinct from active sector picks.
+        assert "Broad Market" in _INDEX_ETF_SECTOR
+        assert _INDEX_ETF_SECTOR not in {
+            "Technology",
+            "Healthcare",
+            "Financials",
+            "Industrials",
+            "Consumer",
+            "Defensives",
+            "Unknown",
+        }


### PR DESCRIPTION
## What

Fixes the SPY sector label on the public site (`nousergon.ai`) at the source — ROADMAP **L2668 (P2)**.

Since the portfolio-optimizer cutover (`use_portfolio_optimizer: true`, 2026-05-13) SPY is held as the enhanced-index core position. SPY is an ETF, not a GICS sector constituent — it has no `sector` in `signals.json`, no `entry_trade.sector`, and is absent from the S&P 500+400 constituents map. The EOD reconcile sector-enrichment lookup chain therefore missed it, and the public positions table rendered a bare "—" (`info.get("sector", "—") or "—"`) that reads as a data gap rather than "this is the broad-market core."

## How

- New pure helper `_index_etf_sector(ticker) -> str | None` + module constants `_INDEX_ETF_SECTOR` / `_INDEX_ETF_TICKERS` (SPY, VOO, IVV, SPLG — extensible for any future core ETF the optimizer substitutes).
- Wired as **step 0** of the existing lookup chain in `eod_reconcile` — short-circuits *before* signals.json/entry-trade/constituents so an index ETF can never be mislabeled with a GICS sector even if it appears in a lookup table. Placed after the existing `if positions[ticker].get("sector"): continue` guard, so a deliberately-set sector is never overridden.
- Source fix → public site **and** private console **and** sector attribution all inherit the label; no dashboard change needed.

## Tests

`+6` in `tests/test_index_etf_sector.py`. **Full executor suite: 904 passed** (898 → 904).

## Notes

- Cosmetic/public-facing correctness — not pipeline-blocking, not on any Saturday/weekday SF code path.
- Composes with the SPY-as-held-core / SPY-as-`universe`-member arc (#181/#185/alpha-engine-config #193).

🤖 Generated with [Claude Code](https://claude.com/claude-code)