### PR TITLE
feat(executor): retry audit trail + universal rationale_json enrichment (L133)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -234,12 +234,25 @@ def _place_order_with_retry(
                    fill when the hold releases. Retrying duplicates the order
                    (PFE incident 2026-04-22).
       * Filled / PartialFill → done.
+
+    L133 (2026-05-22): the returned dict carries two new audit-trail
+    fields the caller embeds into ``rationale_json``:
+      * ``retry_count`` (int) — 0 if the first attempt succeeded.
+      * ``attempts`` (list of dict) — per-attempt
+        ``{attempt, status, ib_order_id, retry_reason}`` records.
+    Closes the home-endnote gap that PR #100 had to reword from
+    "every order, fill, retry, and exit decision recorded with
+    rationale" — the retry chain is now persisted alongside the
+    final fill state, not lost on the floor.
     """
     order_result = None
+    attempts: list[dict] = []
     for attempt in range(MAX_ORDER_RETRIES):
+        retry_reason: str | None = None
         if attempt > 0:
             prior_id = order_result.get("ib_order_id") if order_result else None
             prior_status = order_result.get("status") if order_result else None
+            retry_reason = prior_status  # "Timeout" / "Rejected" → why we're retrying
             if prior_status == "Timeout" and prior_id is not None:
                 try:
                     ibkr.cancel_order(prior_id)
@@ -252,8 +265,19 @@ def _place_order_with_retry(
             order_result = place_bracket_with_stop(ibkr, ticker, shares, **bracket_kwargs)
         else:
             order_result = ibkr.place_market_order(ticker, side, shares)
+        attempts.append({
+            "attempt": attempt + 1,
+            "status": order_result.get("status"),
+            "ib_order_id": order_result.get("ib_order_id"),
+            "retry_reason": retry_reason,
+        })
         if order_result["status"] not in ("Rejected", "Timeout"):
             break
+    # Embed the audit trail on the returned dict so log_trade callers
+    # can include it verbatim in rationale_json. Routing decisions
+    # never read these — purely audit.
+    order_result["retry_count"] = len(attempts) - 1
+    order_result["attempts"] = attempts
     return order_result
 
 
@@ -649,6 +673,24 @@ def run_daemon(dry_run: bool = False) -> None:
                         "exit_detail": urgent.get("detail", ""),
                         "source": "intraday_daemon",
                         "phase": "urgent",
+                        # L133 — universal context on every exit, not
+                        # just edge cases. Closes home endnote bullet 3.
+                        "signal_context": {
+                            "research_score": urgent.get("research_score"),
+                            "research_rating": urgent.get("research_rating"),
+                            "research_conviction": urgent.get("research_conviction"),
+                            "sector": urgent.get("sector"),
+                            "sector_rating": urgent.get("sector_rating"),
+                            "market_regime": urgent.get("market_regime"),
+                            "predicted_direction": urgent.get("predicted_direction"),
+                            "prediction_confidence": urgent.get("prediction_confidence"),
+                        },
+                        # L133 — retry chain audit trail from
+                        # _place_order_with_retry. retry_count=0 +
+                        # single-entry attempts list = first-attempt
+                        # success.
+                        "retry_count": order_result.get("retry_count", 0),
+                        "attempts": order_result.get("attempts", []),
                     }),
                     "entry_trade_id": _entry_id,
                     "trigger_price": fill_price,
@@ -1072,6 +1114,24 @@ def _execute_exit(
             "exit_reason": exit_signal.get("reason"),
             "exit_detail": exit_signal.get("detail"),
             "source": "intraday_daemon",
+            # L133 — signal context at exit time + retry chain audit.
+            # ``exit_signal`` carries scores the intraday exit_manager
+            # used to decide (profit-take threshold, time-decay tier,
+            # ATR multiplier, etc.); pass through verbatim so trades.db
+            # records WHY this specific exit fired, not just THAT it did.
+            "signal_context": {
+                "research_score": exit_signal.get("research_score"),
+                "research_rating": exit_signal.get("research_rating"),
+                "research_conviction": exit_signal.get("research_conviction"),
+                "sector": exit_signal.get("sector"),
+                "sector_rating": exit_signal.get("sector_rating"),
+                "market_regime": exit_signal.get("market_regime"),
+                "predicted_direction": exit_signal.get("predicted_direction"),
+                "prediction_confidence": exit_signal.get("prediction_confidence"),
+                "exit_gate": exit_signal.get("gate"),  # e.g. "atr_trail", "time_decay", "profit_take"
+            },
+            "retry_count": order_result.get("retry_count", 0),
+            "attempts": order_result.get("attempts", []),
         }),
         "entry_trade_id": _entry_id,
         "trigger_price": current_price,
@@ -1205,6 +1265,25 @@ def _execute_entry(
             "planned_price": _signal_price,
             "sizing_factors": entry.get("sizing_factors"),
             "predicted_alpha": entry.get("predicted_alpha"),
+            # L133 — full signal context on every ENTER so the
+            # trade-by-trade audit log can answer "why did we enter
+            # AAPL today?" without joining with signals.json + the
+            # predictor archive at review time.
+            "signal_context": {
+                "research_score": entry.get("research_score"),
+                "research_rating": entry.get("research_rating"),
+                "research_conviction": entry.get("research_conviction"),
+                "sector": entry.get("sector"),
+                "sector_rating": entry.get("sector_rating"),
+                "market_regime": entry.get("market_regime"),
+                "price_target_upside": entry.get("price_target_upside"),
+                "predicted_direction": entry.get("predicted_direction"),
+                "prediction_confidence": entry.get("prediction_confidence"),
+                "position_pct": entry.get("position_pct"),
+            },
+            # L133 retry chain audit — see _place_order_with_retry docstring.
+            "retry_count": order_result.get("retry_count", 0),
+            "attempts": order_result.get("attempts", []),
         }),
         "execution_latency_ms": _latency_ms,
         "signal_price": _signal_price,

--- a/tests/test_daemon_phase0.py
+++ b/tests/test_daemon_phase0.py
@@ -371,3 +371,121 @@ class TestPhase0UrgentExitsActionLabel:
             "to have been refactored — re-audit the new call site for "
             "the L165 action-label correctness before merging."
         )
+
+
+# ── L133: retry-tracking audit trail on `_place_order_with_retry` ──────────
+
+
+class TestPlaceOrderWithRetryAttemptsAudit:
+    """Pin the L133 (2026-05-22) addition — `_place_order_with_retry` now
+    returns an `attempts` list + `retry_count` so callers can embed the
+    audit chain in trades.db `rationale_json`. Closes the home-endnote
+    gap PR #100 had to drop the "retry" qualifier from.
+    """
+
+    def test_first_attempt_success_yields_single_entry_zero_retries(self):
+        ibkr = MagicMock()
+        ibkr.place_market_order.return_value = {
+            "status": "Filled", "ib_order_id": 100,
+        }
+        result = _place_order_with_retry(ibkr, "AAPL", "SELL", 10, "exit")
+        assert result["retry_count"] == 0
+        assert len(result["attempts"]) == 1
+        first = result["attempts"][0]
+        assert first["attempt"] == 1
+        assert first["status"] == "Filled"
+        assert first["ib_order_id"] == 100
+        assert first["retry_reason"] is None  # first attempt — no prior to retry
+
+    @patch("executor.daemon._time.sleep")
+    def test_retry_count_and_reasons_captured_for_each_failed_attempt(self, mock_sleep):
+        ibkr = MagicMock()
+        ibkr.place_market_order.side_effect = [
+            {"status": "Timeout", "ib_order_id": 287},
+            {"status": "Rejected", "ib_order_id": 288},
+            {"status": "Filled", "ib_order_id": 289},
+        ]
+        result = _place_order_with_retry(ibkr, "PFE", "SELL", 77, "urgent")
+        assert result["status"] == "Filled"
+        assert result["retry_count"] == 2
+        assert len(result["attempts"]) == 3
+        assert result["attempts"][0]["status"] == "Timeout"
+        assert result["attempts"][0]["retry_reason"] is None
+        assert result["attempts"][1]["status"] == "Rejected"
+        assert result["attempts"][1]["retry_reason"] == "Timeout"  # why we retried
+        assert result["attempts"][2]["status"] == "Filled"
+        assert result["attempts"][2]["retry_reason"] == "Rejected"
+
+    @patch("executor.daemon._time.sleep")
+    def test_all_retries_failed_still_records_full_audit(self, mock_sleep):
+        ibkr = MagicMock()
+        ibkr.place_market_order.return_value = {
+            "status": "Rejected", "ib_order_id": 300,
+        }
+        result = _place_order_with_retry(ibkr, "AAPL", "SELL", 10, "exit")
+        # MAX_ORDER_RETRIES attempts; all failed; result still carries
+        # the full audit trail so trades.db rationale_json captures
+        # "we tried 3 times and IB rejected every one."
+        assert result["status"] == "Rejected"
+        assert result["retry_count"] == MAX_ORDER_RETRIES - 1
+        assert len(result["attempts"]) == MAX_ORDER_RETRIES
+        for entry in result["attempts"]:
+            assert entry["status"] == "Rejected"
+
+    @patch("executor.daemon._time.sleep")
+    def test_working_status_records_single_attempt_no_retry(self, mock_sleep):
+        """Working status holds — we DON'T retry (PFE incident protection).
+        Audit trail captures the single Working attempt.
+        """
+        ibkr = MagicMock()
+        ibkr.place_market_order.return_value = {
+            "status": "Working", "ib_order_id": 400,
+        }
+        result = _place_order_with_retry(ibkr, "AAPL", "SELL", 10, "urgent")
+        assert result["status"] == "Working"
+        assert result["retry_count"] == 0
+        assert len(result["attempts"]) == 1
+        assert result["attempts"][0]["status"] == "Working"
+
+
+class TestRationaleJsonEnrichmentSourceShape:
+    """Source-inspection pin on the L133 enrichment of the 3 daemon
+    log_trade call sites' rationale_json. Each site MUST include the
+    signal_context block + the retry audit. Full-loop tests require IB
+    Gateway harness; this pin guards against a future refactor that
+    drops the enrichment.
+    """
+
+    def test_urgent_exit_rationale_carries_signal_context_and_retry_audit(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # The Phase 0 urgent-exits log_trade call.
+        assert '"phase": "urgent"' in src, "Phase-0 urgent-exit rationale shape changed"
+        # signal_context block on the urgent path.
+        assert '"signal_context"' in src, (
+            "L133 enrichment dropped — log_trade rationale_json must "
+            "carry a signal_context block on every trade pathway."
+        )
+        # retry audit on every log_trade rationale.
+        assert '"retry_count":' in src and '"attempts":' in src, (
+            "L133 retry audit dropped — log_trade rationale_json must "
+            "carry retry_count + attempts on every trade pathway."
+        )
+
+    def test_enter_rationale_carries_signal_context_and_retry_audit(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # The intraday ENTER log_trade call (PFE incident-class fields:
+        # trigger_reason + sizing_factors + predicted_alpha must remain).
+        assert '"trigger_reason":' in src
+        assert '"sizing_factors":' in src
+        # Pin: the rationale must reference position_pct inside the
+        # signal_context block (not just at the trade dict's top level).
+        assert '"position_pct":' in src, (
+            "L133 ENTER rationale must include position_pct in "
+            "signal_context so the audit log captures the sizing math."
+        )


### PR DESCRIPTION
## Summary

Closes the part of **ROADMAP L133 P2** that doesn't require a schema migration. Picks **Option B** from the L133 entry — "enriched JSONL on the existing schema" — so trades.db carries the retry chain + full signal context without a new column / sibling table.

## Changes

### 1. \`_place_order_with_retry\` returns audit trail

The retry loop now builds \`attempts: list[dict]\` with one record per IB call (\`attempt\`, \`status\`, \`ib_order_id\`, \`retry_reason\`) and embeds it on the returned dict along with \`retry_count\`.

- **Single-attempt success:** \`retry_count=0\`, single-entry attempts list, \`retry_reason=None\`.
- **Multi-attempt (e.g. Timeout → Rejected → Filled):** 3 entries, each carrying the IB status that produced it + the \`retry_reason\` for why we retried into it.

### 2. Universal \`rationale_json\` enrichment on all 3 daemon log_trade sites

Every log_trade call now carries:

- **\`signal_context\` block** — research_score, research_rating, research_conviction, sector, sector_rating, market_regime, predicted_direction, prediction_confidence, plus path-specific fields (position_pct on ENTER, exit_gate on intraday EXIT).
- **\`retry_count\` + \`attempts\`** — verbatim from \`_place_order_with_retry\`'s result.

## Closes the home-endnote gap

PR #100 (L127) had to drop the "retry" qualifier from *"every order, fill, retry, and exit decision recorded with rationale."* That qualifier is now defensible — every trade carries the full decision chain in \`rationale_json\`.

## Test plan

- [x] Suite: **939 → 945**.
- 4 new \`TestPlaceOrderWithRetryAttemptsAudit\` tests pin the attempt-list shape (single-success / multi-retry / all-failed / Working-no-retry).
- 2 new \`TestRationaleJsonEnrichmentSourceShape\` tests pin the daemon source-level rationale_json structure (full-loop testing requires IB Gateway mock harness — source inspection mirrors the L165/L171 pattern from PR #203).

## Scope NOT taken

The L133 (a) alternative path (add \`retry_count\` int column + sibling \`retry_log\` table) is deliberately NOT taken. Option B (JSONL on existing schema) is sufficient for the endnote claim and avoids a schema migration with backfill. trades.db consumers that need queryable retry counts can read the new field from the rationale_json JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)