### PR TITLE
feat(optimizer): surface predicted_alpha_std in cutover records (B.4c)

### DIFF
--- a/executor/optimizer_cutover.py
+++ b/executor/optimizer_cutover.py
@@ -232,12 +232,21 @@ def _build_entry_record(
         "predicted_direction": pred.get("predicted_direction"),
         "prediction_confidence": pred.get("prediction_confidence"),
         "predicted_alpha": pred.get("predicted_alpha"),
+        # B.4c (optimizer-sota-upgrades-260526.md §B.4c): surface the
+        # BayesianRidge posterior std at the order-record layer so
+        # downstream dashboards / emails / EOD reconciliation can show
+        # operators the predictor's confidence on each sized name.
+        # None when the predictor still emits via legacy Ridge (1-week
+        # soak after B.1 #199); downstream consumers handle None per the
+        # additive-field S3 contract.
+        "predicted_alpha_std": pred.get("predicted_alpha_std"),
         "stance": pred.get("stance"),
         "catalyst_date": pred.get("catalyst_date"),
         "sizing_source": "portfolio_optimizer",
         "sizing_factors": {
             "optimizer_target_weight": target_weight,
             "optimizer_delta_dollars": round(delta_dollars, 2),
+            "alpha_uncertainty": pred.get("predicted_alpha_std"),
         },
     }
 
@@ -300,5 +309,7 @@ def _build_urgent_exit_record(
         "predicted_direction": pred.get("predicted_direction"),
         "prediction_confidence": pred.get("prediction_confidence"),
         "predicted_alpha": pred.get("predicted_alpha"),
+        # B.4c — same surfacing rationale as _build_entry_record above.
+        "predicted_alpha_std": pred.get("predicted_alpha_std"),
         "sizing_source": "portfolio_optimizer",
     }

--- a/tests/test_optimizer_cutover.py
+++ b/tests/test_optimizer_cutover.py
@@ -365,3 +365,109 @@ def test_research_metadata_propagated_to_entry():
     assert e["sector"] == "Health Care"
     assert e["predicted_direction"] == "UP"
     assert e["stance"] == "quality"
+
+
+# ─── B.4c α̂-uncertainty surfacing in cutover records ───────────────────────
+# Plan: alpha-engine-docs/private/optimizer-sota-upgrades-260526.md §B.4c
+#
+# Pure observability layer. Cutover already consumes uncertainty-shaped
+# target weights (the shadow_log was produced by B.4's run_shadow_optimizer
+# which threads alpha_uncertainty into solve). B.4c surfaces predicted_alpha_std
+# in the per-trade entry/exit records so dashboards / EOD email / SQLite
+# trade audit can show operators the predictor's confidence on each sized
+# name. Additive field — None when predictor emits via legacy Ridge during
+# the 1-week B.1 soak.
+
+
+def test_entry_record_surfaces_predicted_alpha_std():
+    """An entry record must carry the BayesianRidge posterior std field
+    when it's present in predictions_by_ticker. Also appears in the
+    sizing_factors block so the dashboard / email layer can read either."""
+    ob = OrderBook(data={"date": "2026-05-26"})
+    ibkr = _make_ibkr({"AAPL": 200.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "AAPL",
+            "action": "BUY",
+            "delta_dollars": 50_000.0,
+            "delta_weight": 0.05,
+            "target_weight": 0.05,
+            "current_weight": 0.0,
+        }],
+    }
+    predictions_by_ticker = {
+        "AAPL": {
+            "predicted_alpha": 0.038,
+            "predicted_alpha_std": 0.022,  # B.1 BayesianRidge field
+            "predicted_direction": "UP",
+            "prediction_confidence": 0.74,
+        },
+    }
+    kwargs = _baseline_kwargs(ob, ibkr, atr_map={"AAPL": 0.018})
+    kwargs["predictions_by_ticker"] = predictions_by_ticker
+    entries, _ = apply_optimizer_targets_to_orderbook(log=log, **kwargs)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["predicted_alpha"] == 0.038
+    assert e["predicted_alpha_std"] == 0.022
+    assert e["sizing_factors"]["alpha_uncertainty"] == 0.022
+
+
+def test_entry_record_predicted_alpha_std_is_none_during_legacy_ridge_soak():
+    """During the 1-week soak between B.1 landing and the first BR pickle
+    promoted in production, predicted_alpha_std is absent from predictions
+    JSON. Entry record must show None, not raise."""
+    ob = OrderBook(data={"date": "2026-05-26"})
+    ibkr = _make_ibkr({"MSFT": 400.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "MSFT",
+            "action": "BUY",
+            "delta_dollars": 40_000.0,
+            "delta_weight": 0.04,
+            "target_weight": 0.04,
+            "current_weight": 0.0,
+        }],
+    }
+    predictions_by_ticker = {
+        "MSFT": {
+            "predicted_alpha": 0.025,
+            # No predicted_alpha_std — legacy Ridge era
+            "predicted_direction": "UP",
+        },
+    }
+    kwargs = _baseline_kwargs(ob, ibkr)
+    kwargs["predictions_by_ticker"] = predictions_by_ticker
+    entries, _ = apply_optimizer_targets_to_orderbook(log=log, **kwargs)
+    e = entries[0]
+    assert e["predicted_alpha_std"] is None
+    assert e["sizing_factors"]["alpha_uncertainty"] is None
+
+
+def test_exit_record_surfaces_predicted_alpha_std():
+    """Exit records mirror the entry record additive field."""
+    ob = OrderBook(data={"date": "2026-05-26"})
+    ibkr = _make_ibkr({"JNJ": 150.0})
+    log = {
+        "would_be_trades": [{
+            "ticker": "JNJ",
+            "action": "SELL",
+            "delta_dollars": -22_500.0,
+            "delta_weight": -0.022,
+            "target_weight": 0.0,
+            "current_weight": 0.022,
+        }],
+    }
+    predictions_by_ticker = {
+        "JNJ": {
+            "predicted_alpha": -0.015,
+            "predicted_alpha_std": 0.030,
+        },
+    }
+    current_positions = {"JNJ": {"shares": 150, "sector": "Health Care"}}
+    kwargs = _baseline_kwargs(ob, ibkr, current_positions=current_positions)
+    kwargs["predictions_by_ticker"] = predictions_by_ticker
+    _, exits = apply_optimizer_targets_to_orderbook(log=log, **kwargs)
+    assert len(exits) == 1
+    x = exits[0]
+    assert x["predicted_alpha_std"] == 0.030


### PR DESCRIPTION
## Summary

Sixth PR of **workstream B**. Pure observability — cutover already consumes uncertainty-shaped target weights (the `shadow_log` was produced by B.4's `run_shadow_optimizer` with `alpha_uncertainty` threaded into solve). B.4c surfaces the predictor's σ_α̂ in the per-trade entry/exit records so dashboards, EOD email, SQLite trade audit, and the existing `sizing_factors` block can show operators the predictor's confidence on each sized name.

## What changed

In `executor/optimizer_cutover.py`:

- **`_build_entry_record`** adds `predicted_alpha_std` (from `predictions_by_ticker`) + `alpha_uncertainty` in `sizing_factors`
- **`_build_urgent_exit_record`** adds `predicted_alpha_std`
- Additive field per S3 contract-safety policy (downstream consumers ignore unknown fields); `None` during the 1-week B.1 soak when predictor still emits via legacy Ridge

Example entry record (new fields highlighted):

```jsonc
{
  \"ticker\": \"AAPL\",
  \"signal\": \"ENTER\",
  \"shares\": 250,
  \"dollar_size\": 50000.0,
  \"predicted_alpha\": 0.038,
  \"predicted_alpha_std\": 0.022,         // ← NEW (B.4c)
  \"sizing_source\": \"portfolio_optimizer\",
  \"sizing_factors\": {
    \"optimizer_target_weight\": 0.05,
    \"optimizer_delta_dollars\": 50000.0,
    \"alpha_uncertainty\": 0.022           // ← NEW (B.4c)
  }
}
```

## Test plan

3 new tests in `tests/test_optimizer_cutover.py`:

- [x] Entry record surfaces `predicted_alpha_std` + `sizing_factors.alpha_uncertainty` when present in `predictions_by_ticker`
- [x] Entry record shows `None` for both fields during legacy Ridge soak (no crash, additive-field contract preserved)
- [x] Exit record mirrors the entry record's `predicted_alpha_std` field
- [x] Full alpha-engine suite passes (992/992; +3 new B.4c tests)
- [x] Pre-push dry-run gate passes

## Plan reference

`alpha-engine-docs/private/optimizer-sota-upgrades-260526.md` §B.4c

## Workstream B status — end-to-end functional

```
predictor BayesianRidge (B.1) ✅
  ↓ predicted_alpha_std in predictions JSON
shadow integration + ablation log (B.4) ✅
  ↓ uncertainty-shaped target weights
cutover order records (B.4c, this PR) ⏳
  ↓ σ_α̂ surfaced in entry/exit records
[B.5 cutover gate — operator-driven]
```

Plus analysis substrate:
- ✅ B.2a calibration primitive (backtester #249, merged)
- ⏳ B.4b γ-sweep harness (backtester #250, just opened)
- ⏳ B.2b synthetic-backtest wiring (P2 follow-up)

**B.5 is the cutover gate** — operator-driven decision after observing 2-3 trading days of shadow log ablation deltas + the B.4b γ-sweep verdict on a 2y backtest. The next code milestone is **workstream C** (factor-risk decomposition, Σ = B F Bᵀ + D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)