### PR TITLE
deps(lib): bump alpha-engine-lib v0.21.0 → v0.31.0 (cost-telemetry Phase 0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,16 @@ requests~=2.32
 # setup_logging()/_attach_flow_doctor() before flow_doctor.init() reads
 # os.environ — closes the PR 9g systemd-entrypoint env gap upstream for
 # all repos (replaces the executor-local secrets_bootstrap.py approach).
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.21.0
+# v0.30.0 + v0.31.0 add the cost-telemetry SDK adapter
+# (``metadata_from_anthropic_message``) + server-tool fee tracking
+# (``ToolFee`` / ``ToolFeeTable``) — required by Phase 0 of the cost-
+# optimization workstream to wire ``eod_reconcile.py``'s position-
+# narrative LLM calls into the cost-telemetry stream. Predates ``cost.py``
+# entirely (added at v0.22+); 10-version bump validated by smoke-test of
+# all existing imports (secrets/dates/logging/eval_artifacts/alerts/
+# universe/telegram/decision_capture/preflight/trading_calendar) on
+# 2026-05-25 — all additive, no breaking changes to existing surface.
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ requests~=2.32
 # all existing imports (secrets/dates/logging/eval_artifacts/alerts/
 # universe/telegram/decision_capture/preflight/trading_calendar) on
 # 2026-05-25 — all additive, no breaking changes to existing surface.
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.31.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
## Summary

10-version lib bump unlocking the cost-telemetry SDK adapter (v0.30.0) and server-tool fee tracking (v0.31.0). Predates `cost.py` entirely (added at v0.22+).

Required by Phase 0 of the cost-optimization workstream — the executor's `eod_reconcile.py:314` position-narrative LLM call currently fires daily on weekdays with **zero cost-telemetry attribution** (raw `anthropic.Anthropic()` SDK; runs outside the research Lambda; ~$10–30/mo estimated invisible spend).

## What's new in v0.22 → v0.31

All additive — no breaking changes to the surface executor consumes:
- v0.22.0 / v0.23.0: pillars (not used here)
- v0.24.0: `alerts.dedup_key` / `dedup_window_min` (additive; executor uses `alerts` but doesn't need the new params)
- v0.25.0: `ssm_log_capture` (not used here)
- v0.26.0: `ec2_spot` (not used here)
- v0.27.0: `dates` trading-day-aware freshness (executor uses `dates.now_dual` / `session_for_timestamp`; verified backwards-compat)
- v0.28.0+: `pipeline_status` (not used here)
- v0.29.0: `logging.SecretsRedactingFilter` auto-attached to `setup_logging` — additive
- **v0.30.0: `cost.metadata_from_anthropic_message`** — raw-SDK adapter that the EOD position-narrative call needs
- **v0.31.0: `cost.ToolFee` + `ToolFeeTable`** — Anthropic server-tool fees (web_search, web_fetch)

## Test plan

- [x] All 10 existing import sites (secrets/dates/logging/eval_artifacts/alerts/universe/telegram/decision_capture/preflight/trading_calendar) resolve at v0.31.0
- [x] Full test suite: 962 tests passed
- [x] New `cost.*` imports available (verified)
- [ ] Follow-up PR on this branch (or successor): wire `eod_reconcile.py:314` LLM call into cost-telemetry stream using `metadata_from_anthropic_message`. Separate S3 cost sink at `decision_artifacts/_cost_raw_executor/{date}/` since executor runs outside research Lambda.

## Workstream context

Investigation doc: `~/Development/alpha-engine-docs/private/prompt-caching-investigation-260525.md`. Phase 0 (telemetry coverage) is the precondition for all subsequent cost-optimization work — currently 87% of system Anthropic spend is invisible to cost_tracker, and this is one of 4 untracked sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)