### PR TITLE
feat(optimizer): OAS covariance estimator (A.3)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -325,9 +325,10 @@ portfolio_optimizer:
   # multi-asset / risk-parity layer.
   vol_target_annual: null
   # Covariance estimator. "ledoit_wolf" is the institutional default;
-  # "sample" disables shrinkage (test-only); "ewma" enables RiskMetrics 1996
-  # exponentially-weighted dynamic Σ (vol-clustering aware). See
-  # optimizer-sota-upgrades-260526.md §A.2.
+  # "oas" is Chen et al. 2010 Oracle Approximating Shrinkage (lower MSE than
+  # LW when T/N is small); "sample" disables shrinkage (test-only); "ewma"
+  # enables RiskMetrics 1996 exponentially-weighted dynamic Σ (vol-clustering
+  # aware). See optimizer-sota-upgrades-260526.md §A.2 / §A.3.
   covariance_shrinkage: ledoit_wolf
   # EWMA decay (only used when covariance_shrinkage="ewma"). 0.94 is the
   # RiskMetrics canonical (~11d half-life); 0.97 ↔ ~23d half-life (closer to

--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -265,6 +265,10 @@ def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
     Estimators (cfg["covariance_shrinkage"]):
       * "ledoit_wolf" (default): Ledoit-Wolf 2004 constant-correlation shrinkage
         on equal-weighted samples. Institutional default.
+      * "oas": Chen et al. 2010 Oracle Approximating Shrinkage. Lower-MSE than
+        LW when T/N is small (our universe ~27 × T~252 → T/N≈9 is modestly
+        small-sample). Drop-in alternative; same shrinkage-target family
+        (multiple of identity). See optimizer-sota-upgrades-260526.md §A.3.
       * "sample": raw sample covariance, no shrinkage. Test-only.
       * "ewma": RiskMetrics 1996 EWMA with cfg["ewma_lambda_decay"] (default
         0.94). Captures vol-clustering; weights recent observations more.
@@ -285,6 +289,15 @@ def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
                 "via `pip install 'scikit-learn>=1.3,<1.6'`."
             ) from e
         sigma_daily = LedoitWolf().fit(clean).covariance_
+    elif estimator == "oas":
+        try:
+            from sklearn.covariance import OAS
+        except ImportError as e:
+            raise ImportError(
+                "scikit-learn is required for OAS shrinkage. Install via "
+                "`pip install 'scikit-learn>=1.3,<1.6'`."
+            ) from e
+        sigma_daily = OAS().fit(clean).covariance_
     elif estimator == "sample":
         sigma_daily = np.cov(clean, rowvar=False)
     elif estimator == "ewma":

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -550,3 +550,89 @@ def test_default_estimator_unchanged_after_ewma_addition():
     r_lw = _solve(u_explicit_lw)
 
     np.testing.assert_allclose(r_default.weights, r_lw.weights, atol=1e-8)
+
+
+# ─── A.3 OAS estimator tests ────────────────────────────────────────────────
+# Plan: alpha-engine-docs/private/optimizer-sota-upgrades-260526.md §A.3
+#
+# Chen et al. 2010 Oracle Approximating Shrinkage. Drop-in alongside LW;
+# sklearn.covariance.OAS shares the .fit().covariance_ interface.
+
+
+def test_oas_estimator_produces_valid_psd_matrix():
+    """OAS Σ must be symmetric PSD; same shape as input."""
+    from executor.portfolio_optimizer import _estimate_covariance, OPTIMIZER_CONFIG_DEFAULTS
+
+    rng = np.random.default_rng(5)
+    returns = rng.normal(0, 0.01, size=(252, 5))
+    cfg = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "oas"}
+
+    sigma = _estimate_covariance(returns, cfg)
+
+    assert sigma.shape == (5, 5)
+    np.testing.assert_allclose(sigma, sigma.T, atol=1e-12)
+    eigvals = np.linalg.eigvalsh(sigma)
+    assert eigvals.min() >= -1e-10, f"OAS Σ must be PSD; min eigval={eigvals.min()}"
+
+
+def test_oas_estimator_integrates_with_solve_target_weights():
+    """End-to-end: covariance_shrinkage="oas" produces a valid optimization."""
+    u = _baseline_universe(n_active=2)
+    u["alpha_hat"][:2] = 0.05
+    u["cfg"] = {"covariance_shrinkage": "oas"}
+
+    result = _solve(u)
+
+    assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate")
+    assert result.weights.sum() == pytest.approx(1.0, abs=1e-6)
+    assert result.weights[u["cash_idx"]] == pytest.approx(0.03, abs=1e-6)
+    assert result.weights[0] == pytest.approx(0.08, abs=1e-3)
+    assert result.weights[1] == pytest.approx(0.08, abs=1e-3)
+
+
+def test_oas_composes_with_sigma_horizon_days():
+    """OAS Σ at H=21 = 21 × OAS Σ at H=1 — composition with A.1."""
+    from executor.portfolio_optimizer import _estimate_covariance, OPTIMIZER_CONFIG_DEFAULTS
+
+    rng = np.random.default_rng(7)
+    returns = rng.normal(0, 0.01, size=(252, 4))
+
+    cfg_h1 = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "oas",
+              "sigma_horizon_days": 1}
+    cfg_h21 = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "oas",
+               "sigma_horizon_days": 21}
+
+    sigma_h1 = _estimate_covariance(returns, cfg_h1)
+    sigma_h21 = _estimate_covariance(returns, cfg_h21)
+
+    np.testing.assert_allclose(sigma_h21, 21.0 * sigma_h1, rtol=1e-10)
+
+
+def test_oas_distinct_from_lw_on_correlated_small_sample():
+    """OAS and LW should produce different Σ when shrinkage intensity differs.
+
+    With i.i.d. zero-correlation data both estimators correctly shrink fully
+    to scaled-identity. Need data with real correlation structure so the
+    intensity formulas (which differ between LW and OAS) yield distinct Σ.
+    Confirms OAS is actually wired (not silently aliasing to LW)."""
+    from executor.portfolio_optimizer import _estimate_covariance, OPTIMIZER_CONFIG_DEFAULTS
+
+    rng = np.random.default_rng(11)
+    N = 10
+    T = 40  # small T/N where shrinkage intensity matters most
+    # Build a correlated panel: each return = common factor + idiosyncratic noise
+    common_factor = rng.normal(0, 0.01, size=T)
+    idiosyncratic = rng.normal(0, 0.005, size=(T, N))
+    returns = common_factor[:, None] + idiosyncratic  # broadcast; introduces ρ≈0.8
+
+    cfg_lw = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "ledoit_wolf"}
+    cfg_oas = {**OPTIMIZER_CONFIG_DEFAULTS, "covariance_shrinkage": "oas"}
+
+    sigma_lw = _estimate_covariance(returns, cfg_lw)
+    sigma_oas = _estimate_covariance(returns, cfg_oas)
+
+    # Distinct: different shrinkage intensities → different off-diagonal magnitudes
+    assert not np.allclose(sigma_lw, sigma_oas, atol=1e-7), (
+        "OAS should differ from LW on small T/N correlated data — if these "
+        "match, OAS may be silently aliasing to LW"
+    )


### PR DESCRIPTION
## Summary

Third PR in the **optimizer-sota-upgrades-260526** arc (workstream **A.3 — Oracle Approximating Shrinkage**). Adds `covariance_shrinkage=\"oas\"` as a new estimator option, drop-in alongside `\"ledoit_wolf\"` via `sklearn.covariance.OAS`.

**Why this matters**: Chen et al. 2010 derived a shrinkage intensity formula that minimizes MSE against an oracle estimator under Gaussian assumptions. Empirically lower MSE than Ledoit-Wolf when T/N is small. Our universe is ~27 names × T~252 → T/N≈9 — modestly small-sample regime where OAS's theoretical edge can be realizable.

**Whether OAS actually beats LW on our universe is an empirical question** for the A.4 backtester sweep. This PR just makes OAS available as a candidate; production default remains `\"ledoit_wolf\"`.

## What changed

- New `\"oas\"` branch in `_estimate_covariance` (`executor/portfolio_optimizer.py`)
- `risk.yaml.example` documents the new option
- Production default unchanged

## Test plan

- [x] OAS produces symmetric PSD Σ of correct shape
- [x] End-to-end integration with `solve_target_weights`
- [x] Composes with `sigma_horizon_days` from A.1 (Σ_H = H × Σ_OAS)
- [x] **Distinctness from LW** on correlated small-sample data (guards against silent aliasing — important because sklearn could theoretically deprecate OAS to LW internally)
- [x] Full alpha-engine suite passes (969/969; +4 new OAS tests)
- [x] Pre-push dry-run gate passes

### Note on the distinctness test

First iteration of the LW-vs-OAS distinctness test used i.i.d. zero-correlation data and **failed** because both estimators correctly shrink fully to scaled-identity when the true population covariance IS diagonal — they agree by design in that regime. Rewrote the test with a common-factor structure (`r_t = f_t + ε_t` with vol(f)=0.01, vol(ε)=0.005 → ρ≈0.8) so the two intensity formulas have something to disagree about. The fix is the actual point of the test — silent aliasing would NOT be caught by the original setup.

## Plan reference

`alpha-engine-docs/private/optimizer-sota-upgrades-260526.md` §A.3

## Workstream A status

- ✅ A.1 horizon scaling (#215)
- ✅ A.2 EWMA dynamic Σ (#216)
- ⏳ A.3 OAS (this PR)
- ⏳ A.4 backtester sweep harness (next — produces the cutover verdict over `cov_estimator × sigma_horizon_days × ewma_lambda_decay`)
- ⏳ A.2b Wolf 2018 LW-on-EWMA (P2 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)