### PR TITLE
feat(cost-telemetry): WARN-above-ceiling on EOD narrative call (Phase 4 #1)

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -299,6 +299,38 @@ _RATIONALES_TOOL = {
 _COST_TELEMETRY_BUCKET = "alpha-engine-research"
 _COST_TELEMETRY_PREFIX = "decision_artifacts/_cost_raw"
 
+# Phase 4 #1 — cost-budget WARN threshold. Shared env var with
+# alpha-engine-research's ``llm_cost_tracker.RunBudgetExceededError`` +
+# alpha-engine-data's ``_cost_telemetry.CostBudgetExceededError`` so a
+# single operator knob ceilings cost across all SF entry points.
+# Executor's posture is WARN-only (NOT raise) per [[feedback_no_silent_fails]]
+# applied carefully: the EOD report is operator-critical and survives
+# a cost-sink miss; we cannot let a single anomalous narrative call
+# take down the trading-day reconcile. The WARN log + the per-call
+# JSONL row on S3 are the operator-facing signals.
+_COST_BUDGET_ENV_VAR = "ALPHA_ENGINE_RUN_BUDGET_USD"
+_COST_BUDGET_DEFAULT_USD = 100.0
+
+
+def _resolve_cost_budget_ceiling() -> float:
+    """Read ``ALPHA_ENGINE_RUN_BUDGET_USD`` (shared with research + data).
+
+    Returns the positive threshold to WARN above, or 0.0 to disable.
+    Parse failure → disable (don't let a malformed env take down EOD).
+    """
+    import os
+    raw = os.environ.get(_COST_BUDGET_ENV_VAR, "")
+    if not raw:
+        return _COST_BUDGET_DEFAULT_USD
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[cost_telemetry] ALPHA_ENGINE_RUN_BUDGET_USD=%r is not a "
+            "number; disabling cost-budget WARN", raw,
+        )
+        return 0.0
+
 # Anthropic snapshot suffix: -YYYYMMDD on family names (e.g.
 # "claude-haiku-4-5-20251001"). Cost-telemetry rate cards are family-
 # keyed, so strip the suffix before pricing lookup. Mirrors the research-
@@ -351,12 +383,29 @@ def _record_eod_narrative_cost(response, run_date: str) -> None:
             Body=body,
             ContentType="application/x-ndjson",
         )
+        cost_usd = float(record.get("cost_usd", 0))
         logger.info(
             "[cost_telemetry] EOD narrative cost recorded: $%.4f → "
             "s3://%s/%s",
-            float(record.get("cost_usd", 0)),
+            cost_usd,
             _COST_TELEMETRY_BUCKET, key,
         )
+
+        # Phase 4 #1 — WARN if this single call alone exceeds the run
+        # budget (signal that a narrative prompt expansion or runaway
+        # loop pushed one call into the danger zone). Doesn't raise:
+        # EOD report continues. Operators see the WARN + dashboard's
+        # next refresh shows the spike in the "Recent calls" tab.
+        ceiling = _resolve_cost_budget_ceiling()
+        if ceiling > 0 and cost_usd > ceiling:
+            logger.warning(
+                "[cost_telemetry] EOD narrative single call exceeded "
+                "cost budget: $%.4f > ceiling=$%.4f (env var "
+                "ALPHA_ENGINE_RUN_BUDGET_USD). Investigate the prompt "
+                "or position-count expansion — typical EOD call is "
+                "under $0.01. JSONL row preserved on S3 for diagnosis.",
+                cost_usd, ceiling,
+            )
     except Exception as exc:
         # Best-effort. Operator-facing WARN; EOD report continues.
         logger.warning(

--- a/tests/test_eod_reconcile.py
+++ b/tests/test_eod_reconcile.py
@@ -663,3 +663,76 @@ class TestRecordEodNarrativeCost:
         # Drive the no-context fast path (returns {} without calling LLM).
         eod_reconcile._synthesize_rationales([])
         assert called["n"] == 0
+
+
+class TestCostBudgetWarn:
+    """Phase 4 #1 — WARN when a single EOD narrative call blows the
+    shared ALPHA_ENGINE_RUN_BUDGET_USD threshold. Executor's posture
+    is WARN-only (not raise) per the established "EOD report must
+    survive" semantic."""
+
+    def test_warn_emitted_when_call_exceeds_ceiling(self, monkeypatch, caplog):
+        """A single-call cost > $1 with a $0.001 ceiling should WARN
+        loud but NOT raise. The cost row + EOD report both survive."""
+        import boto3 as _boto3
+        from executor import eod_reconcile
+
+        monkeypatch.setenv("ALPHA_ENGINE_RUN_BUDGET_USD", "0.001")
+
+        class _StubS3:
+            def put_object(self, **kwargs):
+                return {}
+
+        monkeypatch.setattr(_boto3, "client", lambda svc: _StubS3())
+
+        response = _FakeAnthropicMessage(
+            model="claude-haiku-4-5-20251001",
+            usage=_FakeUsage(input_tokens=1000, output_tokens=200),
+        )
+        # Cost: (1000 * 1 + 200 * 5) / 1M = 0.002 > 0.001 ceiling.
+        # Must NOT raise.
+        eod_reconcile._record_eod_narrative_cost(response, "2026-05-25")
+        assert any(
+            "exceeded cost budget" in r.message
+            and "ALPHA_ENGINE_RUN_BUDGET_USD" in r.message
+            for r in caplog.records
+        )
+
+    def test_no_warn_when_call_under_ceiling(self, monkeypatch, caplog):
+        import boto3 as _boto3
+        from executor import eod_reconcile
+
+        monkeypatch.setenv("ALPHA_ENGINE_RUN_BUDGET_USD", "100")
+
+        class _StubS3:
+            def put_object(self, **kwargs):
+                return {}
+
+        monkeypatch.setattr(_boto3, "client", lambda svc: _StubS3())
+
+        response = _FakeAnthropicMessage(
+            model="claude-haiku-4-5-20251001",
+            usage=_FakeUsage(input_tokens=1000, output_tokens=200),
+        )
+        eod_reconcile._record_eod_narrative_cost(response, "2026-05-25")
+        assert not any("exceeded cost budget" in r.message for r in caplog.records)
+
+    def test_zero_ceiling_disables_warn(self, monkeypatch, caplog):
+        import boto3 as _boto3
+        from executor import eod_reconcile
+
+        monkeypatch.setenv("ALPHA_ENGINE_RUN_BUDGET_USD", "0")
+
+        class _StubS3:
+            def put_object(self, **kwargs):
+                return {}
+
+        monkeypatch.setattr(_boto3, "client", lambda svc: _StubS3())
+
+        # Even an enormous call should not WARN when ceiling=0.
+        response = _FakeAnthropicMessage(
+            model="claude-haiku-4-5",
+            usage=_FakeUsage(input_tokens=1_000_000, output_tokens=200_000),
+        )
+        eod_reconcile._record_eod_narrative_cost(response, "2026-05-25")
+        assert not any("exceeded cost budget" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Mirrors the shared cost-budget posture from research's \`RunBudgetExceededError\` + data's \`CostBudgetExceededError\` — single env var \`ALPHA_ENGINE_RUN_BUDGET_USD\` (default \$100) ceilings cost across all SF entry points.

## Executor posture is WARN-only (NOT raise)

Unlike data's hard-fail breaker, the EOD report is operator-critical and survives a single anomalous cost — a runaway narrative prompt expansion should not take down trading-day reconciliation. The WARN log + the per-call JSONL row on S3 + the dashboard's "Recent calls" tab are the operator-facing signals.

## Defensive shape rationale

EOD narratives are a single Haiku batched call per day, typical cost <\$0.01. A \$1+ single call is a strong signal of prompt expansion or position-count explosion worth investigating; WARN-only keeps the trading day from breaking on it.

## Test plan

- [x] \`pytest tests/test_eod_reconcile.py\` — 34 pass (+3 new \`TestCostBudgetWarn\`)
- [x] Full suite 965 → 968 pass, zero regressions

Composes with PR #210 (Phase 0.2 wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)