### PR TITLE
feat(iam): Wave 3 PR2 add reference/price_cache/* to executor role grant

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
@@ -43,7 +43,8 @@
                 "arn:aws:s3:::alpha-engine-research/predictor/predictions/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache_slim/*",
-                "arn:aws:s3:::alpha-engine-research/predictor/metrics/*"
+                "arn:aws:s3:::alpha-engine-research/predictor/metrics/*",
+                "arn:aws:s3:::alpha-engine-research/reference/price_cache/*"
             ]
         },
         {


### PR DESCRIPTION
ROADMAP P1 **"`predictor/` S3 namespace rationalization Wave 3"** — companion to the producer write-both shipped in [alpha-engine-data PR #270](https://github.com/cipher813/alpha-engine-data/pull/270). Adds `reference/price_cache/*` to the existing `ReadWritePredictorData` statement on the executor role's `alpha-engine-s3-access` inline policy.

## What this does

Single ARN addition — keeps the namespace presence codified on the executor role during the write-both soak so any code path still reaching this scoped grant (vestigial or future) can hit both prefixes without `AccessDenied`.

```diff
                 "arn:aws:s3:::alpha-engine-research/predictor/weights/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/predictions/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache/*",
                 "arn:aws:s3:::alpha-engine-research/predictor/price_cache_slim/*",
-                "arn:aws:s3:::alpha-engine-research/predictor/metrics/*"
+                "arn:aws:s3:::alpha-engine-research/predictor/metrics/*",
+                "arn:aws:s3:::alpha-engine-research/reference/price_cache/*"
```

## Why this is the only IAM file touched

Cross-repo grep confirmed only the `alpha-engine` executor role has a scoped grant on `predictor/price_cache/*`. Predictor + research roles use full-bucket grants (`arn:aws:s3:::alpha-engine-research/*`) so they don't need editing. The executor role itself hasn't read `price_cache` directly since the 2026-04-17 ArcticDB migration (alpha-engine #60), so this grant is vestigial — but until PR4 retires both legacy prefixes end-to-end, the additive scope keeps the namespace codified.

## ⚠️ Deploy step runs PRE-merge, not post-merge

The `IAM Drift Check` CI job fails on the first push because it compares codified vs live AWS. This PR makes codified ≠ live until `apply.sh` runs against AWS — same pattern Wave 1 #120 used. **Run before merging:**

```bash
bash infrastructure/iam/apply.sh --role alpha-engine-executor-role --policy alpha-engine-s3-access
```

Then re-run the failed `IAM Drift Check` job from the Actions UI (or push a no-op commit). Drift will resolve, CI will pass, merge.

## Wave 3 sequencing

| PR | Repo | Status |
|---|---|---|
| PR1 — producer write-both | alpha-engine-data #270 | **Open** |
| **PR2 — IAM ARN add** | **alpha-engine (this)** | **Open — apply.sh PRE-merge** |
| PR3+ — reader migrations (4 repos) | post-≥1wk soak | Pending |
| PR4 — cutover (drop legacy, `aws s3 rm`) | post-PR3 | Pending |

🤖 Generated with [Claude Code](https://claude.com/claude-code)