### PR TITLE
fix(daemon+OBR): semantic action label on urgent-exits Telegram + alert on OBR write failure (L165, L171)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -678,8 +678,16 @@ def run_daemon(dry_run: bool = False) -> None:
                     held_after = int(_phase0_positions[ticker].get("shares", 0)) - shares
                     _phase0_positions[ticker]["shares"] = held_after
 
+                # L165 (2026-05-22): pass the SEMANTIC action ("EXIT" /
+                # "REDUCE" / "COVER"), not the IB side ("SELL" / "BUY").
+                # The intraday `_execute_exit` path at L1094 already does
+                # this correctly; the prior asymmetric spelling caused
+                # "Telegram shows SELL but page 16 shows REDUCE" for
+                # morning urgent REDUCEs. The action label IS the
+                # alert's semantic payload — losing it silently fails
+                # the alert's purpose ([[feedback_no_silent_fails]]).
                 send_trade_alert(
-                    action=side,
+                    action=action,
                     ticker=ticker,
                     shares=shares,
                     price=fill_price,

--- a/executor/main.py
+++ b/executor/main.py
@@ -1567,10 +1567,44 @@ def run(
                     bucket=signals_bucket,
                 )
             except Exception as _rat_err:
+                # L171 (2026-05-22) — OBR is observability infra, not
+                # load-bearing, so we don't crash the morning planner on
+                # a rationale-write failure. But the failure MUST reach
+                # the operator: page 16 falling back to yesterday's
+                # snapshot is exactly the silent regression
+                # [[feedback_no_silent_fails]] forbids. WARN-log here
+                # is one recording surface; lib v0.24.0 alerts.publish
+                # is the second (SNS + Telegram). Both best-effort —
+                # alert-publish itself is best-effort per the same
+                # secondary-observability clause as the score_aggregator
+                # pillar-sanity path. dedup_key collapses repeat
+                # failures within the publish window.
                 logger.warning(
                     "Order-book rationale write failed (non-blocking): %s",
                     _rat_err,
                 )
+                try:
+                    from alpha_engine_lib import alerts as _alerts
+                    _alerts.publish(
+                        message=(
+                            f"[executor/main.py] Order-book rationale write "
+                            f"failed for run_date={run_date}: "
+                            f"{type(_rat_err).__name__}: {_rat_err}. "
+                            f"Page 16 will fall back to the prior snapshot "
+                            f"until next morning-planner run."
+                        ),
+                        severity="WARN",
+                        source="alpha-engine/executor/main.py",
+                        sns=True,
+                        telegram=True,
+                        dedup_key=f"obr_write_failed_{run_date}",
+                    )
+                except Exception as _alert_err:  # noqa: BLE001 — secondary observability
+                    logger.warning(
+                        "OBR-failure alert publish itself failed: %s "
+                        "(WARN log above remains the failure surface)",
+                        _alert_err,
+                    )
 
         # ── 7. Backup and disconnect ─────────────────────────────────────────
         if not dry_run and not simulate:

--- a/tests/test_daemon_phase0.py
+++ b/tests/test_daemon_phase0.py
@@ -328,3 +328,46 @@ class TestTriggerEodPipeline:
             _trigger_eod_pipeline({}, "2026-04-29")
             payload = json.loads(sfn.start_execution.call_args.kwargs["input"])
             assert "alpha-engine-alerts" in payload["sns_topic_arn"]
+
+
+# ── L165: urgent-exits action label semantic correctness ─────────────────
+
+
+class TestPhase0UrgentExitsActionLabel:
+    """Pin the L165 fix (2026-05-22): the urgent-exits loop must pass
+    the SEMANTIC action ("EXIT" / "REDUCE" / "COVER") to
+    send_trade_alert, NOT the IB side ("SELL" / "BUY").
+
+    Failure mode this catches: morning urgent REDUCEs surface in
+    Telegram as "SELL" (because the daemon previously passed `side`
+    instead of `action`), while page 16 / OBR shows the real action.
+    Asymmetric with the intraday `_execute_exit` path that already
+    passes `action=action` correctly. Source-inspection pin so a
+    future refactor that drops the fix breaks at CI time, not after
+    the next divergence incident.
+    """
+
+    def test_phase0_urgent_exit_passes_semantic_action_not_side(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # The Phase-0 urgent-exits loop must build `send_trade_alert`
+        # with `action=action`, not `action=side`. The exact spelling
+        # is asserted because that's the single-line bug class the L165
+        # fix closes — any future contributor copy-pasting from a
+        # pre-fix snippet falls into this pin.
+        assert "action=side" not in src, (
+            "daemon.py contains `action=side` — the L165 bug class is "
+            "back. Pass the semantic action label ('EXIT'/'REDUCE'/"
+            "'COVER') to send_trade_alert, not the IB side."
+        )
+        # And the urgent-exits loop's call must still use action= keyword.
+        # Pin the specific surrounding context so we'd notice a future
+        # refactor that moves the call to a helper without preserving
+        # the label.
+        assert 'trigger=f"urgent_{reason}"' in src, (
+            "the Phase-0 urgent-exits send_trade_alert call appears "
+            "to have been refactored — re-audit the new call site for "
+            "the L165 action-label correctness before merging."
+        )

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -645,3 +645,44 @@ class TestHeldFromPortfolioTruth:
         aapl = next(r for r in payload["tickers"] if r["ticker"] == "AAPL")
         assert aapl["held"] is False
         assert aapl["optimizer"] is None
+
+
+# ── L171: OBR write-failure surfaces via alerts.publish ───────────────────
+
+
+def test_obr_write_failure_publishes_alert_not_silent_swallow():
+    """Pin the L171 fix (2026-05-22): an OBR write failure in
+    `executor/main.py` must reach the operator via
+    `alpha_engine_lib.alerts.publish` — silent warning-log only is
+    exactly the [[feedback_no_silent_fails]] failure mode (page 16
+    falls back to yesterday's snapshot with zero signal that today's
+    write never landed).
+
+    Source-inspection regression test (the surrounding `executor/main.py`
+    requires full executor harness to exercise); pin the structural
+    contract so a future refactor that drops the publish call breaks
+    at CI time.
+    """
+    import inspect
+    import executor.main as main_mod
+
+    src = inspect.getsource(main_mod)
+    # Locate the OBR-rationale write block — the WARN log + the
+    # alpha_engine_lib.alerts.publish must BOTH live in the except
+    # handler that wraps write_order_book_rationale.
+    assert "Order-book rationale write failed" in src, (
+        "OBR write-failure WARN log appears to have been refactored — "
+        "re-audit the new except handler for the L171 alert publish "
+        "before merging."
+    )
+    assert "obr_write_failed_" in src, (
+        "OBR write-failure handler must call `alpha_engine_lib.alerts.publish` "
+        "with a `dedup_key` starting `obr_write_failed_` so the failure "
+        "reaches Telegram/SNS rather than silently swallowing "
+        "([[feedback_no_silent_fails]])."
+    )
+    assert "from alpha_engine_lib import alerts" in src, (
+        "OBR write-failure handler must import alpha_engine_lib.alerts "
+        "lazily (inside the except) so a missing lib at boot doesn't "
+        "break the planner cold-start."
+    )


### PR DESCRIPTION
## Summary

Closes 2 of the 4 follow-ups from **alpha-engine-config PR #274**'s 2026-05-22 OBR ↔ Telegram action-label mismatch investigation.

### L165 P1 — daemon urgent-exits passes SEMANTIC action to Telegram

\`executor/daemon.py:681-688\` (Phase 0 urgent-exits loop) called \`send_trade_alert(action=side, ...)\` where \`side\` is the IB-wire side ("SELL"/"BUY"); the real semantic action ("EXIT"/"REDUCE"/"COVER") sat in the local \`action\` variable and was lost on the wire. The intraday \`_execute_exit\` path at L1094 already passes \`action=action\` correctly — asymmetric, which is why morning urgent REDUCEs surfaced as Telegram **SELL** while intraday REDUCEs surfaced as Telegram **REDUCE**.

**Fix:** one-line \`action=side\` → \`action=action\` at L682.

### L171 P3 — OBR write failure publishes alert, not silent swallow

\`executor/main.py:1569-1573\` wrapped the morning-planner OBR write in \`except Exception as _rat_err: logger.warning(...)\` with no metric, no alert, no rerun signal. Page 16 falling back to yesterday's snapshot with zero operator signal is exactly the \`[[feedback_no_silent_fails]]\` failure mode.

**Fix:** keep the WARN log + add \`alpha_engine_lib.alerts.publish\` (SNS+Telegram via the lib v0.24.0 chokepoint, dedup_key \`obr_write_failed_{run_date}\` so repeat-day failures collapse). Best-effort — the alert publish itself catches its own exception so a Telegram outage during an OBR failure doesn't compound. OBR is observability infra, not a load-bearing producer; planner does NOT crash on its failure, but failure MUST reach the operator.

## Tests

Both fixes pinned via **source-inspection regression tests** (the surrounding flows require full executor / IB harness):

- \`TestPhase0UrgentExitsActionLabel\` — fails CI if \`action=side,\` returns to daemon source, or if the surrounding \`urgent_{reason}\` context refactors away.
- \`test_obr_write_failure_publishes_alert_not_silent_swallow\` — fails CI if the \`obr_write_failed_\` dedup_key or the lazy lib import disappear from main.py.

Suite: **937 → 939**.

## Sequencing

Two remaining OBR-cluster items from PR #274 land separately:
- P1 OBR intraday gap (design call: option a vs b) — 1-2 sessions
- P2 per-decision \`decided_at\` timestamps — gated on the design call

🤖 Generated with [Claude Code](https://claude.com/claude-code)