### PR TITLE
fix(iam): codify bare "AlphaEngine" namespace on executor cloudwatch-metrics

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-cloudwatch-metrics.json
@@ -8,7 +8,10 @@
             "Resource": "*",
             "Condition": {
                 "StringLike": {
-                    "cloudwatch:namespace": "AlphaEngine/*"
+                    "cloudwatch:namespace": [
+                        "AlphaEngine",
+                        "AlphaEngine/*"
+                    ]
                 }
             }
         },


### PR DESCRIPTION
## Problem
`IAM Drift Check` has failed on every run since **2026-05-17** (5/17 and 5/18, SHA `b243444`). 5/16 was the last green run.

```
IAM drift detected (1 finding(s)):
  - alpha-engine-executor-role/alpha-engine-cloudwatch-metrics: source document differs from AWS document (content drift)
```

## Root cause
The codified JSON was **unchanged** between the last-green SHA and the failing SHA — the drift was introduced on the **live AWS side**. The live `PutAlphaEngineMetrics` StringLike condition was widened out-of-band (during the 2026-05-16 Saturday SF cascade recovery) to:

```json
"cloudwatch:namespace": ["AlphaEngine", "AlphaEngine/*"]
```

but the repo JSON still constrained to `"AlphaEngine/*"` only. The "fixed+codified" CloudWatch IAM work that session codified the *other* statement (the substrate-check read grant, #145) but not this namespace widening.

## Why codify live, not revert it
The bare `AlphaEngine` namespace is in **active, required** use:
- `alpha-engine/infrastructure/emit-heartbeat.sh:22` — runs on the executor EC2 trading instance (assumes `alpha-engine-executor-role`)
- predictor `spot_train.sh`, data `spot_data_weekly.sh`/`spot_drift_detection.sh`/RAG, backtester `spot_backtest.sh` heartbeats

StringLike `AlphaEngine/*` does **not** match the bare string `AlphaEngine` (no `/`). Reverting the live policy would deny those `PutMetricData` heartbeat calls and trip the dead-man's-switch CloudWatch alarms. Correct direction: codify live state.

## Change
Add `"AlphaEngine"` alongside `"AlphaEngine/*"` in the codified `alpha-engine-cloudwatch-metrics` policy. Pure codification — no live IAM change.

## Verification
`infrastructure/iam/check-drift.py` (full + `--role alpha-engine-executor-role`) → exit 0 against live AWS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)