### PR TITLE
fix(order-book-rationale): source held state from IB portfolio truth

### DIFF
--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -265,12 +265,16 @@ def build_order_book_rationale(
             appended to ``blocked_entries`` / ``risk_events`` — the
             legacy lists win on conflicts (legacy path is more
             authoritative when it ran).
-        current_positions: ``{ticker: position_dict}`` of held tickers,
-            used to suppress synthetic rejections for tickers that are
-            already in the portfolio (a "rejection" for a held ticker
-            is a research-EXIT, which the order book carries as
-            ``urgent_exits`` — that branch already paints the right
-            state).
+        current_positions: ``{ticker: position_dict}`` of held tickers
+            from the IB portfolio. This is the **authoritative source**
+            for whether a ticker is currently held — NOT the research
+            ``signals.json["hold"]`` bucket (which is a research
+            recommendation, not portfolio truth). Used to (a) set the
+            ``STATE_HELD`` terminal state and the per-record ``held``
+            boolean, (b) extend the considered universe so held tickers
+            appear in the table even when research is silent on them,
+            and (c) suppress synthetic optimizer rejections for tickers
+            already in the portfolio (those exit via ``urgent_exits``).
 
     Returns:
         Serializable payload dict (canonical eval_artifacts shape).
@@ -314,9 +318,33 @@ def build_order_book_rationale(
         if e.get("ticker") not in _legacy_event_tickers
     ]
     enter = {s.get("ticker"): s for s in signals.get("enter", []) if s.get("ticker")}
-    held = {s.get("ticker"): s for s in signals.get("hold", []) if s.get("ticker")}
+    research_hold = {
+        s.get("ticker"): s for s in signals.get("hold", []) if s.get("ticker")
+    }
     exited = {s.get("ticker"): s for s in signals.get("exit", []) if s.get("ticker")}
     reduced = {s.get("ticker"): s for s in signals.get("reduce", []) if s.get("ticker")}
+
+    # Per-ticker optimizer view, sourced from the shadow log's parallel
+    # lists (tickers / current_weights / target_weights / alpha_hat /
+    # eligibility). Empty dict for legacy non-optimizer runs.
+    optimizer_view: dict[str, dict[str, Any]] = {}
+    if isinstance(optimizer_shadow_log, Mapping):
+        _tks = optimizer_shadow_log.get("tickers") or []
+        _cw = optimizer_shadow_log.get("current_weights") or []
+        _tw = optimizer_shadow_log.get("target_weights") or []
+        _ah = optimizer_shadow_log.get("alpha_hat") or []
+        _el = optimizer_shadow_log.get("eligibility") or []
+        for i, tk in enumerate(_tks):
+            if not tk:
+                continue
+            optimizer_view[tk] = {
+                "current_weight": _cw[i] if i < len(_cw) else None,
+                "target_weight": _tw[i] if i < len(_tw) else None,
+                "alpha_hat": _ah[i] if i < len(_ah) else None,
+                "eligible": (
+                    bool(_el[i]) if i < len(_el) and _el[i] is not None else None
+                ),
+            }
 
     approved = {
         e.get("ticker"): e
@@ -343,20 +371,23 @@ def build_order_book_rationale(
             first_event[t] = ev
 
     considered = (
-        set(enter) | set(held) | set(exited) | set(reduced)
+        set(enter) | set(research_hold) | set(exited) | set(reduced)
         | set(approved) | set(urgent) | set(blocked) | set(first_event)
+        | _held_set
     )
 
     records: list[dict[str, Any]] = []
     for ticker in considered:
         sig = (
-            enter.get(ticker) or held.get(ticker)
+            enter.get(ticker) or research_hold.get(ticker)
             or exited.get(ticker) or reduced.get(ticker)
         )
         pred = predictions_by_ticker.get(ticker)
         ev = first_event.get(ticker)
         ob_entry = approved.get(ticker)
         ob_exit = urgent.get(ticker)
+        is_held = ticker in _held_set
+        opt_view = optimizer_view.get(ticker)
 
         chain: list[dict[str, Any]] = []
         exclusion: dict[str, Any] | None = None
@@ -437,16 +468,32 @@ def build_order_book_rationale(
                 "threshold": exclusion["threshold"],
                 "detail": exclusion["reason"],
             })
-        elif ticker in held:
+        elif is_held:
             state = STATE_HELD
+            # Surface the optimizer's maintain-decision for held tickers
+            # so the chain explains *why* the position is held today
+            # (target weight ≈ current weight, no rebalance trade).
+            if opt_view is not None:
+                _cw = opt_view.get("current_weight")
+                _tw = opt_view.get("target_weight")
+                chain.append({
+                    "stage": "optimizer",
+                    "result": "maintain",
+                    "detail": (
+                        f"tgt {_tw * 100:.2f}% / cur {_cw * 100:.2f}%"
+                        if _cw is not None and _tw is not None else None
+                    ),
+                })
         else:
             state = STATE_NO_ACTION
 
         records.append({
             "ticker": ticker,
             "terminal_state": state,
+            "held": is_held,
             "research": _research_block(sig),
             "predictor": _predictor_block(pred),
+            "optimizer": opt_view,
             "decision_chain": chain,
             "exclusion": exclusion,
             "order_book": ob_entry or ob_exit or None,

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -123,6 +123,10 @@ def scenario():
         calendar_date="2026-05-15",
         trading_day="2026-05-15",
         run_id="2605151400",
+        # KO is the held ticker — must come from portfolio truth, not
+        # the research `hold` bucket (research HOLD on a non-held ticker
+        # is a recommendation that wasn't acted on, not a held state).
+        current_positions={"KO": {"mkt_val": 1000}},
     )
 
 
@@ -429,12 +433,13 @@ class TestOptimizerShadowLogSynthesis:
         assert by_ticker["KO"]["terminal_state"] == STATE_HELD
 
     def test_legacy_path_with_no_shadow_log_unchanged(self, scenario):
-        # Backwards compat: no optimizer_shadow_log → identical output to
-        # pre-L121 behavior.
+        # Backwards compat: omitting optimizer_shadow_log → identical
+        # output to pre-L121 behavior. Both paths still receive the
+        # scenario's `current_positions` (the held-ticker source), so
+        # the diff isolates shadow-log presence only.
         payload_legacy = build_order_book_rationale(**scenario)
-        payload_no_log = build_order_book_rationale(
-            **scenario, optimizer_shadow_log=None, current_positions=None,
-        )
+        scenario_no_log = {**scenario, "optimizer_shadow_log": None}
+        payload_no_log = build_order_book_rationale(**scenario_no_log)
         assert payload_legacy["summary"] == payload_no_log["summary"]
         assert payload_legacy["tickers"] == payload_no_log["tickers"]
 
@@ -475,3 +480,168 @@ class TestOptimizerShadowLogSynthesis:
         assert isinstance(elig, np.ndarray)
         assert elig.tolist() == [True, False, True, True]
         assert reasons == [None, "score_below_min", None, None]
+
+
+# ── held detection sourced from portfolio truth (current_positions) ──
+#
+# Regression coverage for the 2026-05-20 incident: AXP/LMT were held in
+# the IB portfolio with the optimizer maintaining their target weights,
+# but the producer was deriving STATE_HELD from `signals.json["hold"]`
+# (a research recommendation, not portfolio truth) — so AXP/LMT fell
+# through to STATE_NO_ACTION while SYK (research HOLD but cur_w=0)
+# wrongly showed as STATE_HELD. The fix routes the held branch through
+# `current_positions` and surfaces the optimizer's maintain-decision.
+
+
+class TestHeldFromPortfolioTruth:
+    def _empty_books(self) -> dict[str, Any]:
+        return {
+            "date": "2026-05-20",
+            "approved_entries": [],
+            "urgent_exits": [],
+            "active_stops": [],
+            "executed_today": [],
+        }
+
+    def test_held_ticker_with_research_enter_signal_state_held(self):
+        # AXP case: held in portfolio, research signal is ENTER (wants
+        # to add more), optimizer maintains target weight ≈ current
+        # weight, no order_book entry. Must resolve to STATE_HELD.
+        payload = build_order_book_rationale(
+            signals={"enter": [_sig("AXP", "ENTER", score=75.0)],
+                     "exit": [], "reduce": [], "hold": []},
+            predictions_by_ticker={
+                "AXP": {"predicted_direction": "UP",
+                        "prediction_confidence": 0.33}},
+            order_book_data=self._empty_books(),
+            blocked_entries=[],
+            risk_events=[],
+            market_regime="neutral",
+            run_date="2026-05-20",
+            signal_date="2026-05-20",
+            prediction_date="2026-05-20",
+            calendar_date="2026-05-20",
+            trading_day="2026-05-20",
+            run_id="2605201400",
+            current_positions={"AXP": {"mkt_val": 8000}},
+        )
+        axp = next(r for r in payload["tickers"] if r["ticker"] == "AXP")
+        assert axp["terminal_state"] == STATE_HELD
+        assert axp["held"] is True
+
+    def test_non_held_ticker_with_research_hold_is_no_action(self):
+        # SYK case: research recommends HOLD but the ticker is not in
+        # the portfolio (cur_w=0). Research HOLD on a non-held ticker
+        # is an informational opinion, NOT a held state — resolve to
+        # STATE_NO_ACTION so the table doesn't claim we hold it.
+        payload = build_order_book_rationale(
+            signals={"enter": [], "exit": [], "reduce": [],
+                     "hold": [_sig("SYK", "HOLD")]},
+            predictions_by_ticker={},
+            order_book_data=self._empty_books(),
+            blocked_entries=[],
+            risk_events=[],
+            market_regime="neutral",
+            run_date="2026-05-20",
+            signal_date="2026-05-20",
+            prediction_date="2026-05-20",
+            calendar_date="2026-05-20",
+            trading_day="2026-05-20",
+            run_id="2605201400",
+            current_positions={},
+        )
+        syk = next(r for r in payload["tickers"] if r["ticker"] == "SYK")
+        assert syk["terminal_state"] == STATE_NO_ACTION
+        assert syk["held"] is False
+
+    def test_held_ticker_silent_from_research_appears_in_table(self):
+        # A position the IB portfolio holds but research has no opinion
+        # on this week must STILL appear in the considered universe so
+        # the table can answer "why is X held" for the full portfolio.
+        payload = build_order_book_rationale(
+            signals={"enter": [], "exit": [], "reduce": [], "hold": []},
+            predictions_by_ticker={},
+            order_book_data=self._empty_books(),
+            blocked_entries=[],
+            risk_events=[],
+            market_regime="neutral",
+            run_date="2026-05-20",
+            signal_date="2026-05-20",
+            prediction_date="2026-05-20",
+            calendar_date="2026-05-20",
+            trading_day="2026-05-20",
+            run_id="2605201400",
+            current_positions={"LMT": {"mkt_val": 7000}},
+        )
+        tickers = {r["ticker"] for r in payload["tickers"]}
+        assert "LMT" in tickers
+        lmt = next(r for r in payload["tickers"] if r["ticker"] == "LMT")
+        assert lmt["terminal_state"] == STATE_HELD
+        assert lmt["held"] is True
+
+    def test_optimizer_block_populated_from_shadow_log(self):
+        # When the shadow log is present, each record carries the
+        # per-ticker optimizer view (current_weight, target_weight,
+        # alpha_hat, eligible) so the dashboard can render the
+        # maintain/reduce/select decision without re-loading the log.
+        shadow = {
+            "tickers": ["AXP", "MSFT"],
+            "current_weights": [0.08, 0.0],
+            "target_weights": [0.08, 0.0],
+            "alpha_hat": [0.039, -0.02],
+            "eligibility": [True, True],
+        }
+        payload = build_order_book_rationale(
+            signals={"enter": [], "exit": [], "reduce": [], "hold": []},
+            predictions_by_ticker={},
+            order_book_data=self._empty_books(),
+            blocked_entries=[],
+            risk_events=[],
+            market_regime="neutral",
+            run_date="2026-05-20",
+            signal_date="2026-05-20",
+            prediction_date="2026-05-20",
+            calendar_date="2026-05-20",
+            trading_day="2026-05-20",
+            run_id="2605201400",
+            optimizer_shadow_log=shadow,
+            current_positions={"AXP": {"mkt_val": 8000}},
+        )
+        axp = next(r for r in payload["tickers"] if r["ticker"] == "AXP")
+        assert axp["optimizer"]["current_weight"] == 0.08
+        assert axp["optimizer"]["target_weight"] == 0.08
+        assert axp["optimizer"]["eligible"] is True
+        # Optimizer maintain-decision is in the chain for held tickers.
+        opt_stage = next(
+            (s for s in axp["decision_chain"] if s["stage"] == "optimizer"),
+            None,
+        )
+        assert opt_stage is not None
+        assert opt_stage["result"] == "maintain"
+        assert "tgt 8.00%" in opt_stage["detail"]
+        assert "cur 8.00%" in opt_stage["detail"]
+
+    def test_legacy_path_records_carry_held_false_and_null_optimizer(self):
+        # No shadow_log + no current_positions → backwards-compat:
+        # `held` is False for every record, `optimizer` is None.
+        payload = build_order_book_rationale(
+            signals={"enter": [_sig("AAPL", "ENTER")],
+                     "exit": [], "reduce": [], "hold": []},
+            predictions_by_ticker={},
+            order_book_data={"date": "2026-05-20",
+                             "approved_entries": [_entry_with_meta("AAPL")],
+                             "urgent_exits": [], "active_stops": [],
+                             "executed_today": []},
+            blocked_entries=[],
+            risk_events=[],
+            market_regime="neutral",
+            run_date="2026-05-20",
+            signal_date="2026-05-20",
+            prediction_date="2026-05-20",
+            calendar_date="2026-05-20",
+            trading_day="2026-05-20",
+            run_id="2605201400",
+        )
+        aapl = next(r for r in payload["tickers"] if r["ticker"] == "AAPL")
+        assert aapl["held"] is False
+        assert aapl["optimizer"] is None


### PR DESCRIPTION
## Summary

Today's OBR artifact for 2026-05-20 mislabels AXP and LMT (both held, both maintained by optimizer at target ≈ current weight) as `no_action`, while wrongly labeling SYK (cur_w=0, not in portfolio) as `held`. Root cause: `build_order_book_rationale` derived `STATE_HELD` from `signals.json["hold"]` — a research recommendation, not portfolio truth. `current_positions` was already passed but only used for the synthetic-rejection dedup.

## What changed

`executor/order_book_rationale.py`:
- `STATE_HELD` branch now routes through `current_positions` (the IB portfolio truth). Local var renamed `held` → `research_hold` to keep the dichotomy explicit.
- `current_positions` included in the `considered` set — held tickers with no research signal still appear in the table.
- Per-record `held: bool` field added.
- Per-record `optimizer: {current_weight, target_weight, alpha_hat, eligible}` block added (extracted from the shadow log) — gives the dashboard everything it needs for the maintain/reduce/select decision without re-loading the log.
- New `optimizer: maintain` chain stage on held tickers shows `tgt X.XX% / cur X.XX%` so the decision chain explains *why* the position is held today.

## Effect on today's artifact

| Ticker | Before (wrong) | After (correct) |
|--------|----------------|-----------------|
| AXP (cur_w 7.91%, tgt_w 8.00%, research ENTER) | `no_action` | `held` + `optimizer: maintain (tgt 8.00% / cur 7.91%)` |
| LMT (cur_w 7.11%, tgt_w 7.00%, research ENTER) | `no_action` | `held` + `optimizer: maintain (tgt 7.00% / cur 7.11%)` |
| SYK (cur_w 0, research HOLD) | `held` (wrong — not in portfolio) | `no_action` |

## Tests

- 937/937 green
- Shared `scenario` fixture updated to pass `current_positions={"KO": {...}}` (KO's held-ness was previously research-bucket-inferred — now portfolio truth, which is the correct invariant)
- New `TestHeldFromPortfolioTruth` class:
  - `test_held_ticker_with_research_enter_signal_state_held` — AXP case
  - `test_non_held_ticker_with_research_hold_is_no_action` — SYK case
  - `test_held_ticker_silent_from_research_appears_in_table` — held + research silent
  - `test_optimizer_block_populated_from_shadow_log` — optimizer block + maintain chain stage
  - `test_legacy_path_records_carry_held_false_and_null_optimizer` — backwards-compat

## Followups

Dashboard PR-B follows separately — adds a `Held` column to `pages/16_Order_Book_Rationale.py` and surfaces `optimizer.current_weight` / `target_weight` so the user can see the maintain decision at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)