### PR TITLE
feat(iam): grant dashboard EC2 SFN read for pipeline_status page 25

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-dashboard-sfn-read.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-dashboard-sfn-read.json
@@ -1,0 +1,22 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "PipelineStatusPageRead",
+            "Effect": "Allow",
+            "Action": [
+                "states:DescribeExecution",
+                "states:GetExecutionHistory",
+                "states:ListExecutions"
+            ],
+            "Resource": [
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-saturday-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-weekday-pipeline",
+                "arn:aws:states:us-east-1:711398986525:stateMachine:alpha-engine-eod-pipeline",
+                "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-saturday-pipeline:*",
+                "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-weekday-pipeline:*",
+                "arn:aws:states:us-east-1:711398986525:execution:alpha-engine-eod-pipeline:*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- New inline policy `alpha-engine-dashboard-sfn-read` on `alpha-engine-executor-role`: `states:DescribeExecution` + `states:GetExecutionHistory` + `states:ListExecutions` scoped to the 3 SF ARNs + their execution prefixes
- Applied live to AWS via `apply.sh`; drift check clean
- Substrate for the dashboard `pages/25_Pipeline_Status.py` (alpha-engine-dashboard PR follow-up) — consumer of `alpha_engine_lib.pipeline_status.read_pipeline_state` (lib v0.28.0)

## Context

Phase 2 substrate of the pipeline-reporting-revamp arc (ROADMAP L3050, plan doc `~/Development/alpha-engine-docs/private/pipeline-reporting-revamp-260524.md` §3.6). Phase 1 (lib v0.28.0 — `alpha-engine-lib` PR #60) merged 2026-05-24 15:37 UTC.

**Phase 0 Q1 resolution:** the dashboard EC2 (`i-09b539c844515d549`) shares the `alpha-engine-executor-profile` instance profile with the executor trading instance. Verified via `aws ec2 describe-instances --instance-ids i-09b539c844515d549` + `aws iam get-instance-profile --instance-profile-name alpha-engine-executor-profile`. The Explore agent's uncertainty about the role identity (flagged in the plan doc §6.1 Q1) was resolved against the live IAM API — same role, same codification path, fewer moving parts than originally feared.

Least-privilege scope: no `states:StartExecution`, no `states:Update*`, no wildcard resource. Read-only on the 3 SFs the dashboard renders.

## Test plan

- [x] `apply.sh --role alpha-engine-executor-role --policy alpha-engine-dashboard-sfn-read` succeeded
- [x] `aws iam get-role-policy --role-name alpha-engine-executor-role --policy-name alpha-engine-dashboard-sfn-read` returns the expected 3-action list
- [x] `check-drift.py` clean post-apply
- [ ] Page 25 (alpha-engine-dashboard PR, follow-up) successfully calls `read_pipeline_state` against all 3 ARNs on first render

## Composes with

- `alpha-engine-lib` #60 (v0.28.0 — `pipeline_status` lib substrate, MERGED 2026-05-24 15:37Z)
- `alpha-engine` #190 (precedent: SSM IAM codification + `apply.sh` pattern)
- `feedback_no_silent_fails` (typed `SFNAccessDenied` from the lib relies on these grants being present at runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)