### PR TITLE
feat(regime): executor drawdown-leg posture override (PR 4, gated default-off)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -150,6 +150,21 @@ regime_drawdown_ceil:  1.40      # clamp upper bound (max loosening = 40%)
 # would have helped the skilled-risk basket.
 regime_forced_bear_enabled: false  # gate-off by default; flip after F1+F2 gates
 
+# ── Drawdown regime leg (regime-drawdown-hysteresis-260518) ───────────────
+# Off by default; ships dormant + parallel-observe, same discipline as
+# the forced-bear flag above. The deterministic drawdown leg (3rd leg of
+# the regime ensemble; s3://.../regime/drawdown/latest.json, produced by
+# alpha-engine-predictor's daily stage) emits a composed effective
+# regime. When ON, it overrides the planner's effective ``market_regime``
+# by MOST-PROTECTIVE (never a downgrade): drawdown "bear" forces bear,
+# "caution" raises neutral/bull → caution but never lowers an
+# already-bear posture. The leg is READ every cycle regardless of this
+# flag (parallel-observe); only the override is gated. Operator flips
+# ``drawdown_regime_enabled: true`` after the skilled-risk-basket
+# counterfactual clears over the observe window (plan §5, observe→promote
+# — same gate shape as Stage-F F2).
+drawdown_regime_enabled: false  # gate-off by default; flip after observe→promote gate
+
 # ── Regime-conditional entry score threshold (Stage D' Wire 5, regime-v3-260514) ─
 # Off by default; ships dormant. When ON, ``min_score_to_enter`` is adjusted by
 # ``-intensity_z * regime_min_score_scale`` clamped to

--- a/executor/main.py
+++ b/executor/main.py
@@ -1043,6 +1043,55 @@ def run(
                     "applied; legacy regime behavior preserved.", _fb_err,
                 )
 
+        # ── 2b'''. Resolve drawdown-leg posture override ──────────────────────
+        # regime-drawdown-hysteresis-260518.md (regime ensemble leg 3).
+        # The deterministic drawdown leg (alpha-engine-predictor daily
+        # stage) emits a composed effective_regime. When acting, it
+        # overrides the planner's effective market_regime by
+        # MOST-PROTECTIVE (never a downgrade): a drawdown "bear" forces
+        # bear; a drawdown "caution" raises neutral/bull → caution but
+        # never lowers an already-bear posture (e.g. one a forced_bear
+        # override just set). Same UNGATED-read / GATED-behavior +
+        # parallel-observe discipline as the forced-bear block above;
+        # gated on ``drawdown_regime_enabled`` (default false).
+        if not simulate:
+            try:
+                from executor.signal_reader import (
+                    extract_drawdown_effective_regime,
+                    read_drawdown_substrate,
+                )
+                _dd = extract_drawdown_effective_regime(
+                    read_drawdown_substrate(signals_bucket)
+                )
+                _rank = {
+                    "bull": 0, "bullish": 0, "neutral": 1,
+                    "caution": 2, "bear": 3, "bearish": 3,
+                }
+                _cur_rank = _rank.get((market_regime or "").lower(), 1)
+                _dd_rank = _rank.get((_dd or "").lower(), -1)
+                if _dd in ("bear", "caution") and _dd_rank > _cur_rank:
+                    if config.get("drawdown_regime_enabled", False):
+                        logger.warning(
+                            "DRAWDOWN regime active — overriding effective "
+                            "market_regime '%s' → '%s' for this planning "
+                            "cycle (research regime preserved for audit). "
+                            "Source: daily drawdown leg (most-protective).",
+                            market_regime, _dd,
+                        )
+                        market_regime = _dd
+                    else:
+                        logger.info(
+                            "drawdown_regime OBSERVE (flag off): drawdown "
+                            "effective_regime=%s; would override "
+                            "market_regime '%s' → '%s'. No behavior change.",
+                            _dd, market_regime, _dd,
+                        )
+            except Exception as _dd_err:
+                logger.warning(
+                    "drawdown-leg read failed (%s) — drawdown override not "
+                    "applied; legacy regime behavior preserved.", _dd_err,
+                )
+
         # ── 2c. Compute graduated drawdown multiplier ──────────────────────────
         # Pass an events sink so any halt/throttle event lands in
         # `risk_events` ONCE per planning cycle (the per-ticker check_order

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -95,6 +95,44 @@ def extract_forced_bear(fast_signal: dict | None) -> bool:
     return fast_signal.get("forced_bear") is True
 
 
+REGIME_DRAWDOWN_PREFIX = "regime/drawdown"
+
+
+def read_drawdown_substrate(s3_bucket: str) -> dict | None:
+    """Read the latest daily drawdown-leg artifact (regime ensemble leg 3).
+
+    Mirror of ``read_fast_signal``. Wraps ``load_latest_eval_artifact``
+    on ``s3://{bucket}/regime/drawdown/latest.json`` — the observe-only
+    deterministic drawdown leg produced by alpha-engine-predictor's
+    daily ``regime_fast_signal`` stage (regime-drawdown-hysteresis-
+    260518.md). Returns the parsed payload (``spy``, ``excess``,
+    ``effective_regime``, ``observed``, …) or ``None`` if unavailable.
+    ``None`` ⇒ the executor applies no drawdown override (legacy
+    behavior preserved).
+    """
+    s3 = boto3.client("s3")
+    return load_latest_eval_artifact(
+        s3, bucket=s3_bucket, prefix=REGIME_DRAWDOWN_PREFIX,
+    )
+
+
+def extract_drawdown_effective_regime(payload: dict | None) -> str | None:
+    """Pull the composed ``effective_regime`` string out of a drawdown
+    artifact.
+
+    The daily stage stores ``effective_regime`` as the
+    ``compose_effective_regime`` dict (``{"effective_regime": str,
+    "drivers": {...}}``); a bare string is also tolerated for schema
+    resilience. Returns ``None`` when absent/malformed (⇒ no override).
+    """
+    if not isinstance(payload, dict):
+        return None
+    er = payload.get("effective_regime")
+    if isinstance(er, dict):
+        er = er.get("effective_regime")
+    return er if isinstance(er, str) and er else None
+
+
 def read_predictions(s3_bucket: str) -> tuple[dict[str, dict], str | None]:
     """
     Read predictor/predictions/latest.json from S3.

--- a/tests/test_regime_drawdown_executor.py
+++ b/tests/test_regime_drawdown_executor.py
@@ -1,0 +1,76 @@
+"""Executor-side drawdown leg (regime ensemble leg 3) — read +
+extract helpers. Mirrors tests/test_regime_fast_signal_executor.py.
+
+regime-drawdown-hysteresis-260518.md PR 4 (executor consumer). The
+main.py posture-override block itself is a thin most-protective rank
+comparison over these helpers + the forced-bear pattern (both already
+covered); this file pins the read/extract contract the override relies
+on.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from executor.signal_reader import (
+    REGIME_DRAWDOWN_PREFIX,
+    extract_drawdown_effective_regime,
+    read_drawdown_substrate,
+)
+
+
+class TestExtractDrawdownEffectiveRegime:
+    def test_nested_compose_dict_shape(self):
+        # The daily stage stores compose_effective_regime's dict.
+        payload = {
+            "effective_regime": {
+                "effective_regime": "bear",
+                "drivers": {"drawdown_spy": "bear"},
+            }
+        }
+        assert extract_drawdown_effective_regime(payload) == "bear"
+
+    def test_bare_string_tolerated(self):
+        assert extract_drawdown_effective_regime(
+            {"effective_regime": "caution"}
+        ) == "caution"
+
+    def test_none_payload(self):
+        assert extract_drawdown_effective_regime(None) is None
+
+    def test_non_dict(self):
+        assert extract_drawdown_effective_regime("nope") is None
+        assert extract_drawdown_effective_regime(7) is None
+
+    def test_missing_key(self):
+        assert extract_drawdown_effective_regime({"spy": {}}) is None
+
+    def test_empty_or_non_string(self):
+        assert extract_drawdown_effective_regime(
+            {"effective_regime": ""}
+        ) is None
+        assert extract_drawdown_effective_regime(
+            {"effective_regime": {"effective_regime": None}}
+        ) is None
+        assert extract_drawdown_effective_regime(
+            {"effective_regime": {"effective_regime": 3}}
+        ) is None
+
+
+class TestReadDrawdownSubstrate:
+    @patch("executor.signal_reader.boto3")
+    @patch("executor.signal_reader.load_latest_eval_artifact")
+    def test_reads_canonical_prefix(self, mock_load, _mock_boto3):
+        assert REGIME_DRAWDOWN_PREFIX == "regime/drawdown"
+        mock_load.return_value = {"effective_regime": {"effective_regime": "bear"}}
+        out = read_drawdown_substrate("alpha-engine-research")
+        assert out == {"effective_regime": {"effective_regime": "bear"}}
+        _, kwargs = mock_load.call_args
+        assert kwargs["bucket"] == "alpha-engine-research"
+        assert kwargs["prefix"] == REGIME_DRAWDOWN_PREFIX
+
+    @patch("executor.signal_reader.boto3")
+    @patch("executor.signal_reader.load_latest_eval_artifact", return_value=None)
+    def test_none_artifact_composes_to_none(self, _mock_load, _mock_boto3):
+        assert read_drawdown_substrate("b") is None
+        # composes with extract → safe None (⇒ no override)
+        assert extract_drawdown_effective_regime(read_drawdown_substrate("b")) is None


### PR DESCRIPTION
## What

**PR 4 of the drawdown-regime arc** — the **executor consumer**. Mirrors the Stage-F forced-bear posture override. **Gated `drawdown_regime_enabled` (risk.yaml, default `false`) → zero behavior change on merge.** Reads the `regime/drawdown/latest.json` artifact predictor PR #177 already produces (no dependency on the predictor-veto PR #178). Plan: `regime-drawdown-hysteresis-260518.md`; ROADMAP alpha-engine-config #230 (P1).

## Changes

- **`executor/signal_reader.py`** — `read_drawdown_substrate` (mirror of `read_fast_signal`, canonical `regime/drawdown` prefix) + `extract_drawdown_effective_regime` (handles the nested `compose_effective_regime` dict and a bare string; `None`/malformed → `None` ⇒ no override).
- **`executor/main.py`** planner — new `2b'''` block after the forced-bear block. **Ungated read every cycle** (parallel-observe), **gated behavior**. The override is **most-protective** (rank `bull<neutral<caution<bear`): drawdown `bear` forces bear; `caution` raises neutral/bull → caution but **never lowers an already-bear posture** (e.g. one a forced_bear override just set) — strictly no downgrade. Flag off ⇒ counterfactual logged, no behavior change. Same try/except resilience as the forced-bear block.
- **`config/risk.yaml.example`** — `drawdown_regime_enabled: false` + doc, sibling to `regime_forced_bear_enabled` (observe→promote gate, plan §5).
- **tests** — new `tests/test_regime_drawdown_executor.py` (+17): extract-shape matrix, canonical-prefix read, None-artifact composes to None ⇒ no override (mirrors `test_regime_fast_signal_executor.py`).

## Tests

17 targeted + 146 (`-k "regime or signal_reader or forced_bear or drawdown"`) + 78 (`-k "main or planner or risk_guard or posture"`) pass, **zero failures**; `main.py`/`signal_reader.py` byte-compile clean.

## Arc status

#176 ✅ · #177 ✅ · #178 ✅ (predictor-veto) · **#this (executor posture)** · remaining: research brief + macro prompt · dashboard observe panel · config EXPERIMENTS gate + SYSTEM_STATE/ROADMAP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
