### PR TITLE
feat(cost-telemetry): wire EOD narrative + lib v0.32→v0.33 (Phase 0.2)

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -296,7 +296,77 @@ _RATIONALES_TOOL = {
 }
 
 
-def _synthesize_rationales(contexts: list[dict]) -> dict[str, str]:
+_COST_TELEMETRY_BUCKET = "alpha-engine-research"
+_COST_TELEMETRY_PREFIX = "decision_artifacts/_cost_raw"
+
+# Anthropic snapshot suffix: -YYYYMMDD on family names (e.g.
+# "claude-haiku-4-5-20251001"). Cost-telemetry rate cards are family-
+# keyed, so strip the suffix before pricing lookup. Mirrors the research-
+# side normalization at ``alpha-engine-research/graph/llm_cost_tracker.py``
+# (the 2026-05-02 SF halt that motivated that fix). Lift candidate:
+# both research + executor now do this — when a 3rd consumer adopts the
+# same pin pattern, fold into ``alpha_engine_lib.cost``'s SDK adapter.
+import re as _re
+_SNAPSHOT_SUFFIX_RE = _re.compile(r"-\d{8}$")
+
+
+def _record_eod_narrative_cost(response, run_date: str) -> None:
+    """Price + persist one cost-telemetry JSONL row for the EOD narrative.
+
+    Best-effort: any failure is logged and swallowed so the EOD report
+    (the primary deliverable) survives. The cost-telemetry surface
+    itself fails loud at flush time per
+    ``[[feedback_no_silent_fails]]`` — but since the executor's EOD
+    runs nightly outside the research SF, we cannot let a cost-sink
+    miss take down the trading-day report. The WARN log is the
+    operator-facing signal that the row was lost.
+
+    Writes to the same partition the research-side
+    ``aggregate_costs.py`` already scans, so the daily parquet rolls
+    executor + data + research rows up under one ``by_agent_id``
+    breakdown — single source of truth for the cost dashboard.
+    """
+    try:
+        from alpha_engine_lib.cost import record_anthropic_call
+
+        # Normalize snapshot suffix off the SDK-reported model so the
+        # family-keyed rate card matches (see _SNAPSHOT_SUFFIX_RE above).
+        family_model = _SNAPSHOT_SUFFIX_RE.sub("", getattr(response, "model", ""))
+        record = record_anthropic_call(
+            response,
+            model_name=family_model or None,
+            extra_fields={
+                "run_id": run_date,
+                "agent_id": "executor:eod_narrative",
+            },
+        )
+        key = (
+            f"{_COST_TELEMETRY_PREFIX}/{run_date}/{run_date}/"
+            f"executor:eod_narrative.jsonl"
+        )
+        body = (json.dumps(record, default=str) + "\n").encode("utf-8")
+        boto3.client("s3").put_object(
+            Bucket=_COST_TELEMETRY_BUCKET,
+            Key=key,
+            Body=body,
+            ContentType="application/x-ndjson",
+        )
+        logger.info(
+            "[cost_telemetry] EOD narrative cost recorded: $%.4f → "
+            "s3://%s/%s",
+            float(record.get("cost_usd", 0)),
+            _COST_TELEMETRY_BUCKET, key,
+        )
+    except Exception as exc:
+        # Best-effort. Operator-facing WARN; EOD report continues.
+        logger.warning(
+            "[cost_telemetry] EOD narrative cost record FAILED for "
+            "run_date=%s — cost row LOST: %s",
+            run_date, exc,
+        )
+
+
+def _synthesize_rationales(contexts: list[dict], run_date: str | None = None) -> dict[str, str]:
     """Call Haiku via Anthropic tool-use + Pydantic validation to synthesize
     per-position narratives. Falls back to templates on any failure.
 
@@ -305,6 +375,15 @@ def _synthesize_rationales(contexts: list[dict]) -> dict[str, str]:
     preamble / trailing text). Tool-use makes the parse failure mode
     structurally impossible: Haiku returns a typed ``tool_use`` block
     whose ``input`` is schema-validated by the SDK *before* it lands here.
+
+    ``run_date``: when provided, the response's tokens + tool-fee usage
+    are priced via ``alpha_engine_lib.cost.record_anthropic_call`` and
+    written as one JSONL row to
+    ``s3://alpha-engine-research/decision_artifacts/_cost_raw/{run_date}/{run_date}/executor:eod_narrative.jsonl``.
+    Phase 0.2 wiring of the executor's only LLM call site
+    (previously-untracked ~$10–30/mo cost slice per the
+    ``prompt-caching-investigation-260525.md`` audit). When ``run_date``
+    is None (e.g., tests, ad-hoc invocation), cost telemetry is skipped.
     """
     if not contexts:
         return {}
@@ -330,6 +409,13 @@ def _synthesize_rationales(contexts: list[dict]) -> dict[str, str]:
             tool_choice={"type": "tool", "name": "emit_rationales"},
             messages=[{"role": "user", "content": prompt}],
         )
+
+        # Phase 0.2 cost telemetry — best-effort capture. Failures here
+        # MUST NOT break narrative synthesis (the primary deliverable);
+        # log + continue. Per [[feedback_no_silent_fails]] we still WARN
+        # loud so missed rows surface in CloudWatch.
+        if run_date is not None:
+            _record_eod_narrative_cost(response, run_date)
         # tool_choice={"type": "tool", "name": ...} forces Haiku to emit a
         # tool_use block — but Anthropic still allows additional text blocks
         # alongside it. Pick the tool_use block explicitly.
@@ -903,7 +989,7 @@ def run(run_date: str | None = None) -> None:
     try:
         if positions:
             contexts, ctx_warnings = _build_position_contexts(positions, conn, signals_bucket, run_date)
-            position_narratives = _synthesize_rationales(contexts)
+            position_narratives = _synthesize_rationales(contexts, run_date=run_date)
             logger.info(f"Position narratives generated for {len(position_narratives)} tickers")
             data_warnings.extend(ctx_warnings)
     except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ requests~=2.32
 # all existing imports (secrets/dates/logging/eval_artifacts/alerts/
 # universe/telegram/decision_capture/preflight/trading_calendar) on
 # 2026-05-25 — all additive, no breaking changes to existing surface.
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.32.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.33.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -542,3 +542,124 @@ def test_eod_reconcile_uses_macro_aware_dispatch_for_held_positions():
         "to route reads between universe_lib and macro_lib (mirrors "
         "price_cache.load_price_histories:128-145)."
     )
+
+
+# ── Phase 0.2 cost telemetry on EOD narrative LLM call ──────────────────
+
+
+class _FakeServerToolUsage:
+    def __init__(self, *, web_search_requests=0, web_fetch_requests=0):
+        self.web_search_requests = web_search_requests
+        self.web_fetch_requests = web_fetch_requests
+
+
+class _FakeUsage:
+    def __init__(
+        self, *, input_tokens, output_tokens,
+        cache_read_input_tokens=None, cache_creation_input_tokens=None,
+        server_tool_use=None,
+    ):
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+        self.cache_read_input_tokens = cache_read_input_tokens
+        self.cache_creation_input_tokens = cache_creation_input_tokens
+        self.server_tool_use = server_tool_use
+
+
+class _FakeAnthropicMessage:
+    """Stand-in for ``anthropic.types.Message`` shaped for the cost lib."""
+
+    def __init__(self, *, model, usage):
+        self.model = model
+        self.usage = usage
+
+
+class TestRecordEodNarrativeCost:
+    """Lock down the Phase 0.2 cost-telemetry wiring on EOD's sole
+    LLM call site (executor/eod_reconcile.py:326).
+
+    Per the audit at alpha-engine-docs/private/prompt-caching-investigation-260525.md
+    §1.1 this was the second-largest previously-untracked LLM cost
+    slice (~$10–30/mo, ~10–30% of monthly spend). Sink mirrors the
+    research-side ``decision_artifacts/_cost_raw/`` partition so the
+    daily aggregator sees executor's rows alongside research's + data's.
+    """
+
+    def test_writes_jsonl_row_to_canonical_s3_key(self, monkeypatch):
+        import boto3 as _boto3
+        from executor import eod_reconcile
+
+        captured = {}
+
+        class _StubS3:
+            def put_object(self, **kwargs):
+                captured.update(kwargs)
+                return {}
+
+        monkeypatch.setattr(_boto3, "client", lambda svc: _StubS3())
+
+        response = _FakeAnthropicMessage(
+            model="claude-haiku-4-5-20251001",
+            usage=_FakeUsage(input_tokens=2000, output_tokens=500),
+        )
+        eod_reconcile._record_eod_narrative_cost(response, "2026-05-25")
+
+        assert captured["Bucket"] == "alpha-engine-research"
+        assert captured["Key"] == (
+            "decision_artifacts/_cost_raw/2026-05-25/2026-05-25/"
+            "executor:eod_narrative.jsonl"
+        )
+        assert captured["ContentType"] == "application/x-ndjson"
+
+        body = captured["Body"].decode("utf-8").strip()
+        import json as _json
+        row = _json.loads(body)
+        assert row["run_id"] == "2026-05-25"
+        assert row["agent_id"] == "executor:eod_narrative"
+        # Snapshot suffix stripped — rate card is family-keyed.
+        assert row["model"] == "claude-haiku-4-5"
+        assert row["input_tokens"] == 2000
+        assert row["output_tokens"] == 500
+        # (2000 * 1.0 + 500 * 5.0) / 1M = 0.0045
+        assert row["cost_usd"] == pytest.approx(0.0045, abs=1e-6)
+
+    def test_failure_swallowed_so_eod_report_survives(self, monkeypatch, caplog):
+        """A cost-telemetry exception must NOT propagate — EOD report
+        is the primary deliverable. The WARN log is operator-facing
+        signal that the row was lost."""
+        import boto3 as _boto3
+        from executor import eod_reconcile
+
+        class _BrokenS3:
+            def put_object(self, **kwargs):
+                raise RuntimeError("AccessDenied")
+
+        monkeypatch.setattr(_boto3, "client", lambda svc: _BrokenS3())
+
+        response = _FakeAnthropicMessage(
+            model="claude-haiku-4-5-20251001",
+            usage=_FakeUsage(input_tokens=10, output_tokens=5),
+        )
+        # Must NOT raise.
+        eod_reconcile._record_eod_narrative_cost(response, "2026-05-25")
+        assert any(
+            "cost record FAILED" in r.message and "AccessDenied" in r.message
+            for r in caplog.records
+        )
+
+    def test_synthesize_rationales_skips_cost_when_run_date_none(self, monkeypatch):
+        """Back-compat — callers passing no run_date (tests, ad-hoc CLI)
+        must not invoke the cost-telemetry path."""
+        from executor import eod_reconcile
+
+        called = {"n": 0}
+
+        def _spy(*args, **kwargs):
+            called["n"] += 1
+
+        monkeypatch.setattr(
+            eod_reconcile, "_record_eod_narrative_cost", _spy,
+        )
+        # Drive the no-context fast path (returns {} without calling LLM).
+        eod_reconcile._synthesize_rationales([])
+        assert called["n"] == 0


### PR DESCRIPTION
## Summary

Closes the second-largest previously-untracked LLM cost slice in the system (~\$10–30/mo, ~10–30% of monthly Anthropic spend per the [Phase 0 audit](../alpha-engine-docs/private/prompt-caching-investigation-260525.md) §1.1). EOD position-narrative synthesis at \`executor/eod_reconcile.py:326\` fires one Haiku batched call per weekday EOD; this PR records the response's tokens + tool-fee usage into a per-day JSONL row written to S3 at the canonical research-side cost-raw partition.

## Single S3 chokepoint

Rows land at \`s3://alpha-engine-research/decision_artifacts/_cost_raw/{run_date}/{run_date}/executor:eod_narrative.jsonl\` — same partition the research-side \`aggregate_costs.py\` already scans. Executor's rows roll into the daily parquet's \`by_agent_id\` breakdown alongside research + data.

## Failure semantics

Unlike data's news pipeline (whose flush hard-fails per \`[[feedback_no_silent_fails]]\` since cost telemetry IS the explicit Phase 0 goal there), **executor's nightly EOD report is operator-critical and MUST survive a cost-sink hiccup**. \`_record_eod_narrative_cost\` swallows + WARN-logs any exception; the operator-facing log is the signal that a row was lost. One call per day = no buffering needed (single PutObject).

## Lift candidate flagged

Anthropic snapshot-suffix normalization (\`-YYYYMMDD\` → family name for rate-card lookup) is now mirrored in research (\`llm_cost_tracker.py::_normalize_model_for_pricing\`) + executor (this PR's \`_SNAPSHOT_SUFFIX_RE\`). Per \`[[feedback_lift_invariants_to_chokepoint_after_second_recurrence]]\` when a 3rd consumer adopts the same pattern, fold into \`alpha_engine_lib.cost\`'s SDK adapter rather than per-repo mirroring. Inline comment marks the lift point.

## Lib pin

\`v0.32.0 → v0.33.0\` to consume the lifted \`alpha_engine_lib.cost.record_anthropic_call\` (alpha-engine-lib #69 — executor is consumer #3 of the SOTA chokepoint after morning-signal originated + data adopted).

## Test plan

- [x] \`pytest tests/test_eod_reconcile.py\` — 31 pass (+3 new \`TestRecordEodNarrativeCost\`)
- [x] Full executor suite 962 → 965 pass, zero regressions
- [x] Lib v0.33.0 install resolved cleanly
- [ ] Next weekday EOD SF (Mon 5/26) fires \`_synthesize_rationales\` + lands JSONL at the canonical key
- [ ] Sat 5/30 \`aggregate_costs.py\` picks up executor's rows alongside research + data in the daily parquet

🤖 Generated with [Claude Code](https://claude.com/claude-code)