### PR TITLE
feat(daemon): tag EOD pipeline executions with pipeline_role="eod"

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -1058,6 +1058,11 @@ def _trigger_eod_pipeline(config: dict, run_date: str) -> None:
                 "sns_topic_arn": sns_topic_arn,
                 "run_date": run_date,
                 "triggered_by": "daemon_shutdown",
+                # pipeline_role tag (Option-D 2026-05-25) — page 25 filters
+                # EOD section to role="eod" by default. Operator-initiated
+                # EOD replays MUST set their own pipeline_role per the
+                # taxonomy in pipeline-reporting-revamp-260524.md §6.
+                "pipeline_role": "eod",
             }),
         )
         logger.info("EOD pipeline triggered: %s", state_machine_arn)


### PR DESCRIPTION
## Summary

Companion to [alpha-engine-data PR](https://github.com/cipher813/alpha-engine-data/pulls?q=is%3Apr+pipeline-role) (Option-D execution-picker plan, Brian-approved 2026-05-25 evening). The daemon's `_trigger_eod_pipeline` helper is the sole caller that starts an EOD SF execution; tagging it here ensures page 25's EOD section default-filters to canonical daemon-triggered runs.

Operator-initiated EOD replays MUST set their own `pipeline_role` per the taxonomy documented in the alpha-engine-data PR body — the default tag is the daemon's `"eod"`, not `"operator-replay"`.

## Substrate

- Lib (cipher813/alpha-engine-lib#75): `read_pipeline_state(arn, role_filter={"eod"})` will pick the most-recent execution whose `input.pipeline_role == "eod"`.
- Dashboard PR (forthcoming after this + the data PR merge): flips page 25's EOD section consumer.

## Test plan

- [x] Code edit is additive — one new field on the existing input dict. SF's EOD input handling has no JsonMerge (input flows direct), so the field lands raw in `DescribeExecution.input` where the lib parses it.
- [ ] After merge: trigger an EOD run (live shutdown of daemon, or `aws stepfunctions start-execution` with the same input shape) and verify `input.pipeline_role == "eod"` via `aws stepfunctions describe-execution`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)