### PR TITLE
feat(daemon): intraday decision capture for replay parity substrate (L139a)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -50,6 +50,7 @@ from executor.intraday_snapshot import (
     IntradaySnapshotWriter,
     compute_surveillance_universe,
 )
+from executor.daemon_state_logger import get_logger as _get_decision_logger
 from executor.market_hours import is_market_hours
 from executor.notifier import send_daemon_status, send_trade_alert
 from executor.order_book import OrderBook
@@ -737,6 +738,39 @@ def run_daemon(dry_run: bool = False) -> None:
                     source="daemon",
                 )
 
+                # L139(a) — daemon-stage intraday replay capture. The
+                # urgent_exits loop is the morning-planner-to-daemon
+                # handoff; recording it here gives the backtester an
+                # entry point into the intraday decision stream for
+                # eventual gate-enforcement (L139b).
+                _get_decision_logger().record(
+                    decision_type=(
+                        "phase0_auto_cover" if action == "COVER"
+                        else "urgent_exit"
+                    ),
+                    ticker=ticker,
+                    action=action,
+                    trading_day=run_date,
+                    shares=shares,
+                    trigger_reason=reason,
+                    fill_price=fill_price,
+                    ib_order_id=order_result.get("ib_order_id"),
+                    status=order_result.get("status"),
+                    retry_count=order_result.get("retry_count", 0),
+                    attempts=order_result.get("attempts", []),
+                    context={
+                        "exit_detail": urgent.get("detail", ""),
+                        "research_score": urgent.get("research_score"),
+                        "research_conviction": urgent.get("research_conviction"),
+                        "research_rating": urgent.get("research_rating"),
+                        "sector": urgent.get("sector"),
+                        "sector_rating": urgent.get("sector_rating"),
+                        "market_regime": urgent.get("market_regime"),
+                        "predicted_direction": urgent.get("predicted_direction"),
+                        "prediction_confidence": urgent.get("prediction_confidence"),
+                    },
+                )
+
                 trades_executed += 1
                 # COVER trades shouldn't prevent new ENTER for the same ticker
                 if action != "COVER":
@@ -919,6 +953,19 @@ def run_daemon(dry_run: bool = False) -> None:
         send_daemon_status("\u274c *Daemon crashed* — check logs")
         raise
     finally:
+        # ── L139(a) — flush intraday decision capture for replay parity ──
+        # Best-effort; flush failures WARN-log only (the primary trade
+        # path already completed via log_trade / send_trade_alert).
+        # Append semantics handle fix-and-rerun cycles within a single
+        # trading_day.
+        try:
+            _get_decision_logger().flush_to_s3(
+                bucket=config.get("signals_bucket", "alpha-engine-research"),
+                trading_day=run_date,
+            )
+        except Exception:
+            logger.debug("daemon_state flush failed", exc_info=True)
+
         # ── Data manifest ──────────────────────────────────────────────────
         try:
             from executor.health_status import write_data_manifest
@@ -1168,6 +1215,39 @@ def _execute_exit(
         source="daemon",
     )
 
+    # L139(a) — intraday exit decision capture for replay parity.
+    _get_decision_logger().record(
+        decision_type="intraday_exit",
+        ticker=ticker,
+        action=action,
+        trading_day=run_date,
+        shares=shares,
+        trigger_reason=exit_signal.get("reason", ""),
+        trigger_price=current_price,
+        fill_price=fill_price,
+        ib_order_id=order_result.get("ib_order_id"),
+        status=order_result.get("status"),
+        retry_count=order_result.get("retry_count", 0),
+        attempts=order_result.get("attempts", []),
+        entry_trade_id=_entry_id,
+        spy_price_at_order=_spy_now,
+        context={
+            "exit_detail": exit_signal.get("detail"),
+            "exit_gate": exit_signal.get("gate"),
+            "research_score": exit_signal.get("research_score"),
+            "research_conviction": exit_signal.get("research_conviction"),
+            "sector": exit_signal.get("sector"),
+            "market_regime": exit_signal.get("market_regime"),
+            "predicted_direction": exit_signal.get("predicted_direction"),
+            "prediction_confidence": exit_signal.get("prediction_confidence"),
+            "realized_pnl": _rpnl,
+            "realized_return_pct": _rpct,
+            "spy_return_during_hold": _spy_ret,
+            "realized_alpha_pct": _ralpha,
+            "days_held": _dheld,
+        },
+    )
+
 
 def _execute_entry(
     ibkr: IBKRClient,
@@ -1398,6 +1478,38 @@ def _execute_entry(
         price=fill_price,
         trigger=trigger_reason,
         source="daemon",
+    )
+
+    # L139(a) — entry trigger decision capture for replay parity.
+    _get_decision_logger().record(
+        decision_type="entry_trigger",
+        ticker=ticker,
+        action="ENTER",
+        trading_day=run_date,
+        shares=shares,
+        trigger_reason=trigger_reason,
+        signal_price=_signal_price,
+        trigger_price=_trigger_price,
+        fill_price=fill_price,
+        ib_order_id=order_result.get("ib_order_id"),
+        status=order_result.get("status"),
+        retry_count=order_result.get("retry_count", 0),
+        attempts=order_result.get("attempts", []),
+        execution_latency_ms=_latency_ms,
+        spy_price_at_order=_spy_now,
+        context={
+            "predicted_alpha": entry.get("predicted_alpha"),
+            "research_score": entry.get("research_score"),
+            "research_conviction": entry.get("research_conviction"),
+            "research_rating": entry.get("research_rating"),
+            "sector": entry.get("sector"),
+            "sector_rating": entry.get("sector_rating"),
+            "market_regime": entry.get("market_regime"),
+            "predicted_direction": entry.get("predicted_direction"),
+            "prediction_confidence": entry.get("prediction_confidence"),
+            "position_pct": entry.get("position_pct"),
+            "sizing_factors": entry.get("sizing_factors"),
+        },
     )
 
 

--- a/executor/daemon_state_logger.py
+++ b/executor/daemon_state_logger.py
@@ -1,0 +1,209 @@
+"""
+Daemon decision-state capture for intraday replay parity (ROADMAP L139a).
+
+The morning-planner stage already replays cleanly through
+``alpha-engine-backtester/tests/test_parity_replay.py`` — but the
+backtester has no visibility into intraday daemon decisions (urgent
+exits, intraday trigger fires, ATR-trail exits, profit-take REDUCEs,
+time-decay exits, COVER fills). The test_parity_replay docstring
+explicitly carves these out:
+
+  "Backtester sim runs the morning planner only — none of these exist
+   at planner stage, so they're null in replay output. Including them
+   as required-match fields produced spurious divergence on every
+   cohort-matched ENTER (observed 2026-04-26 ROST 4/12 trade). Phase 2
+   (entry_triggers.py daily-bar port) will eventually populate them in
+   sim, but until then they're a pure noise floor."
+
+This module is the substrate that closes that gap. Every intraday
+decision point in ``executor/daemon.py`` calls ``record_decision()`` with
+the live state at the time of the call; on daemon shutdown,
+``flush_to_s3()`` writes the buffered events to
+``s3://{bucket}/daemon_state/{trading_day}/intraday_decisions.jsonl``.
+
+Backtester consumer (L139b, separate PR) reads that artifact, replays
+the intraday decision rules deterministically, and the parity gate
+turns from "PARITY IS OBSERVABILITY NOT A GATE" into a real gate at
+predictor weight promotion. Until L139b lands, this artifact is
+observability-only.
+
+Schema — one JSON object per line:
+
+    {
+        "timestamp_utc": "2026-05-22T15:42:01.123456Z",
+        "trading_day": "2026-05-22",
+        "decision_type": "urgent_exit" | "intraday_exit" | "entry_trigger"
+                         | "cover" | "phase0_auto_cover",
+        "ticker": "AAPL",
+        "action": "EXIT" | "REDUCE" | "ENTER" | "COVER",
+        "shares": 100,
+        "trigger_reason": "atr_trail" | "vwap_pullback" | "research_signal"
+                          | "time_decay" | "profit_take" | ...,
+        "trigger_price": 150.0,
+        "signal_price": 149.50,    # daemon's snapshot at decision time
+        "fill_price": 150.25,      # IB fill (None if order failed)
+        "ib_order_id": 287,
+        "retry_count": 0,
+        "attempts": [...],         # from _place_order_with_retry (L133)
+        "context": {...},          # decision-type-specific extras
+    }
+
+The artifact is **append-only per trading day** — each daemon run
+on a given trading_day appends to the existing JSONL via S3 read +
+re-upload. The 2026-05-22 EOD-SF can re-trigger the daemon mid-day for
+fix-and-rerun cycles; we want every decision recorded, not just the
+last invocation's.
+
+Best-effort observability — recording or flushing failures DO NOT
+block the daemon's primary order-execution path (`[[feedback_no_silent_fails]]`
+secondary-observability clause). WARN logs surface the failure;
+the loss is one cycle of replay coverage, not a stuck order.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_JSONL_PREFIX = "daemon_state"
+_JSONL_FILENAME = "intraday_decisions.jsonl"
+
+
+class DaemonDecisionLogger:
+    """In-memory buffer of intraday decisions, flushed to S3 on shutdown.
+
+    Thread-safe — the daemon's monitor + main loop both call into
+    decision recording paths. Append-only buffer; no eviction.
+
+    Singleton-ish — `get_logger()` returns the module-level instance.
+    Tests construct their own instances via the class constructor to
+    avoid leaking buffer state across runs.
+    """
+
+    def __init__(self) -> None:
+        self._buffer: list[dict] = []
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        *,
+        decision_type: str,
+        ticker: str,
+        action: str | None,
+        trading_day: str,
+        **context: Any,
+    ) -> None:
+        """Record one decision. Never raises — record failures swallow.
+
+        Required positional-keyword args lock down the schema's
+        required fields; ``**context`` admits decision-type-specific
+        extras (e.g. ``trigger_reason``, ``fill_price``, ``attempts``).
+        """
+        try:
+            entry = {
+                "timestamp_utc": datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"),
+                "trading_day": trading_day,
+                "decision_type": decision_type,
+                "ticker": ticker,
+                "action": action,
+                **context,
+            }
+            with self._lock:
+                self._buffer.append(entry)
+        except Exception as exc:  # noqa: BLE001 — secondary observability; primary path unaffected
+            logger.warning(
+                "DaemonDecisionLogger.record swallowed exception (decision_type=%s, ticker=%s): %s",
+                decision_type, ticker, exc,
+            )
+
+    def snapshot(self) -> list[dict]:
+        """Return a defensive copy of the current buffer."""
+        with self._lock:
+            return list(self._buffer)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._buffer)
+
+    def flush_to_s3(self, bucket: str, trading_day: str, s3_client=None) -> bool:
+        """Write the buffered decisions to S3 as JSONL. Append semantics
+        per the module docstring — fix-and-rerun cycles within a single
+        trading_day must preserve prior captures rather than overwriting.
+
+        Returns True on successful write (or no-op on empty buffer);
+        False on any failure. Never raises — secondary observability.
+        """
+        with self._lock:
+            entries = list(self._buffer)
+        if not entries:
+            return True
+        try:
+            import boto3
+            s3 = s3_client or boto3.client("s3")
+            key = f"{_JSONL_PREFIX}/{trading_day}/{_JSONL_FILENAME}"
+
+            # Append semantics: read prior JSONL (or empty on miss),
+            # concat new entries, re-upload. Prior decisions land first
+            # in line order. For huge runs we could switch to multipart
+            # append via S3 ListObjects + sequential parts, but a typical
+            # daemon run is <100 decisions so single-blob is fine.
+            existing_body = b""
+            try:
+                obj = s3.get_object(Bucket=bucket, Key=key)
+                existing_body = obj["Body"].read()
+            except Exception:  # noqa: BLE001 — NoSuchKey or other; treat as first write
+                existing_body = b""
+
+            new_body = b"".join(
+                (json.dumps(e, default=str) + "\n").encode("utf-8") for e in entries
+            )
+            combined = existing_body + new_body
+
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=combined,
+                ContentType="application/x-ndjson",
+            )
+            logger.info(
+                "daemon_state: flushed %d intraday decisions to s3://%s/%s "
+                "(combined size %d bytes)",
+                len(entries), bucket, key, len(combined),
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001 — secondary observability
+            logger.warning(
+                "daemon_state: flush_to_s3 failed (trading_day=%s, n=%d): %s — "
+                "intraday replay coverage lost for this cycle, but primary "
+                "order-execution path unaffected",
+                trading_day, len(entries), exc,
+            )
+            return False
+
+
+_singleton: DaemonDecisionLogger | None = None
+_singleton_lock = threading.Lock()
+
+
+def get_logger() -> DaemonDecisionLogger:
+    """Return the module-level singleton logger.
+
+    Tests should NOT use this — they construct their own instance via
+    ``DaemonDecisionLogger()`` to keep buffers isolated.
+    """
+    global _singleton
+    with _singleton_lock:
+        if _singleton is None:
+            _singleton = DaemonDecisionLogger()
+        return _singleton
+
+
+def reset_singleton_for_tests() -> None:
+    """Reset the module singleton. Test-only — never call in production."""
+    global _singleton
+    with _singleton_lock:
+        _singleton = None

--- a/tests/test_daemon_state_logger.py
+++ b/tests/test_daemon_state_logger.py
@@ -1,0 +1,305 @@
+"""Tests for ``executor/daemon_state_logger.py`` (ROADMAP L139a substrate)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from executor.daemon_state_logger import (
+    DaemonDecisionLogger,
+    get_logger,
+    reset_singleton_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_singleton():
+    """Each test gets a fresh module-level singleton."""
+    reset_singleton_for_tests()
+    yield
+    reset_singleton_for_tests()
+
+
+# ── record() ──────────────────────────────────────────────────────────────
+
+
+class TestRecord:
+    def test_empty_buffer_initially(self):
+        log = DaemonDecisionLogger()
+        assert len(log) == 0
+        assert log.snapshot() == []
+
+    def test_record_appends_entry_with_required_fields(self):
+        log = DaemonDecisionLogger()
+        log.record(
+            decision_type="intraday_exit",
+            ticker="AAPL",
+            action="EXIT",
+            trading_day="2026-05-22",
+            shares=100,
+            fill_price=150.25,
+        )
+        assert len(log) == 1
+        entry = log.snapshot()[0]
+        assert entry["decision_type"] == "intraday_exit"
+        assert entry["ticker"] == "AAPL"
+        assert entry["action"] == "EXIT"
+        assert entry["trading_day"] == "2026-05-22"
+        assert entry["shares"] == 100
+        assert entry["fill_price"] == 150.25
+        # Auto-stamped timestamp
+        assert "timestamp_utc" in entry
+        assert entry["timestamp_utc"].endswith("Z")
+
+    def test_record_admits_arbitrary_context_kwargs(self):
+        """**context fan-out — decision-type-specific extras land in
+        the entry without schema-level pre-declaration."""
+        log = DaemonDecisionLogger()
+        log.record(
+            decision_type="urgent_exit",
+            ticker="PFE",
+            action="REDUCE",
+            trading_day="2026-05-22",
+            trigger_reason="research_signal",
+            retry_count=2,
+            attempts=[{"attempt": 1, "status": "Timeout"}],
+            context={"research_score": 72.0, "sector": "Healthcare"},
+        )
+        entry = log.snapshot()[0]
+        assert entry["trigger_reason"] == "research_signal"
+        assert entry["retry_count"] == 2
+        assert entry["attempts"] == [{"attempt": 1, "status": "Timeout"}]
+        assert entry["context"]["research_score"] == 72.0
+
+    def test_record_never_raises_on_bad_input(self):
+        """Secondary observability — record() must never block the
+        daemon's primary order-execution path on schema mishaps.
+        """
+        log = DaemonDecisionLogger()
+        # decision_type passed as a non-serializable object — record
+        # swallows the exception and the buffer remains empty (or
+        # whatever fallback the implementation chose).
+        class _Unserializable:
+            def __repr__(self):
+                raise RuntimeError("kaboom")
+
+        # Passing should not raise even with a weird value.
+        try:
+            log.record(
+                decision_type="intraday_exit",
+                ticker="AAPL",
+                action="EXIT",
+                trading_day="2026-05-22",
+                weird_field=_Unserializable(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"record() should swallow exceptions, raised: {exc}")
+
+
+# ── thread-safety ─────────────────────────────────────────────────────────
+
+
+class TestThreadSafety:
+    def test_concurrent_records_do_not_lose_entries(self):
+        """Daemon has multiple call paths (Phase-0 sync, intraday
+        monitor, entry-trigger callbacks). Lock-protected buffer
+        guarantees no entries are dropped under concurrent record().
+        """
+        import threading
+
+        log = DaemonDecisionLogger()
+        n_threads = 8
+        n_per = 50
+
+        def _runner():
+            for i in range(n_per):
+                log.record(
+                    decision_type="intraday_exit",
+                    ticker=f"T{i}",
+                    action="EXIT",
+                    trading_day="2026-05-22",
+                    shares=i,
+                )
+
+        threads = [threading.Thread(target=_runner) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert len(log) == n_threads * n_per
+
+
+# ── flush_to_s3() ─────────────────────────────────────────────────────────
+
+
+class TestFlushToS3:
+    def _stub_s3_get_404(self, client):
+        """Default: simulate first-write (NoSuchKey) by raising."""
+        client.get_object.side_effect = Exception("NoSuchKey")
+
+    def test_empty_buffer_is_no_op_returns_true(self):
+        log = DaemonDecisionLogger()
+        client = MagicMock()
+        assert log.flush_to_s3("bucket", "2026-05-22", s3_client=client) is True
+        client.put_object.assert_not_called()
+        client.get_object.assert_not_called()
+
+    def test_first_write_uploads_jsonl_to_canonical_key(self):
+        log = DaemonDecisionLogger()
+        log.record(
+            decision_type="intraday_exit",
+            ticker="AAPL",
+            action="EXIT",
+            trading_day="2026-05-22",
+            shares=100,
+        )
+        client = MagicMock()
+        self._stub_s3_get_404(client)
+        ok = log.flush_to_s3("alpha-engine-research", "2026-05-22", s3_client=client)
+        assert ok is True
+
+        client.put_object.assert_called_once()
+        call_kwargs = client.put_object.call_args.kwargs
+        assert call_kwargs["Bucket"] == "alpha-engine-research"
+        assert call_kwargs["Key"] == "daemon_state/2026-05-22/intraday_decisions.jsonl"
+        assert call_kwargs["ContentType"] == "application/x-ndjson"
+
+        # Body is JSONL — each non-empty line parses to the same dict
+        body = call_kwargs["Body"]
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        lines = [json.loads(ln) for ln in body.strip().split("\n") if ln]
+        assert len(lines) == 1
+        assert lines[0]["ticker"] == "AAPL"
+        assert lines[0]["action"] == "EXIT"
+
+    def test_append_preserves_prior_jsonl(self):
+        """fix-and-rerun on the same trading_day must append, not
+        overwrite. Tests this by stubbing get_object to return existing
+        JSONL and verifying the put_object body carries both.
+        """
+        log = DaemonDecisionLogger()
+        log.record(
+            decision_type="entry_trigger",
+            ticker="NVDA",
+            action="ENTER",
+            trading_day="2026-05-22",
+            shares=50,
+        )
+        client = MagicMock()
+        prior_jsonl = (
+            json.dumps({
+                "timestamp_utc": "2026-05-22T13:00:00Z",
+                "trading_day": "2026-05-22",
+                "decision_type": "intraday_exit",
+                "ticker": "AAPL",
+                "action": "EXIT",
+            }) + "\n"
+        ).encode("utf-8")
+        client.get_object.return_value = {
+            "Body": MagicMock(read=lambda: prior_jsonl)
+        }
+        ok = log.flush_to_s3("bucket", "2026-05-22", s3_client=client)
+        assert ok is True
+
+        call_kwargs = client.put_object.call_args.kwargs
+        body = call_kwargs["Body"]
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        lines = [json.loads(ln) for ln in body.strip().split("\n") if ln]
+        assert len(lines) == 2
+        # Prior entry first, new entry second
+        assert lines[0]["ticker"] == "AAPL"
+        assert lines[1]["ticker"] == "NVDA"
+
+    def test_flush_failure_returns_false_does_not_raise(self):
+        """S3 outage must not crash the daemon's finally block."""
+        log = DaemonDecisionLogger()
+        log.record(
+            decision_type="intraday_exit",
+            ticker="AAPL",
+            action="EXIT",
+            trading_day="2026-05-22",
+            shares=100,
+        )
+        client = MagicMock()
+        client.put_object.side_effect = RuntimeError("S3 down")
+        ok = log.flush_to_s3("bucket", "2026-05-22", s3_client=client)
+        assert ok is False  # signaled the failure, didn't raise
+
+
+# ── module-level singleton ────────────────────────────────────────────────
+
+
+class TestSingleton:
+    def test_get_logger_returns_same_instance(self):
+        a = get_logger()
+        b = get_logger()
+        assert a is b
+
+    def test_reset_clears_singleton(self):
+        a = get_logger()
+        reset_singleton_for_tests()
+        b = get_logger()
+        assert a is not b
+
+
+# ── source-inspection pins on daemon.py call sites ────────────────────────
+
+
+class TestDaemonCallSites:
+    """Pin that each of the 3 daemon decision call sites records to the
+    decision logger. Mirrors the L165 / L171 / L133 source-inspection
+    pattern — full-loop tests require IB Gateway mock harness; source
+    inspection guards against a future refactor dropping the record()
+    call.
+    """
+
+    def test_daemon_records_urgent_exits(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # Phase 0 urgent-exits loop calls record(decision_type="urgent_exit"
+        # or "phase0_auto_cover" for COVER). Both spellings must be live.
+        assert '"urgent_exit"' in src and '"phase0_auto_cover"' in src, (
+            "L139a Phase-0 urgent-exits capture dropped — both regular "
+            "urgent_exit + auto-cover variants must record."
+        )
+
+    def test_daemon_records_intraday_exits(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # _execute_exit must record decision_type="intraday_exit" so
+        # ATR-trail / time-decay / profit-take exits land in the
+        # replay artifact.
+        assert '"intraday_exit"' in src, (
+            "L139a intraday-exit capture dropped — backtester replay "
+            "loses visibility into ATR/time-decay/profit-take exits."
+        )
+
+    def test_daemon_records_entry_triggers(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        # _execute_entry must record decision_type="entry_trigger" so
+        # VWAP/pullback/support/time-expiry ENTERs land in replay.
+        assert '"entry_trigger"' in src, (
+            "L139a entry-trigger capture dropped — backtester replay "
+            "loses visibility into intraday ENTER decisions."
+        )
+
+    def test_daemon_finally_flushes_to_s3(self):
+        import inspect
+        import executor.daemon as daemon
+
+        src = inspect.getsource(daemon)
+        assert "flush_to_s3" in src, (
+            "L139a daemon shutdown flush dropped — captured decisions "
+            "would stay in-memory and be lost on daemon exit."
+        )


### PR DESCRIPTION
## Summary

**Closes ROADMAP L139 part (a).** Part (b) — promote-gate enforcement turning the parity diff into a hard gate at predictor weight promotion — is deferred per the L139 entry's explicit split suggestion (needs operator policy decision on the divergence-tolerance bar before scoping).

## Why

The morning-planner stage already replays cleanly through \`alpha-engine-backtester/tests/test_parity_replay.py\`. The backtester has **zero visibility into intraday daemon decisions** (urgent exits, intraday trigger fires, ATR-trail exits, profit-take REDUCEs, time-decay exits, COVER fills). test_parity_replay excludes \`trigger_type\` / \`trigger_price\` / \`signal_price\` / \`fill_price\` from its comparison precisely because the backtester only replays morning planner.

This PR ships the **capture substrate** that closes that gap. The backtester consumer + promote-gate enforcement come in L139b.

## New module: `executor/daemon_state_logger.py`

- \`DaemonDecisionLogger\` — thread-safe in-memory buffer, schema-enforced required fields + \`**context\` fan-out for decision-type-specific extras.
- \`record()\` never raises (secondary observability per CLAUDE.md fail-loud rule's clause (i)).
- \`flush_to_s3()\` writes \`daemon_state/{trading_day}/intraday_decisions.jsonl\` with **append semantics** (fix-and-rerun cycles preserve prior captures).
- Module-level singleton via \`get_logger()\`; tests isolate via \`reset_singleton_for_tests()\`.

Schema (one JSON object per line):
\`timestamp_utc / trading_day / decision_type / ticker / action / shares / trigger_reason / trigger_price / signal_price / fill_price / ib_order_id / retry_count / attempts / context\`

## Daemon wiring (executor/daemon.py)

Three call sites added (mirrors the existing 3 \`log_trade\` sites + the L165 / L171 / L133 enrichments from PRs #203 / #204):

- **Phase 0 urgent-exits** — records \`urgent_exit\` (or \`phase0_auto_cover\` for short auto-cover).
- **Intraday \`_execute_exit\`** — records \`intraday_exit\` with \`exit_gate\` (atr_trail / time_decay / profit_take), realized pnl/return/alpha, days held.
- **Intraday \`_execute_entry\`** — records \`entry_trigger\` with sizing factors, predicted_alpha, full signal_context.

Shutdown flush in the daemon \`finally:\` block, ahead of the existing data-manifest write. Best-effort — flush failures WARN-log only.

## Tests

15 new in \`tests/test_daemon_state_logger.py\`:
- \`TestRecord\` (4): empty / required-fields / context-fan-out / never-raises.
- \`TestThreadSafety\` (1): 8 threads × 50 records = 400 retained.
- \`TestFlushToS3\` (4): empty no-op / first-write canonical key / append-preserves-prior / failure-returns-false.
- \`TestSingleton\` (2): same instance / reset clears.
- \`TestDaemonCallSites\` (4): source-inspection pins on the 4 daemon integration points.

Suite: **945 → 960**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)