### PR TITLE
feat(optimizer): wire predicted_alpha_std + ablation into shadow log (B.4)

### DIFF
--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -123,6 +123,9 @@ def _build_and_solve(
 
     signals_by_ticker = signals_raw.get("signals", {})
     alpha_hat = _build_alpha_hat(tickers, predictions_by_ticker, spy_idx, cash_idx)
+    alpha_uncertainty = _build_alpha_uncertainty(
+        tickers, predictions_by_ticker, spy_idx, cash_idx,
+    )
     returns_panel = _build_returns_panel(tickers, price_histories, cash_idx)
     w_prev = _build_w_prev(tickers, current_positions, portfolio_nav, cash_idx, optimizer_cfg)
     sectors = _build_sectors(tickers, signals_by_ticker, spy_idx, cash_idx)
@@ -146,13 +149,35 @@ def _build_and_solve(
         spy_idx=spy_idx,
         cash_idx=cash_idx,
         cfg=optimizer_cfg,
+        alpha_uncertainty=alpha_uncertainty,
     )
 
     would_be_trades = _compute_trade_deltas(
         tickers, result.weights, w_prev, portfolio_nav, optimizer_cfg,
     )
 
-    return {
+    # B.4 ablation: when the α̂-uncertainty penalty is configured ON, solve
+    # a second time with γ=0 so the shadow log carries both perspectives
+    # side-by-side. Operators read the ablation diff to decide whether the
+    # uncertainty signal is shaping sizing in a sane way before B.5 cutover.
+    # No-op when γ=0 (default) or when no per-ticker σ_α̂ is available —
+    # the active solve already IS the no-penalty solve in that regime.
+    ablation = _maybe_run_ablation(
+        tickers=tickers,
+        alpha_hat=alpha_hat,
+        alpha_uncertainty=alpha_uncertainty,
+        returns_panel=returns_panel,
+        w_prev=w_prev,
+        sectors=sectors,
+        stance_caps=stance_caps,
+        eligibility=eligibility,
+        spy_idx=spy_idx,
+        cash_idx=cash_idx,
+        optimizer_cfg=optimizer_cfg,
+        active_weights=result.weights,
+    )
+
+    out: dict = {
         "run_date": run_date,
         "written_at_utc": datetime.now(timezone.utc).isoformat(),
         "shadow_status": "ok",
@@ -162,6 +187,7 @@ def _build_and_solve(
         "target_weights": [float(x) for x in result.weights],
         "current_weights": [float(x) for x in w_prev],
         "alpha_hat": [float(x) for x in alpha_hat],
+        "alpha_uncertainty": _alpha_uncertainty_to_json(alpha_uncertainty),
         "eligibility": [bool(x) for x in eligibility],
         "eligibility_reasons": list(eligibility_reasons),
         "stance_caps": [float(x) for x in stance_caps],
@@ -170,6 +196,102 @@ def _build_and_solve(
         "diagnostics": result.diagnostics,
         "legacy_orders": [_redact_order(o) for o in legacy_orders],
         "optimizer_cfg": optimizer_cfg,
+    }
+    if ablation is not None:
+        out["uncertainty_ablation"] = ablation
+    return out
+
+
+def _alpha_uncertainty_to_json(arr: np.ndarray) -> list:
+    """Convert per-ticker σ_α̂ array to a JSON-safe list. NaN entries are
+    emitted as None so consumers can distinguish 'unknown' from 0 (which
+    means 'sentinel — no uncertainty' for SPY/CASH)."""
+    out: list = []
+    for v in arr:
+        if not np.isfinite(v):
+            out.append(None)
+        else:
+            out.append(float(v))
+    return out
+
+
+def _maybe_run_ablation(
+    *,
+    tickers: list[str],
+    alpha_hat: np.ndarray,
+    alpha_uncertainty: np.ndarray,
+    returns_panel: np.ndarray,
+    w_prev: np.ndarray,
+    sectors: list[str],
+    stance_caps: np.ndarray,
+    eligibility: np.ndarray,
+    spy_idx: int,
+    cash_idx: int,
+    optimizer_cfg: dict,
+    active_weights: np.ndarray,
+) -> dict | None:
+    """Run a second solve with γ=0 for side-by-side comparison.
+
+    Skipped (returns None) when γ=0 already (no difference would result)
+    or when alpha_uncertainty has no usable signal (all-NaN). In both
+    cases the canonical solve IS the no-penalty solve.
+    """
+    gamma = float(optimizer_cfg.get("alpha_uncertainty_penalty", 0.0))
+    if gamma <= 0.0:
+        return None
+    has_any_signal = bool(np.any(np.isfinite(alpha_uncertainty) & (alpha_uncertainty > 0.0)))
+    if not has_any_signal:
+        return None
+
+    no_penalty_cfg = {**optimizer_cfg, "alpha_uncertainty_penalty": 0.0}
+    try:
+        no_penalty_result = solve_target_weights(
+            tickers=tickers,
+            alpha_hat=alpha_hat,
+            returns_panel=returns_panel,
+            w_prev=w_prev,
+            sectors=sectors,
+            stance_caps=stance_caps,
+            eligibility=eligibility,
+            spy_idx=spy_idx,
+            cash_idx=cash_idx,
+            cfg=no_penalty_cfg,
+            alpha_uncertainty=alpha_uncertainty,  # passed but γ=0 → unused
+        )
+    except Exception as exc:
+        logger.warning(
+            "Uncertainty-ablation solve failed (non-blocking, shadow continues): %s",
+            exc,
+        )
+        return None
+
+    no_penalty_weights = np.asarray(no_penalty_result.weights, dtype=np.float64)
+    active = np.asarray(active_weights, dtype=np.float64)
+    deltas = active - no_penalty_weights
+    # Per-ticker rows make the diff readable in the shadow JSON. Only
+    # include names that actually moved (≥1bp) to keep the log compact.
+    per_ticker = []
+    for i, t in enumerate(tickers):
+        if abs(deltas[i]) >= 1e-4:
+            per_ticker.append({
+                "ticker": t,
+                "with_penalty": float(active[i]),
+                "no_penalty": float(no_penalty_weights[i]),
+                "delta": float(deltas[i]),
+                "sigma_alpha": (
+                    float(alpha_uncertainty[i])
+                    if np.isfinite(alpha_uncertainty[i])
+                    else None
+                ),
+            })
+    return {
+        "gamma": gamma,
+        "no_penalty_weights": [float(x) for x in no_penalty_weights],
+        "no_penalty_diagnostics": no_penalty_result.diagnostics,
+        "l1_delta": float(np.sum(np.abs(deltas))),
+        "max_abs_delta": float(np.max(np.abs(deltas))),
+        "n_names_moved": len(per_ticker),
+        "per_ticker_delta": per_ticker,
     }
 
 
@@ -251,6 +373,46 @@ def _build_alpha_hat(
         if not math.isfinite(alpha[i]):
             alpha[i] = 0.0
     return alpha
+
+
+def _build_alpha_uncertainty(
+    tickers: list[str],
+    predictions_by_ticker: dict[str, dict],
+    spy_idx: int,
+    cash_idx: int,
+) -> np.ndarray:
+    """Read per-ticker σ_α̂ from the predictor's BayesianRidge posterior
+    (predicted_alpha_std field shipped in B.1, predictor PR #199).
+
+    Returns a length-N array with:
+      • 0.0 for SPY and CASH (sentinels — no uncertainty)
+      • finite σ_α̂ ≥ 0 when the predictor emitted a usable value
+      • NaN when the predictor's predicted_alpha_std was missing, None,
+        or non-numeric (legacy Ridge fallback case during the 1-week
+        soak between B.1 landing and the first BayesianRidge model
+        promoted by the Saturday training cycle)
+
+    The downstream B.3 solve_target_weights treats NaN entries as
+    zero-penalty for that name — partial-rollout is tolerated by design.
+    Plan: alpha-engine-docs/private/optimizer-sota-upgrades-260526.md §B.4.
+    """
+    sigma = np.full(len(tickers), np.nan)
+    for i, t in enumerate(tickers):
+        if i == spy_idx or i == cash_idx:
+            sigma[i] = 0.0
+            continue
+        pred = predictions_by_ticker.get(t, {})
+        raw_std = pred.get("predicted_alpha_std")  # B.1 field; may be missing/None
+        if raw_std is None:
+            continue
+        try:
+            v = float(raw_std)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(v) and v >= 0.0:
+            sigma[i] = v
+        # else leave NaN — partial-rollout case; B.3 handles by skipping penalty
+    return sigma
 
 
 def _build_returns_panel(

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -26,6 +26,7 @@ import pytest
 
 from executor.optimizer_shadow import (
     _build_alpha_hat,
+    _build_alpha_uncertainty,
     _build_eligibility,
     _build_sectors,
     _build_stance_caps,
@@ -283,3 +284,192 @@ def test_wrapper_never_raises_writes_sentinel_on_failure():
     body = json.loads(s3.put_object.call_args_list[0].kwargs["Body"])
     assert body["shadow_status"] == "failed"
     assert "SPY price history" in body["error"]
+
+
+# ─── B.4 uncertainty wiring + ablation tests ────────────────────────────────
+# Plan: alpha-engine-docs/private/optimizer-sota-upgrades-260526.md §B.4
+#
+# The shadow wrapper reads B.1's predicted_alpha_std from
+# predictions_by_ticker, threads it to solve_target_weights, and logs an
+# ablation comparison (with/without penalty) when γ > 0.
+
+
+class TestBuildAlphaUncertainty:
+    """The new helper that reads predicted_alpha_std from the predictor
+    output. NaN-tolerant to handle the 1-week soak case."""
+
+    def _tickers_with_sentinels(self):
+        return ["AAPL", "MSFT", "JNJ", "SPY", "CASH"]
+
+    def test_predicted_alpha_std_present_populates_array(self):
+        tickers = self._tickers_with_sentinels()
+        preds = {
+            "AAPL": {"predicted_alpha": 0.04, "predicted_alpha_std": 0.021},
+            "MSFT": {"predicted_alpha": 0.02, "predicted_alpha_std": 0.018},
+            "JNJ":  {"predicted_alpha": -0.01, "predicted_alpha_std": 0.030},
+        }
+        sigma = _build_alpha_uncertainty(tickers, preds, spy_idx=3, cash_idx=4)
+        assert sigma[0] == pytest.approx(0.021)
+        assert sigma[1] == pytest.approx(0.018)
+        assert sigma[2] == pytest.approx(0.030)
+        assert sigma[3] == 0.0  # SPY sentinel
+        assert sigma[4] == 0.0  # CASH sentinel
+
+    def test_missing_field_yields_nan_per_partial_rollout(self):
+        """During the 1-week soak window the legacy Ridge model is still
+        in production — predictions JSON has no predicted_alpha_std for
+        any ticker. Result: all-NaN for non-sentinel tickers, optimizer's
+        B.3 path falls through to zero penalty."""
+        tickers = self._tickers_with_sentinels()
+        preds = {
+            "AAPL": {"predicted_alpha": 0.04},  # no std (legacy Ridge)
+            "MSFT": {"predicted_alpha": 0.02},
+            "JNJ":  {"predicted_alpha": -0.01},
+        }
+        sigma = _build_alpha_uncertainty(tickers, preds, spy_idx=3, cash_idx=4)
+        assert np.isnan(sigma[0])
+        assert np.isnan(sigma[1])
+        assert np.isnan(sigma[2])
+        # Sentinels still zero
+        assert sigma[3] == 0.0 and sigma[4] == 0.0
+
+    def test_none_field_yields_nan(self):
+        """Predictor explicitly emits None when legacy Ridge model loaded
+        (B.1 fallback path). Treat as missing."""
+        tickers = ["AAPL", "SPY", "CASH"]
+        preds = {"AAPL": {"predicted_alpha": 0.04, "predicted_alpha_std": None}}
+        sigma = _build_alpha_uncertainty(tickers, preds, spy_idx=1, cash_idx=2)
+        assert np.isnan(sigma[0])
+        assert sigma[1] == 0.0
+        assert sigma[2] == 0.0
+
+    def test_negative_or_non_numeric_yields_nan(self):
+        """Invalid σ (negative, non-numeric) → NaN. The optimizer's B.3
+        coercion path will then treat them as zero penalty."""
+        tickers = ["A", "B", "C", "SPY", "CASH"]
+        preds = {
+            "A": {"predicted_alpha": 0.01, "predicted_alpha_std": -0.05},
+            "B": {"predicted_alpha": 0.02, "predicted_alpha_std": "not-a-number"},
+            "C": {"predicted_alpha": 0.03, "predicted_alpha_std": float("inf")},
+        }
+        sigma = _build_alpha_uncertainty(tickers, preds, spy_idx=3, cash_idx=4)
+        assert np.isnan(sigma[0])
+        assert np.isnan(sigma[1])
+        assert np.isnan(sigma[2])
+
+    def test_partial_rollout_some_tickers_have_std_others_dont(self):
+        """Mixed case: AAPL has BR std (fresh BayesianRidge inference),
+        MSFT was scored by legacy Ridge inside the same predictions JSON
+        (transient mid-rollout state). Must work."""
+        tickers = ["AAPL", "MSFT", "SPY", "CASH"]
+        preds = {
+            "AAPL": {"predicted_alpha": 0.04, "predicted_alpha_std": 0.025},
+            "MSFT": {"predicted_alpha": 0.02},  # legacy path
+        }
+        sigma = _build_alpha_uncertainty(tickers, preds, spy_idx=2, cash_idx=3)
+        assert sigma[0] == pytest.approx(0.025)
+        assert np.isnan(sigma[1])
+        assert sigma[2] == 0.0 and sigma[3] == 0.0
+
+
+class TestShadowWiringAndAblation:
+    """End-to-end: shadow wrapper threads predicted_alpha_std into the
+    optimizer and emits the ablation block when γ > 0."""
+
+    def _inputs_with_std(self, gamma=0.0):
+        inputs = _baseline_inputs()
+        # Augment predictions with BR std field per B.1
+        inputs["predictions_by_ticker"]["AAPL"]["predicted_alpha_std"] = 0.040  # diffuse
+        inputs["predictions_by_ticker"]["MSFT"]["predicted_alpha_std"] = 0.005  # confident
+        inputs["predictions_by_ticker"]["JNJ"]["predicted_alpha_std"] = 0.020
+        if gamma > 0:
+            inputs["config"] = {
+                **inputs["config"],
+                "portfolio_optimizer": {"alpha_uncertainty_penalty": gamma},
+            }
+        return inputs
+
+    def test_shadow_log_includes_alpha_uncertainty_field(self):
+        """Per-ticker σ_α̂ emitted in the shadow JSON for full diagnostic
+        visibility. NaN-as-None per JSON-safe conversion."""
+        inputs = self._inputs_with_std(gamma=0.0)
+        s3 = MagicMock()
+        log = run_shadow_optimizer(s3_client=s3, **inputs)
+        assert log is not None
+        assert "alpha_uncertainty" in log
+        assert len(log["alpha_uncertainty"]) == log["n_tickers"]
+        # Ordering: same as `tickers` list. SPY/CASH at end are 0.0 (sentinels).
+        # The 3 real tickers should have populated σ_α̂ (sorted alphabetically
+        # by _build_universe → AAPL, JNJ, MSFT order).
+        tickers = log["tickers"]
+        spy_pos = tickers.index("SPY")
+        cash_pos = tickers.index("CASH")
+        assert log["alpha_uncertainty"][spy_pos] == 0.0
+        assert log["alpha_uncertainty"][cash_pos] == 0.0
+        # AAPL appears in the universe with predicted_alpha_std=0.040
+        assert log["alpha_uncertainty"][tickers.index("AAPL")] == pytest.approx(0.040)
+        assert log["alpha_uncertainty"][tickers.index("MSFT")] == pytest.approx(0.005)
+        assert log["alpha_uncertainty"][tickers.index("JNJ")]  == pytest.approx(0.020)
+
+    def test_ablation_skipped_when_gamma_zero(self):
+        """Default γ=0 → no ablation block (active solve already IS no-penalty)."""
+        inputs = self._inputs_with_std(gamma=0.0)
+        s3 = MagicMock()
+        log = run_shadow_optimizer(s3_client=s3, **inputs)
+        assert log is not None
+        assert "uncertainty_ablation" not in log
+        # Diagnostics should also report penalty_used=False
+        assert log["diagnostics"]["alpha_uncertainty_penalty_used"] is False
+
+    def test_ablation_emitted_when_gamma_positive(self):
+        """γ > 0 with usable σ_α̂ signal → ablation block populated with
+        side-by-side no-penalty weights + diff summary."""
+        inputs = self._inputs_with_std(gamma=500.0)
+        s3 = MagicMock()
+        log = run_shadow_optimizer(s3_client=s3, **inputs)
+        assert log is not None
+        ab = log.get("uncertainty_ablation")
+        assert ab is not None
+        assert ab["gamma"] == 500.0
+        assert len(ab["no_penalty_weights"]) == log["n_tickers"]
+        assert "no_penalty_diagnostics" in ab
+        assert ab["l1_delta"] >= 0
+        assert ab["max_abs_delta"] >= 0
+        # Diagnostics on the canonical (with-penalty) solve must report
+        # penalty_used=True
+        assert log["diagnostics"]["alpha_uncertainty_penalty_used"] is True
+
+    def test_ablation_skipped_when_no_usable_std_signal(self):
+        """γ > 0 but predictions JSON has no predicted_alpha_std anywhere
+        (legacy Ridge inference) → ablation skipped (canonical IS
+        no-penalty already since the B.3 path treats all-NaN as inactive)."""
+        inputs = _baseline_inputs()
+        inputs["config"] = {
+            **inputs["config"],
+            "portfolio_optimizer": {"alpha_uncertainty_penalty": 500.0},
+        }
+        # No predicted_alpha_std added to any ticker
+        s3 = MagicMock()
+        log = run_shadow_optimizer(s3_client=s3, **inputs)
+        assert log is not None
+        assert "uncertainty_ablation" not in log
+        # And the canonical solve also reports no penalty active
+        assert log["diagnostics"]["alpha_uncertainty_penalty_used"] is False
+
+    def test_per_ticker_delta_only_lists_names_that_moved(self):
+        """The shadow JSON's per_ticker_delta list only includes names that
+        moved ≥ 1bp — keeps the log compact while preserving observability
+        on the names that actually changed under the penalty."""
+        # Construct a case where most names don't move: γ very low so the
+        # penalty is dominated by α̂ gain
+        inputs = self._inputs_with_std(gamma=0.01)
+        s3 = MagicMock()
+        log = run_shadow_optimizer(s3_client=s3, **inputs)
+        assert log is not None
+        ab = log.get("uncertainty_ablation")
+        if ab is not None:
+            # All listed names actually moved by ≥ 1bp
+            for entry in ab["per_ticker_delta"]:
+                assert abs(entry["delta"]) >= 1e-4
+            # n_names_moved must equal length of the list
+            assert ab["n_names_moved"] == len(ab["per_ticker_delta"])


### PR DESCRIPTION
## Summary

Fourth PR of **workstream B (α̂ posterior-uncertainty)**. Threads B.1's `predicted_alpha_std` field from `predictions/{date}.json` through `optimizer_shadow.py` into the B.3 `solve_target_weights` call, then logs a **side-by-side ablation** (with vs without the uncertainty penalty) when γ > 0 — so operators can read how the new term reshapes sizing before the B.5 cutover gate.

## What changed

New helpers in `executor/optimizer_shadow.py`:

- **`_build_alpha_uncertainty(...)`** — reads `predicted_alpha_std` per ticker; SPY/CASH sentinels are 0.0; missing/None/non-numeric/negative → NaN (downstream B.3 treats NaN as zero penalty per the partial-rollout contract from B.1 #199's 1-week soak window).
- **`_alpha_uncertainty_to_json(...)`** — JSON-safe conversion: NaN → None in the shadow log so consumers can distinguish \"unknown\" from 0 (sentinel).
- **`_maybe_run_ablation(...)`** — when γ > 0 AND ≥1 ticker has usable σ_α̂, solves a second time with γ=0 and emits `l1_delta`, `max_abs_delta`, `n_names_moved` + per-ticker entries for names that moved ≥ 1bp. Skipped when γ=0 (default) or when all-NaN signal — no marginal info in either case (the canonical solve IS the no-penalty solve). Ablation solve catches its own exceptions — shadow log degrades to \"ablation absent\" rather than failing the whole wrapper.

Shadow log shape additions (additive, backwards-compat):

```jsonc
{
  // ... existing fields ...
  \"alpha_uncertainty\": [0.025, 0.030, null, 0.0, 0.0],  // NaN → null
  \"uncertainty_ablation\": {  // only present when γ > 0 + usable signal
    \"gamma\": 500.0,
    \"no_penalty_weights\": [...],
    \"no_penalty_diagnostics\": {...},
    \"l1_delta\": 0.124,
    \"max_abs_delta\": 0.064,
    \"n_names_moved\": 4,
    \"per_ticker_delta\": [
      {\"ticker\": \"AAPL\", \"with_penalty\": 0.016, \"no_penalty\": 0.080,
       \"delta\": -0.064, \"sigma_alpha\": 0.040}
    ]
  }
}
```

## What is NOT in this PR (by design)

- **B.4b**: alpha-engine-backtester γ-sweep harness (mirror of A.4 cov-sweep — sweep `cfg[\"alpha_uncertainty_penalty\"]` over a logarithmic grid + report Sortino-ranking)
- **B.4c**: `optimizer_cutover.py` wiring so cutover mode also threads `alpha_uncertainty` into the order book translation. Currently shadow-only — cutover path is unchanged.

Same scope-control pattern as A.2/A.2b, A.4/A.4b, B.2/B.2b — analysis substrate first, integration follow-ups.

## Test plan

10 new tests in `tests/test_optimizer_shadow.py`:

**TestBuildAlphaUncertainty (5)**:
- [x] `predicted_alpha_std` populates the array correctly with sentinels
- [x] Missing field (full legacy Ridge case) → NaN per partial-rollout
- [x] Explicit `None` → NaN
- [x] Negative / non-numeric / inf → NaN
- [x] Partial-rollout: some tickers have std, others don't

**TestShadowWiringAndAblation (5)**:
- [x] Shadow log includes `alpha_uncertainty` field with sentinel + real values
- [x] **Ablation block absent when γ=0** (no marginal info)
- [x] **Ablation block populated when γ > 0** with l1_delta + per-ticker detail
- [x] **Ablation skipped when γ > 0 but no usable std signal** (predictions JSON has no predicted_alpha_std anywhere — 1-week soak case)
- [x] `per_ticker_delta` only lists names that actually moved ≥ 1bp

Suite: 989/989 pass (was 979; +10 new B.4 tests).

## Plan reference

`alpha-engine-docs/private/optimizer-sota-upgrades-260526.md` §B.4

## Workstream B status

- ✅ B.1 BayesianRidge cutover in predictor (predictor #199, merged)
- ✅ B.2a calibration primitive (backtester #249, merged)
- ⏳ B.2b synthetic-backtest wiring (P2)
- ✅ B.3 uncertainty-penalty term (alpha-engine #218, merged)
- ⏳ **B.4 this PR** — shadow wiring + ablation log
- ⏳ B.4b γ-sweep harness in backtester (P2)
- ⏳ B.4c optimizer_cutover wiring (P2)
- ⏳ B.5 cutover gate (next sequential step — requires 2-3 days of shadow logs to read the ablation deltas before flipping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)