### PR TITLE
feat(optimizer): EWMA dynamic covariance estimator (A.2)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -325,8 +325,14 @@ portfolio_optimizer:
   # multi-asset / risk-parity layer.
   vol_target_annual: null
   # Covariance estimator. "ledoit_wolf" is the institutional default;
-  # "sample" disables shrinkage (useful only for synthetic-input tests).
+  # "sample" disables shrinkage (test-only); "ewma" enables RiskMetrics 1996
+  # exponentially-weighted dynamic Σ (vol-clustering aware). See
+  # optimizer-sota-upgrades-260526.md §A.2.
   covariance_shrinkage: ledoit_wolf
+  # EWMA decay (only used when covariance_shrinkage="ewma"). 0.94 is the
+  # RiskMetrics canonical (~11d half-life); 0.97 ↔ ~23d half-life (closer to
+  # canonical 21d α̂ horizon). Must be in [0.5, 1.0].
+  ewma_lambda_decay: 0.94
   # Σ horizon in trading days. 1 (default) = legacy daily Σ, bit-identical to
   # pre-260526 behavior. Set to 21 to align Σ with the canonical 21d log-domain
   # α̂; under i.i.d. log-returns Σ_H = H · Σ_daily, with vol-target SOC and

--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -183,6 +183,10 @@ OPTIMIZER_CONFIG_DEFAULTS: dict = {
     # (bit-identical to pre-260526 behavior); set to 21 to align Σ with the
     # canonical 21d log-domain α̂. See optimizer-sota-upgrades-260526.md §A.1.
     "sigma_horizon_days": 1,
+    # EWMA decay for ``covariance_shrinkage="ewma"``. RiskMetrics 1996
+    # canonical value 0.94 ↔ ~11d half-life; 0.97 ↔ ~23d half-life (closer
+    # to canonical 21d α̂ horizon). See optimizer-sota-upgrades-260526.md §A.2.
+    "ewma_lambda_decay": 0.94,
 }
 
 
@@ -222,20 +226,57 @@ def _validate_inputs(
         raise ValueError("CASH must be eligible (sleeve pin)")
 
 
+def _ewma_covariance(returns: np.ndarray, lambda_decay: float) -> np.ndarray:
+    """RiskMetrics 1996 EWMA covariance with zero-mean assumption.
+
+    Σ_EWMA = (1−λ) · Σ_{k=0}^{T-1} λ^k · r_{t-k} r_{t-k}ᵀ, normalized so weights
+    sum to 1 over the finite window. The zero-mean simplification is standard
+    for daily equity returns (E[r] ≪ σ); RiskMetrics 1996 §5.3.2.
+
+    With λ=0.94 the effective half-life is log(0.5)/log(0.94) ≈ 11.2 trading days
+    (RiskMetrics canonical); 0.97 → ~22.8 days (closer to 21d α̂ horizon).
+
+    Degenerate at λ=1.0: weights become uniform 1/T → reduces to (unbiased
+    only up to the 1/T vs 1/(T-1) factor) sample covariance. Tested.
+    """
+    if not 0.5 <= lambda_decay <= 1.0:
+        raise ValueError(
+            f"ewma_lambda_decay must be in [0.5, 1.0]; got {lambda_decay}. "
+            f"RiskMetrics 1996 canonical is 0.94 (daily) or 0.97 (monthly)."
+        )
+    T = returns.shape[0]
+    if lambda_decay >= 1.0 - 1e-12:
+        # Uniform weights (degenerate). Treat λ=1 as plain sample-cov-equivalent.
+        return (returns.T @ returns) / T
+    # Newest observation first; row 0 carries the largest weight.
+    R = returns[::-1]
+    weights = (1.0 - lambda_decay) * lambda_decay ** np.arange(T)
+    weights /= weights.sum()  # normalize for finite-window truncation
+    return (R.T * weights) @ R
+
+
 def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
     """Return covariance at horizon ``cfg["sigma_horizon_days"]``.
 
-    Estimates Σ_daily via the configured shrinkage (Ledoit-Wolf default) on the
-    NaN-clean returns panel, then scales by horizon-days under i.i.d. log-return
-    assumption: Σ_H = H · Σ_daily. Default H=1 preserves legacy daily Σ
-    bit-identical (1 × Σ = Σ).
+    Estimates Σ_daily via the configured estimator, then scales by horizon-days
+    under i.i.d. log-return assumption: Σ_H = H · Σ_daily. Default H=1 preserves
+    legacy daily Σ bit-identical (1 × Σ = Σ).
+
+    Estimators (cfg["covariance_shrinkage"]):
+      * "ledoit_wolf" (default): Ledoit-Wolf 2004 constant-correlation shrinkage
+        on equal-weighted samples. Institutional default.
+      * "sample": raw sample covariance, no shrinkage. Test-only.
+      * "ewma": RiskMetrics 1996 EWMA with cfg["ewma_lambda_decay"] (default
+        0.94). Captures vol-clustering; weights recent observations more.
+        See optimizer-sota-upgrades-260526.md §A.2.
     """
     clean = returns_panel[~np.isnan(returns_panel).any(axis=1)]
     if clean.shape[0] < 20:
         raise ValueError(
             f"Need ≥20 clean return rows for covariance; got {clean.shape[0]}"
         )
-    if cfg["covariance_shrinkage"] == "ledoit_wolf":
+    estimator = cfg["covariance_shrinkage"]
+    if estimator == "ledoit_wolf":
         try:
             from sklearn.covariance import LedoitWolf
         except ImportError as e:
@@ -244,12 +285,12 @@ def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
                 "via `pip install 'scikit-learn>=1.3,<1.6'`."
             ) from e
         sigma_daily = LedoitWolf().fit(clean).covariance_
-    elif cfg["covariance_shrinkage"] == "sample":
+    elif estimator == "sample":
         sigma_daily = np.cov(clean, rowvar=False)
+    elif estimator == "ewma":
+        sigma_daily = _ewma_covariance(clean, float(cfg.get("ewma_lambda_decay", 0.94)))
     else:
-        raise ValueError(
-            f"Unknown covariance_shrinkage: {cfg['covariance_shrinkage']}"
-        )
+        raise ValueError(f"Unknown covariance_shrinkage: {estimator}")
 
     horizon = int(cfg.get("sigma_horizon_days", 1))
     if horizon < 1:

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -401,3 +401,152 @@ def test_sigma_horizon_days_below_one_raises():
 
     with pytest.raises(ValueError, match="sigma_horizon_days must be ≥ 1"):
         _solve(u)
+
+
+# ─── A.2 EWMA covariance tests ──────────────────────────────────────────────
+# Plan: alpha-engine-docs/private/optimizer-sota-upgrades-260526.md §A.2
+#
+# RiskMetrics 1996 EWMA with zero-mean assumption. New estimator option
+# "ewma" + cfg["ewma_lambda_decay"] (default 0.94). Default estimator
+# (ledoit_wolf) is unchanged; EWMA is opt-in.
+
+
+def test_ewma_concentrates_on_recent_regime():
+    """Two-regime synthetic panel: EWMA should be closer to recent regime's
+    sample cov than to a pooled sample cov.
+
+    Construct T=500 daily returns: first 250 rows have N=2 with vol=0.005
+    and ρ=+0.8 (calm regime); last 250 rows have vol=0.03 and ρ=-0.3
+    (stress regime). EWMA(λ=0.94, half-life≈11d) should weight the stress
+    regime heavily because its window is much shorter than 250 days.
+    """
+    from executor.portfolio_optimizer import _ewma_covariance
+
+    rng = np.random.default_rng(42)
+    T_per = 250
+
+    # Calm regime: vol 0.005, correlation +0.8
+    calm_cov = np.array([[0.005**2, 0.8 * 0.005**2], [0.8 * 0.005**2, 0.005**2]])
+    calm = rng.multivariate_normal([0, 0], calm_cov, size=T_per)
+
+    # Stress regime: vol 0.03, correlation -0.3 (decorrelating in a crash)
+    stress_cov = np.array([[0.03**2, -0.3 * 0.03**2], [-0.3 * 0.03**2, 0.03**2]])
+    stress = rng.multivariate_normal([0, 0], stress_cov, size=T_per)
+
+    panel = np.vstack([calm, stress])  # calm first, stress last (most recent)
+
+    sigma_sample = np.cov(panel, rowvar=False)
+    sigma_ewma = _ewma_covariance(panel, lambda_decay=0.94)
+
+    # EWMA diagonals should be far closer to stress vol² than to the pooled
+    # ~mean of the two regimes' vol². Pooled vol² ≈ (0.005² + 0.03²) / 2 ≈ 4.6e-4.
+    pooled_var_avg = (0.005**2 + 0.03**2) / 2
+    stress_var = 0.03**2
+    ewma_var_avg = (sigma_ewma[0, 0] + sigma_ewma[1, 1]) / 2
+
+    assert abs(ewma_var_avg - stress_var) < abs(ewma_var_avg - pooled_var_avg), (
+        f"EWMA should track recent regime: ewma_var_avg={ewma_var_avg:.6f}, "
+        f"stress_var={stress_var:.6f}, pooled_var={pooled_var_avg:.6f}"
+    )
+    # And sample-cov should be in-between (averages across both regimes)
+    sample_var_avg = (sigma_sample[0, 0] + sigma_sample[1, 1]) / 2
+    assert abs(sample_var_avg - pooled_var_avg) < abs(sample_var_avg - stress_var), (
+        f"Sample cov should be closer to pooled than to stress; "
+        f"sample_var_avg={sample_var_avg:.6f}"
+    )
+
+
+def test_ewma_lambda_one_degenerates_to_uniform_weighted_cov():
+    """λ=1.0 → uniform weights → cov matches (R.T @ R)/T (zero-mean assumption)."""
+    from executor.portfolio_optimizer import _ewma_covariance
+
+    rng = np.random.default_rng(0)
+    returns = rng.normal(0, 0.01, size=(300, 3))
+
+    sigma_ewma_lambda1 = _ewma_covariance(returns, lambda_decay=1.0)
+    sigma_uniform = (returns.T @ returns) / returns.shape[0]
+
+    np.testing.assert_allclose(sigma_ewma_lambda1, sigma_uniform, rtol=1e-10)
+
+
+def test_ewma_weights_normalize_to_one():
+    """The EWMA weights must sum to 1 — sanity check that finite-T normalization
+    is correct so total variance scale is preserved."""
+    from executor.portfolio_optimizer import _ewma_covariance
+
+    rng = np.random.default_rng(1)
+    returns = rng.normal(0, 0.01, size=(500, 4))
+
+    sigma = _ewma_covariance(returns, lambda_decay=0.94)
+    # If weights summed wrong, the diagonal magnitude would be off by O(1/T)
+    # vs the true variance. Compare to uniform cov for plausibility check.
+    uniform_var_avg = float(np.mean(np.diag((returns.T @ returns) / 500)))
+    ewma_var_avg = float(np.mean(np.diag(sigma)))
+    # Both should be O(0.01²) = 1e-4. EWMA can deviate in either direction
+    # due to recent-window noise but must be in the same order of magnitude.
+    assert 0.1 * uniform_var_avg < ewma_var_avg < 10 * uniform_var_avg
+
+
+def test_ewma_invalid_lambda_raises():
+    """λ outside [0.5, 1.0] is a config error — RiskMetrics canonical range."""
+    from executor.portfolio_optimizer import _ewma_covariance
+
+    rng = np.random.default_rng(2)
+    returns = rng.normal(0, 0.01, size=(100, 2))
+
+    with pytest.raises(ValueError, match="ewma_lambda_decay must be in"):
+        _ewma_covariance(returns, lambda_decay=0.3)
+    with pytest.raises(ValueError, match="ewma_lambda_decay must be in"):
+        _ewma_covariance(returns, lambda_decay=1.1)
+
+
+def test_ewma_estimator_integrates_with_solve_target_weights():
+    """End-to-end: covariance_shrinkage="ewma" produces a valid optimization."""
+    u = _baseline_universe(n_active=2)
+    u["alpha_hat"][:2] = 0.05
+    u["cfg"] = {"covariance_shrinkage": "ewma", "ewma_lambda_decay": 0.94}
+
+    result = _solve(u)
+
+    assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate")
+    assert result.weights.sum() == pytest.approx(1.0, abs=1e-6)
+    assert result.weights[u["cash_idx"]] == pytest.approx(0.03, abs=1e-6)
+    # Conviction picks should hit their cap given strong α̂
+    assert result.weights[0] == pytest.approx(0.08, abs=1e-3)
+    assert result.weights[1] == pytest.approx(0.08, abs=1e-3)
+
+
+def test_ewma_composes_with_sigma_horizon_days():
+    """EWMA Σ at H=21 = 21 × EWMA Σ at H=1 — composition with A.1."""
+    from executor.portfolio_optimizer import _estimate_covariance, OPTIMIZER_CONFIG_DEFAULTS
+
+    rng = np.random.default_rng(3)
+    returns = rng.normal(0, 0.01, size=(300, 4))
+
+    cfg_h1 = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "ewma",
+              "ewma_lambda_decay": 0.94, "sigma_horizon_days": 1}
+    cfg_h21 = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "ewma",
+               "ewma_lambda_decay": 0.94, "sigma_horizon_days": 21}
+
+    sigma_h1 = _estimate_covariance(returns, cfg_h1)
+    sigma_h21 = _estimate_covariance(returns, cfg_h21)
+
+    np.testing.assert_allclose(sigma_h21, 21.0 * sigma_h1, rtol=1e-10)
+
+
+def test_default_estimator_unchanged_after_ewma_addition():
+    """Adding EWMA must NOT change behavior when covariance_shrinkage is unset
+    or set to ledoit_wolf — no silent regression of the production path."""
+    u_default = _baseline_universe(n_active=2)
+    u_default["alpha_hat"][:2] = 0.05
+    u_default["cfg"] = {}  # default everything
+
+    u_explicit_lw = _baseline_universe(n_active=2)
+    u_explicit_lw["alpha_hat"][:2] = 0.05
+    u_explicit_lw["returns_panel"] = u_default["returns_panel"].copy()
+    u_explicit_lw["cfg"] = {"covariance_shrinkage": "ledoit_wolf"}
+
+    r_default = _solve(u_default)
+    r_lw = _solve(u_explicit_lw)
+
+    np.testing.assert_allclose(r_default.weights, r_lw.weights, atol=1e-8)


### PR DESCRIPTION
## Summary

Second PR in the **optimizer-sota-upgrades-260526** arc (workstream **A.2 — dynamic / exponentially-weighted Σ**). Adds RiskMetrics 1996 EWMA as a new `covariance_shrinkage="ewma"` option with configurable `ewma_lambda_decay` (default 0.94, ~11d half-life).

**Why this matters**: today's Σ is a 252-row constant-window sample (LW-shrunk) that equally weights an August 2025 return with a yesterday return. Vol-clustering and regime shifts are erased. EWMA upweights recent observations geometrically — aligns the Σ-window with the 21d α̂ horizon, RiskMetrics 1996 canonical.

```
Σ_EWMA = (1−λ) · Σ_{k=0}^{T-1} λ^k · r_{t-k} r_{t-k}ᵀ
```

Zero-mean assumption (RiskMetrics §5.3.2) — standard for daily equity returns where E[r] ≪ σ.

## What changed

- New `_ewma_covariance(returns, lambda_decay)` helper in `executor/portfolio_optimizer.py`
- `_estimate_covariance` gains an \"ewma\" branch alongside `\"ledoit_wolf\"` (default) and `\"sample\"`
- Two new config keys in `OPTIMIZER_CONFIG_DEFAULTS` / `risk.yaml.example`:
  - `covariance_shrinkage`: now accepts `\"ewma\"` (in addition to `\"ledoit_wolf\"`, `\"sample\"`)
  - `ewma_lambda_decay`: default 0.94 (RiskMetrics canonical, ~11d half-life)
- Default behavior unchanged: `covariance_shrinkage=\"ledoit_wolf\"` remains; EWMA is opt-in

## A.2 / A.2b scope split

A.2 ships **pure EWMA** only. The Wolf 2018 _\"Honey, I Shrunk the EWMA\"_ shrink-on-EWMA pipeline (would be `\"ewma_ledoit_wolf\"`) is **deferred to A.2b** because the proper δ formula requires weighted-sample fourth-moment calculation that warrants its own PR + validation cycle. Per the no-bandaid + SOTA rule, silently mis-implementing the shrinkage formula defeats the purpose of going to SOTA. The backtester sweep in A.4 will test pure EWMA against sample-LW; if pure EWMA wins or ties on OOS Sharpe, dynamic-window is the load-bearing piece and A.2b becomes the next refinement.

Plan doc updated in alpha-engine-docs/private/ to reflect the split (separate PR there).

## What is NOT in this PR (by design)

- Wolf 2018 LW-on-EWMA — workstream **A.2b** (P2 follow-up)
- Backtester sweep harness over `λ_decay ∈ {0.92, 0.94, 0.97, 1.0}` — workstream **A.4**
- Production cutover to `\"ewma\"` — gated on A.4 verdict

## Test plan

- [x] EWMA on two-regime synthetic panel concentrates on recent regime (stress regime tracked closer than the pooled mean across both regimes; sample-cov by contrast tracks the pooled mean)
- [x] λ=1.0 degenerates to uniform-weighted second-moment matrix (regression against `(R.T @ R) / T`)
- [x] EWMA weights normalize to 1 (no scale drift; diagonal magnitude stays in correct order)
- [x] Invalid λ outside [0.5, 1.0] raises (no silent fail per [[feedback_no_silent_fails]])
- [x] End-to-end integration with `solve_target_weights`
- [x] Composes with `sigma_horizon_days` from A.1 (Σ_EWMA × H = H · Σ_EWMA)
- [x] Default-estimator regression: explicit and implicit `\"ledoit_wolf\"` produce bit-identical weights (no silent change to production path)
- [x] Full alpha-engine suite passes (965/965; +7 new EWMA tests)
- [x] Pre-push dry-run gate passes

## Plan reference

`alpha-engine-docs/private/optimizer-sota-upgrades-260526.md` §A.2 (also updated this session to reflect A.2/A.2b split)

🤖 Generated with [Claude Code](https://claude.com/claude-code)