### PR TITLE
refactor(health-checker): migrate inline curl→Telegram to alpha_engine_lib.alerts CLI

### DIFF
--- a/infrastructure/health_checker.sh
+++ b/infrastructure/health_checker.sh
@@ -41,13 +41,29 @@ declare -A MAX_HOURS=(
 
 send_alert() {
     local msg="$1"
-    if [ -z "${TELEGRAM_BOT_TOKEN:-}" ] || [ -z "${TELEGRAM_CHAT_ID:-}" ]; then
-        echo "ALERT (no Telegram): $msg"
-        return
+    # Migrated 2026-05-20 (ROADMAP L146) — was an inline `curl` to the
+    # Telegram bot API; now delegates to the canonical
+    # ``alpha_engine_lib.alerts`` primitive (v0.21.0, lib #52) which
+    # fans out to BOTH the SNS ``alpha-engine-alerts`` topic (→ email)
+    # AND ``@nous_ergon_alerts_bot``. The Bash-side contract is
+    # unchanged: ``send_alert "$msg"`` from anywhere in the script.
+    #
+    # Resolve a Python that has alpha_engine_lib installed — prefer the
+    # repo-local venv (matches the dispatcher-cleanup pattern in
+    # alpha-engine-backtester #231), fall back to whichever system
+    # python3 is on PATH. ``|| echo`` is the same graceful-degrade
+    # surface the pre-migration ``no Telegram`` branch provided.
+    local _alert_python
+    if [ -x "$(dirname "$0")/../.venv/bin/python" ]; then
+        _alert_python="$(dirname "$0")/../.venv/bin/python"
+    else
+        _alert_python="$(command -v python3 || command -v python || echo python)"
     fi
-    curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-        -d chat_id="${TELEGRAM_CHAT_ID}" \
-        -d text="$msg" > /dev/null 2>&1
+    "$_alert_python" -m alpha_engine_lib.alerts publish \
+        --message "$msg" \
+        --severity error \
+        --source alpha-engine/infrastructure/health_checker.sh \
+        > /dev/null 2>&1 || echo "ALERT (alerts.publish failed): $msg"
 }
 
 alerts=""

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ requests~=2.32
 # setup_logging()/_attach_flow_doctor() before flow_doctor.init() reads
 # os.environ — closes the PR 9g systemd-entrypoint env gap upstream for
 # all repos (replaces the executor-local secrets_bootstrap.py approach).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.17.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
## Summary
- **L146 (P2)** — alpha-engine half of the inline-alerts → lib.alerts migration.
- `infrastructure/health_checker.sh send_alert()`: raw `curl` POST to `api.telegram.org` → `python -m alpha_engine_lib.alerts publish --severity error --source alpha-engine/infrastructure/health_checker.sh`. Fans out to BOTH the SNS `alpha-engine-alerts` topic (→ email) AND `@nous_ergon_alerts_bot`.
- Lib pin bumped v0.17.0 → v0.21.0 (alerts module floor). v0.18–v0.21 are additive: email_sender, arcticdb extensions, alerts — none of the lib modules alpha-engine consumes were changed.
- Python resolution mirrors the alpha-engine-backtester #231 `cleanup()` pattern (`.venv` first, system `python3` fallback, graceful-degrade to stdout echo).

## Why
ROADMAP L146 / SOTA sub-sub-rule (lift-to-lib for ≥2 consumers). First consumer was alpha-engine-backtester #231; this is the second of two inline sites named in the ROADMAP. The sibling alpha-engine-data PR migrates the changelog-incident-mirror smoke test in the same arc.

## Test plan
- [x] Lib v0.21.0 installs cleanly in alpha-engine venv; `alpha_engine_lib.alerts` imports.
- [x] CLI dry-run with `--no-sns --no-telegram` exits with the expected one-line status message.
- [x] Full executor suite: 925 passed (no regressions from the lib bump).
- [ ] Operator validation: next health-alert firing on the dashboard EC2 should land in both the alpha-engine-alerts SNS topic AND the Telegram channel (vs Telegram-only pre-migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)