### PR TITLE
fix(order-book-rationale): source per-ticker rejection reasons from optimizer shadow log

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -1553,6 +1553,13 @@ def run(
                     calendar_date=_dual.calendar_date,
                     trading_day=_dual.trading_day,
                     run_id=new_eval_run_id(),
+                    # L121 — when the portfolio optimizer is the
+                    # authoritative entry driver, legacy blocked/
+                    # risk_event lists are empty; the optimizer's
+                    # eligibility mask supplies the per-ticker
+                    # rejection reasons instead.
+                    optimizer_shadow_log=shadow_log,
+                    current_positions=current_positions,
                 )
                 write_order_book_rationale(
                     _rationale,

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -130,7 +130,7 @@ def _build_and_solve(
         tickers, signals_by_ticker, predictions_by_ticker,
         config, optimizer_cfg, spy_idx, cash_idx,
     )
-    eligibility = _build_eligibility(
+    eligibility, eligibility_reasons = _build_eligibility(
         tickers, signals_by_ticker, predictions_by_ticker,
         current_positions, config, spy_idx, cash_idx,
     )
@@ -163,6 +163,7 @@ def _build_and_solve(
         "current_weights": [float(x) for x in w_prev],
         "alpha_hat": [float(x) for x in alpha_hat],
         "eligibility": [bool(x) for x in eligibility],
+        "eligibility_reasons": list(eligibility_reasons),
         "stance_caps": [float(x) for x in stance_caps],
         "sectors": sectors,
         "would_be_trades": would_be_trades,
@@ -373,9 +374,30 @@ def _build_eligibility(
     config: dict,
     spy_idx: int,
     cash_idx: int,
-) -> np.ndarray:
+) -> tuple[np.ndarray, list[str | None]]:
+    """Compute per-ticker eligibility for new entries + the gate that
+    excluded each ineligible ticker.
+
+    Returns (eligibility_mask, reasons). ``reasons[i]`` is None for
+    eligible tickers, otherwise a stable slug naming the gate that
+    excluded the ticker — consumed downstream by
+    ``order_book_rationale.build_order_book_rationale`` to answer
+    "why didn't ticker X enter?" when the portfolio optimizer is the
+    authoritative driver (the legacy ``_plan_entries`` path is bypassed
+    and produces no ``blocked_entries`` / ``risk_events`` itself).
+
+    Reason slugs:
+      * ``"signal_exit"`` — research said EXIT.
+      * ``"gbm_veto"`` — predictor's high-confidence DOWN veto fired.
+      * ``"score_below_min"`` — research composite < ``min_score_to_enter``.
+      * ``"no_score"`` — no research signal / score for this ticker.
+
+    Held tickers stay eligible regardless of score (the optimizer
+    decides whether to reduce them).
+    """
     min_score = float(config.get("min_score_to_enter", 57))
     eligibility = np.ones(len(tickers), dtype=bool)
+    reasons: list[str | None] = [None] * len(tickers)
     for i, t in enumerate(tickers):
         if i in (spy_idx, cash_idx):
             continue
@@ -385,16 +407,22 @@ def _build_eligibility(
 
         if sig.get("signal") == "EXIT":
             eligibility[i] = False
+            reasons[i] = "signal_exit"
             continue
         if pred.get("gbm_veto") is True:
             eligibility[i] = False
+            reasons[i] = "gbm_veto"
             continue
         if is_held:
             continue
         score = sig.get("score")
-        if score is None or float(score) < min_score:
+        if score is None:
             eligibility[i] = False
-    return eligibility
+            reasons[i] = "no_score"
+        elif float(score) < min_score:
+            eligibility[i] = False
+            reasons[i] = "score_below_min"
+    return eligibility, reasons
 
 
 def _compute_trade_deltas(

--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -77,7 +77,109 @@ _STATE_ORDER = {
 # drove the rejection — these map to STATE_PREDICTOR_VETOED so the
 # console can answer "blocked by the ML layer" distinctly from
 # "blocked by a hard risk rule". Sourced from deciders.py emit sites.
-_PREDICTOR_RULES = {"stance_gate", "momentum_gate"}
+_PREDICTOR_RULES = {"stance_gate", "momentum_gate", "gbm_veto"}
+
+# Mapping from optimizer_shadow eligibility-rejection slugs to the
+# (rule, event_type, human_message) tuple used to synthesize
+# risk_events for the optimizer-authoritative path. Maps to the same
+# state vocabulary as the legacy path:
+#   - ``gbm_veto`` → STATE_PREDICTOR_VETOED (predictor-driven)
+#   - everything else → STATE_RISK_BLOCKED (research/score-driven)
+_OPTIMIZER_REJECTION_SLUGS = {
+    "gbm_veto": (
+        "gbm_veto",
+        "override",
+        "Predictor high-confidence DOWN veto fired (gbm_veto=true).",
+    ),
+    "score_below_min": (
+        "min_score_to_enter",
+        "block",
+        "Research composite score below configured min_score_to_enter.",
+    ),
+    "no_score": (
+        "missing_score",
+        "block",
+        "No research score available for this ticker (universe entry but signals "
+        "missing).",
+    ),
+    # ``signal_exit`` is intentionally not surfaced as a block — research-EXIT
+    # tickers flow through urgent_exits in the order book and are handled by
+    # the existing exit_path branch in build_order_book_rationale.
+}
+
+
+def _synthesize_optimizer_rejections(
+    *,
+    shadow_log: Mapping[str, Any] | None,
+    signals_by_ticker: Mapping[str, Mapping[str, Any]],
+    current_positions: set[str],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Reconstruct ``blocked_entries`` + ``risk_events`` from the optimizer log.
+
+    When ``use_portfolio_optimizer: true`` the legacy ``_plan_entries``
+    path is bypassed (executor/main.py § "Process ENTER signals"), so
+    ``plan.blocked`` and ``plan.risk_events`` are empty — but the
+    optimizer's eligibility mask still encodes per-ticker rejection
+    reasons. This function projects those reasons into the same dict
+    shape the legacy path produces so
+    ``build_order_book_rationale`` can answer "why didn't ticker X
+    enter?" identically across both code paths.
+
+    Returns (synthetic_blocked_entries, synthetic_risk_events). Both
+    lists are stable-ordered by the optimizer's ``tickers`` order.
+
+    Tickers that are currently held are excluded — a "rejection" for an
+    already-held ticker is structurally a research-EXIT (which the
+    order book carries as ``urgent_exits``), not a missed entry.
+    """
+    if not shadow_log:
+        return [], []
+    tickers = shadow_log.get("tickers") or []
+    eligibility = shadow_log.get("eligibility") or []
+    reasons = shadow_log.get("eligibility_reasons") or []
+    opt_cfg = shadow_log.get("optimizer_cfg") or {}
+    min_score_threshold = opt_cfg.get("min_score_to_enter")
+
+    blocked: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
+
+    for i, ticker in enumerate(tickers):
+        if i >= len(eligibility) or eligibility[i]:
+            continue
+        if ticker in current_positions:
+            continue
+        reason = reasons[i] if i < len(reasons) else None
+        mapped = _OPTIMIZER_REJECTION_SLUGS.get(reason or "")
+        if mapped is None:
+            continue
+        rule_slug, event_type, message = mapped
+
+        # Surface threshold + ticker's actual value when meaningful.
+        # score_below_min: threshold = min_score; value = the score.
+        # gbm_veto / no_score / others: best-effort, may be None.
+        sig = signals_by_ticker.get(ticker, {}) or {}
+        value: Any | None = None
+        threshold: Any | None = None
+        if reason == "score_below_min":
+            value = sig.get("score")
+            threshold = min_score_threshold
+        elif reason == "gbm_veto":
+            value = True
+        elif reason == "no_score":
+            value = None
+            threshold = min_score_threshold
+
+        blocked.append({"ticker": ticker, "block_reason": message})
+        events.append({
+            "ticker": ticker,
+            "event_type": event_type,
+            "rule": rule_slug,
+            "value": value,
+            "threshold": threshold,
+            "reason": message,
+        })
+
+    return blocked, events
 
 
 def _research_block(sig: Mapping[str, Any] | None) -> dict[str, Any]:
@@ -123,6 +225,8 @@ def build_order_book_rationale(
     calendar_date: str,
     trading_day: str,
     run_id: str,
+    optimizer_shadow_log: Mapping[str, Any] | None = None,
+    current_positions: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Join the morning-planner decision structures into a per-ticker record.
 
@@ -142,17 +246,73 @@ def build_order_book_rationale(
             incl. ``sizing_factors`` + ``triggers``; ``urgent_exits``
             carry exit/reduce/cover records).
         blocked_entries: ``plan.blocked`` — per-ENTER rejections with a
-            free-text ``block_reason``.
+            free-text ``block_reason``. EMPTY when the portfolio
+            optimizer is the authoritative entry driver (legacy
+            ``_plan_entries`` bypassed); the missing information is
+            then sourced from ``optimizer_shadow_log``.
         risk_events: ``plan.risk_events`` — structured rule log with
             ``event_type`` / ``rule`` / ``value`` / ``threshold``.
+            Same EMPTY-on-optimizer-path caveat as ``blocked_entries``.
         market_regime: effective regime for the run.
         run_date / signal_date / prediction_date: lineage dates.
         calendar_date / trading_day: dual-tracked dates (LdP).
         run_id: ``YYMMDDHHMM`` from ``new_eval_run_id``.
+        optimizer_shadow_log: when present, sources synthetic blocked /
+            risk_event records from ``log["eligibility"]`` +
+            ``log["eligibility_reasons"]`` so the rationale answers
+            "why didn't ticker X enter?" for the optimizer-driven path
+            (``use_portfolio_optimizer: true``). Synthetic records are
+            appended to ``blocked_entries`` / ``risk_events`` — the
+            legacy lists win on conflicts (legacy path is more
+            authoritative when it ran).
+        current_positions: ``{ticker: position_dict}`` of held tickers,
+            used to suppress synthetic rejections for tickers that are
+            already in the portfolio (a "rejection" for a held ticker
+            is a research-EXIT, which the order book carries as
+            ``urgent_exits`` — that branch already paints the right
+            state).
 
     Returns:
         Serializable payload dict (canonical eval_artifacts shape).
     """
+    # Optimizer-aware augmentation — see _synthesize_optimizer_rejections
+    # docstring. Synthesized records extend the legacy lists; existing
+    # legacy entries take precedence (the legacy gate, when it ran, is
+    # the authoritative source).
+    _signals_by_ticker_for_synth: dict[str, dict[str, Any]] = {}
+    for bucket in ("enter", "hold", "exit", "reduce"):
+        for sig in signals.get(bucket, []) or []:
+            t = sig.get("ticker") if isinstance(sig, Mapping) else None
+            if t:
+                _signals_by_ticker_for_synth[t] = dict(sig)
+    _held_set = (
+        {t for t in (current_positions or {}).keys() if t}
+        if current_positions is not None
+        else set()
+    )
+    _legacy_blocked_tickers = {
+        (b.get("ticker") if isinstance(b, Mapping) else None)
+        for b in (blocked_entries or [])
+    }
+    _legacy_event_tickers = {
+        (ev.get("ticker") if isinstance(ev, Mapping) else None)
+        for ev in (risk_events or [])
+    }
+    _synth_blocked, _synth_events = _synthesize_optimizer_rejections(
+        shadow_log=optimizer_shadow_log,
+        signals_by_ticker=_signals_by_ticker_for_synth,
+        current_positions=_held_set,
+    )
+    # De-duplicate against legacy entries by ticker so a ticker the
+    # legacy path already explained doesn't get a second synthetic row.
+    blocked_entries = list(blocked_entries or []) + [
+        b for b in _synth_blocked
+        if b.get("ticker") not in _legacy_blocked_tickers
+    ]
+    risk_events = list(risk_events or []) + [
+        e for e in _synth_events
+        if e.get("ticker") not in _legacy_event_tickers
+    ]
     enter = {s.get("ticker"): s for s in signals.get("enter", []) if s.get("ticker")}
     held = {s.get("ticker"): s for s in signals.get("hold", []) if s.get("ticker")}
     exited = {s.get("ticker"): s for s in signals.get("exit", []) if s.get("ticker")}

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -197,7 +197,7 @@ def test_exit_signal_makes_ticker_ineligible():
     cash_idx = tickers.index("CASH")
     aapl_idx = tickers.index("AAPL")
 
-    eligibility = _build_eligibility(
+    eligibility, _reasons = _build_eligibility(
         tickers, inputs["signals_raw"]["signals"],
         inputs["predictions_by_ticker"], inputs["current_positions"],
         inputs["config"], spy_idx, cash_idx,
@@ -219,7 +219,7 @@ def test_gbm_veto_makes_ticker_ineligible():
     spy_idx = tickers.index("SPY")
     cash_idx = tickers.index("CASH")
 
-    eligibility = _build_eligibility(
+    eligibility, _reasons = _build_eligibility(
         tickers, inputs["signals_raw"]["signals"],
         inputs["predictions_by_ticker"], inputs["current_positions"],
         inputs["config"], spy_idx, cash_idx,

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -310,3 +310,168 @@ def test_round_trip_via_lib_loader(scenario):
     )
     assert loaded["run_id"] == payload["run_id"]
     assert loaded["summary"]["n_considered"] == 7
+
+
+# ── optimizer-aware path (L121) ─────────────────────────────────────────
+
+
+class TestOptimizerShadowLogSynthesis:
+    """When use_portfolio_optimizer: true, the legacy _plan_entries path
+    is bypassed and blocked_entries / risk_events arrive EMPTY. The
+    rationale producer must source per-ticker rejection reasons from
+    the optimizer's shadow log to answer "why didn't ticker X enter?"
+    on the optimizer-driven path (ROADMAP L121)."""
+
+    def _optimizer_scenario(self):
+        """Optimizer-driven run. legacy lists are empty (legacy path skipped).
+        The shadow log carries the eligibility mask + reasons.
+        order_book_data carries the optimizer-translated approved + exits."""
+        signals = {
+            "enter": [
+                _sig("AAPL", "ENTER"),
+                _sig("NVDA", "ENTER", score=40.0),  # below min_score
+                _sig("AMD", "ENTER"),               # gbm_veto
+                _sig("F", "ENTER"),                 # universe but no score
+            ],
+            "exit": [_sig("MSFT", "EXIT")],
+            "reduce": [],
+            "hold": [_sig("KO", "HOLD")],
+        }
+        signals["enter"][3].pop("score", None)  # F has no score
+        predictions = {
+            "AAPL": {"predicted_direction": "UP", "predicted_alpha": 0.03},
+            "AMD": {"predicted_direction": "DOWN", "gbm_veto": True},
+        }
+        # Optimizer-translated order book: AAPL is the lone approved
+        # entry; MSFT comes through urgent_exits from the EXIT signal.
+        order_book = {
+            "date": "2026-05-15",
+            "approved_entries": [_entry_with_meta("AAPL")],
+            "urgent_exits": [
+                {"ticker": "MSFT", "signal": "EXIT", "shares": 50,
+                 "reason": "research_exit"},
+            ],
+            "active_stops": [],
+            "executed_today": [],
+        }
+        # Optimizer-shadow log shape per executor.optimizer_shadow._build_and_solve.
+        shadow_log = {
+            "shadow_status": "ok",
+            "tickers": ["AAPL", "NVDA", "AMD", "F", "MSFT", "KO", "SPY", "CASH"],
+            "eligibility": [True, False, False, False, False, True, True, True],
+            "eligibility_reasons": [
+                None,
+                "score_below_min",
+                "gbm_veto",
+                "no_score",
+                "signal_exit",
+                None,
+                None,
+                None,
+            ],
+            "optimizer_cfg": {"min_score_to_enter": 57.0},
+            "diagnostics": {"status": "optimal"},
+        }
+        return dict(
+            signals=signals,
+            predictions_by_ticker=predictions,
+            order_book_data=order_book,
+            blocked_entries=[],   # legacy path skipped
+            risk_events=[],       # legacy path skipped
+            market_regime="neutral",
+            run_date="2026-05-15",
+            signal_date="2026-05-15",
+            prediction_date="2026-05-15",
+            calendar_date="2026-05-15",
+            trading_day="2026-05-15",
+            run_id="2605151400",
+            optimizer_shadow_log=shadow_log,
+            current_positions={"KO": {"mkt_val": 1000}},
+        )
+
+    def test_optimizer_rejected_tickers_surface_in_rationale(self):
+        scenario = self._optimizer_scenario()
+        payload = build_order_book_rationale(**scenario)
+        by_ticker = {r["ticker"]: r for r in payload["tickers"]}
+        # NVDA: score below min → STATE_RISK_BLOCKED with min_score rule.
+        assert by_ticker["NVDA"]["terminal_state"] == STATE_RISK_BLOCKED
+        assert by_ticker["NVDA"]["exclusion"]["rule"] == "min_score_to_enter"
+        assert by_ticker["NVDA"]["exclusion"]["value"] == 40.0
+        assert by_ticker["NVDA"]["exclusion"]["threshold"] == 57.0
+
+    def test_optimizer_gbm_veto_surfaces_as_predictor_vetoed(self):
+        scenario = self._optimizer_scenario()
+        payload = build_order_book_rationale(**scenario)
+        by_ticker = {r["ticker"]: r for r in payload["tickers"]}
+        # AMD: gbm_veto → STATE_PREDICTOR_VETOED (event_type=override or
+        # rule in _PREDICTOR_RULES).
+        assert by_ticker["AMD"]["terminal_state"] == STATE_PREDICTOR_VETOED
+        assert by_ticker["AMD"]["exclusion"]["rule"] == "gbm_veto"
+
+    def test_optimizer_no_score_surfaces_as_risk_blocked(self):
+        scenario = self._optimizer_scenario()
+        payload = build_order_book_rationale(**scenario)
+        by_ticker = {r["ticker"]: r for r in payload["tickers"]}
+        # F: no score → STATE_RISK_BLOCKED with missing_score rule.
+        assert by_ticker["F"]["terminal_state"] == STATE_RISK_BLOCKED
+        assert by_ticker["F"]["exclusion"]["rule"] == "missing_score"
+
+    def test_optimizer_held_ticker_does_not_get_synthetic_rejection(self):
+        # KO is held (current_positions). Even if it were ineligible, we
+        # should NOT fabricate a "blocked" record — exits go through
+        # urgent_exits. Here KO IS eligible, so this is also a sanity
+        # check that the eligible branch doesn't produce noise.
+        scenario = self._optimizer_scenario()
+        payload = build_order_book_rationale(**scenario)
+        by_ticker = {r["ticker"]: r for r in payload["tickers"]}
+        # KO is held with no rebalance trade → STATE_HELD (research said
+        # HOLD; no order_book record).
+        assert by_ticker["KO"]["terminal_state"] == STATE_HELD
+
+    def test_legacy_path_with_no_shadow_log_unchanged(self, scenario):
+        # Backwards compat: no optimizer_shadow_log → identical output to
+        # pre-L121 behavior.
+        payload_legacy = build_order_book_rationale(**scenario)
+        payload_no_log = build_order_book_rationale(
+            **scenario, optimizer_shadow_log=None, current_positions=None,
+        )
+        assert payload_legacy["summary"] == payload_no_log["summary"]
+        assert payload_legacy["tickers"] == payload_no_log["tickers"]
+
+    def test_legacy_blocked_takes_precedence_over_synth(self):
+        # If both legacy and shadow_log produce rejection records for
+        # the same ticker, the legacy entry wins (it ran, it's
+        # authoritative). Mixed-path defensive case — production never
+        # produces this, but the dedup must be deterministic.
+        scenario = self._optimizer_scenario()
+        scenario["blocked_entries"] = [
+            {"ticker": "NVDA", "block_reason": "LEGACY reason"}
+        ]
+        scenario["risk_events"] = [
+            {"ticker": "NVDA", "event_type": "veto", "rule": "legacy_rule",
+             "value": 1.0, "threshold": 2.0, "reason": "LEGACY reason"}
+        ]
+        payload = build_order_book_rationale(**scenario)
+        nvda = next(r for r in payload["tickers"] if r["ticker"] == "NVDA")
+        # Legacy rule slug survives — synth row was filtered.
+        assert nvda["exclusion"]["rule"] == "legacy_rule"
+
+    def test_optimizer_shadow_eligibility_reasons_field_in_log(self):
+        # Sanity: the field name the producer reads matches what
+        # optimizer_shadow.py emits. Pins the contract between the two
+        # modules so a rename of either side is caught.
+        from executor.optimizer_shadow import _build_eligibility
+        import numpy as np
+        elig, reasons = _build_eligibility(
+            tickers=["AAA", "BBB", "SPY", "CASH"],
+            signals_by_ticker={"AAA": {"score": 80, "signal": "ENTER"},
+                               "BBB": {"score": 30, "signal": "ENTER"}},
+            predictions_by_ticker={},
+            current_positions={},
+            config={"min_score_to_enter": 57},
+            spy_idx=2,
+            cash_idx=3,
+        )
+        assert isinstance(elig, np.ndarray)
+        assert elig.tolist() == [True, False, True, True]
+        assert reasons == [None, "score_below_min", None, None]


### PR DESCRIPTION
## Summary
- **L121 (P2)** — order_book_rationale producer now answers "why didn't ticker X enter?" on the optimizer-driven path. Previously the rationale (and dashboard page 16) was structurally stale when `use_portfolio_optimizer: true` because the legacy `_plan_entries` path was bypassed and `blocked_entries` / `risk_events` arrived empty.
- `_build_eligibility` now returns `(mask, reasons)` — a parallel slug list (`"signal_exit"`, `"gbm_veto"`, `"score_below_min"`, `"no_score"`) added to the shadow log under `eligibility_reasons`.
- `build_order_book_rationale` accepts `optimizer_shadow_log` + `current_positions`; `_synthesize_optimizer_rejections` projects ineligibility reasons into the same `blocked_entries` / `risk_events` shape the legacy path produces.
- Mappings: `gbm_veto` → `STATE_PREDICTOR_VETOED`; `score_below_min` / `no_score` → `STATE_RISK_BLOCKED` (with `min_score_to_enter` / `missing_score` rules and threshold + ticker value populated).
- Legacy lists take precedence on conflicts; held tickers are excluded from synthesis (research-EXIT goes through `urgent_exits`).

## Why
ROADMAP L121 — audit finding from the 2026-05-20 canonical-alpha alpha-floor arc. Dashboard PR #90 fixed the styler-shape crash; this PR fixes the underlying artifact CONTENT staleness.

## Test plan
- [x] 7 new cases in `TestOptimizerShadowLogSynthesis` pin: min_score rejection, gbm_veto → predictor-vetoed, no_score → risk-blocked, held tickers stay STATE_HELD, no-shadow-log identical to pre-L121 output, legacy-takes-precedence dedup, producer↔consumer contract between `optimizer_shadow.eligibility_reasons` and `_OPTIMIZER_REJECTION_SLUGS`.
- [x] Existing `tests/test_optimizer_shadow.py` updated for the new 2-tuple return type (2 sites).
- [x] Full executor suite: 932 passed (additive, no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)