### PR TITLE
feat(rationale): project optimizer reconciliation fields into payload

### DIFF
--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -46,7 +46,7 @@ from typing import Any, Mapping, Sequence
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_VERSION = "1.0.0"
+SCHEMA_VERSION = "1.1.0"
 
 # Default S3 prefix. Lives under ``trades/`` alongside the order book
 # itself (``trades/order_book/{date}.json``) so the rationale and the
@@ -507,6 +507,26 @@ def build_order_book_rationale(
             f"n_{r['terminal_state']}", 0
         ) + 1
 
+    # Optimizer reconciliation projection — surfaces target-vs-current
+    # NAV state + the rebalance band so consumers can render the
+    # three-way "target / current / planned trade / residual gap" view
+    # without re-reading the optimizer shadow log. All four fields are
+    # None on legacy non-optimizer runs (the shadow log is absent).
+    portfolio_nav: float | None = None
+    optimizer_trades: list[dict[str, Any]] | None = None
+    rebalance_band_pct: float | None = None
+    if isinstance(optimizer_shadow_log, Mapping):
+        _nav = optimizer_shadow_log.get("portfolio_nav")
+        if isinstance(_nav, (int, float)):
+            portfolio_nav = float(_nav)
+        _trades = optimizer_shadow_log.get("would_be_trades")
+        if isinstance(_trades, list):
+            optimizer_trades = [dict(t) for t in _trades if isinstance(t, Mapping)]
+        _cfg = optimizer_shadow_log.get("optimizer_cfg") or {}
+        _band = _cfg.get("rebalance_band_pct") if isinstance(_cfg, Mapping) else None
+        if isinstance(_band, (int, float)):
+            rebalance_band_pct = float(_band)
+
     return {
         "schema_version": SCHEMA_VERSION,
         "run_id": run_id,
@@ -516,6 +536,9 @@ def build_order_book_rationale(
         "signal_date": signal_date,
         "prediction_date": prediction_date,
         "market_regime": market_regime,
+        "portfolio_nav": portfolio_nav,
+        "optimizer_trades": optimizer_trades,
+        "rebalance_band_pct": rebalance_band_pct,
         "summary": summary,
         "tickers": records,
     }

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -461,6 +461,66 @@ class TestOptimizerShadowLogSynthesis:
         # Legacy rule slug survives — synth row was filtered.
         assert nvda["exclusion"]["rule"] == "legacy_rule"
 
+    def test_reconciliation_fields_projected_from_shadow_log(self):
+        # Producer must surface portfolio_nav, would_be_trades, and the
+        # rebalance band into the rationale payload so the dashboard
+        # renders the target-vs-current-vs-planned reconciliation view
+        # without a second S3 read of the optimizer shadow log.
+        scenario = self._optimizer_scenario()
+        scenario["optimizer_shadow_log"] = {
+            **scenario["optimizer_shadow_log"],
+            "portfolio_nav": 125_000.0,
+            "would_be_trades": [
+                {"ticker": "AAPL", "action": "BUY",
+                 "delta_weight": 0.041, "delta_dollars": 5125.0,
+                 "target_weight": 0.041, "current_weight": 0.0},
+                {"ticker": "MSFT", "action": "SELL",
+                 "delta_weight": -0.032, "delta_dollars": -4000.0,
+                 "target_weight": 0.0, "current_weight": 0.032},
+            ],
+            "optimizer_cfg": {
+                **scenario["optimizer_shadow_log"]["optimizer_cfg"],
+                "rebalance_band_pct": 0.005,
+            },
+        }
+        payload = build_order_book_rationale(**scenario)
+        assert payload["portfolio_nav"] == 125_000.0
+        assert payload["rebalance_band_pct"] == 0.005
+        trades = payload["optimizer_trades"]
+        assert isinstance(trades, list) and len(trades) == 2
+        aapl_trade = next(t for t in trades if t["ticker"] == "AAPL")
+        assert aapl_trade["action"] == "BUY"
+        assert aapl_trade["delta_dollars"] == 5125.0
+        assert aapl_trade["target_weight"] == 0.041
+
+    def test_reconciliation_fields_none_when_no_shadow_log(self, scenario):
+        # Legacy non-optimizer run → fields default to None so the
+        # consumer can detect "no reconciliation view available" without
+        # KeyErrors.
+        payload = build_order_book_rationale(**scenario)
+        assert payload["portfolio_nav"] is None
+        assert payload["optimizer_trades"] is None
+        assert payload["rebalance_band_pct"] is None
+
+    def test_reconciliation_fields_partial_shadow_log_safe(self):
+        # Defensive: a shadow log that omits portfolio_nav /
+        # would_be_trades / rebalance_band_pct (e.g. an older
+        # producer or a sentinel-state log) must not crash the
+        # rationale build. Missing fields → None.
+        scenario = self._optimizer_scenario()
+        scenario["optimizer_shadow_log"] = {
+            "shadow_status": "ok",
+            "tickers": scenario["optimizer_shadow_log"]["tickers"],
+            "eligibility": scenario["optimizer_shadow_log"]["eligibility"],
+            "eligibility_reasons":
+                scenario["optimizer_shadow_log"]["eligibility_reasons"],
+            "optimizer_cfg": scenario["optimizer_shadow_log"]["optimizer_cfg"],
+        }
+        payload = build_order_book_rationale(**scenario)
+        assert payload["portfolio_nav"] is None
+        assert payload["optimizer_trades"] is None
+        assert payload["rebalance_band_pct"] is None
+
     def test_optimizer_shadow_eligibility_reasons_field_in_log(self):
         # Sanity: the field name the producer reads matches what
         # optimizer_shadow.py emits. Pins the contract between the two


### PR DESCRIPTION
## Summary

- Surfaces `portfolio_nav`, `would_be_trades`, and `rebalance_band_pct` from the optimizer shadow log into the order-book rationale payload, so the dashboard can render a per-ticker target-vs-current-vs-planned reconciliation table without a second S3 read of `optimizer_shadow/{date}.json`.
- Three fields default to `None` on legacy non-optimizer runs (shadow log absent) and degrade gracefully when the log is partial.
- Schema bumped 1.0.0 → 1.1.0 to signal the additive surface.

## Why

Operator asked: "are we able to derive the target vs actual portfolio state? is the portfolio optimization giving us specific amounts of each stock to hold? it would be informative if we could compare the target to the existing portfolio + the open orders." The optimizer already produces all of this — it was just unsurfaced. This is the producer half; consumer-side rendering is a sibling PR in `alpha-engine-dashboard`.

## Cross-repo dependency

Consumer PR: `cipher813/alpha-engine-dashboard` — adds the reconciliation table to page 16. The consumer reads the new fields when present and tolerates their absence on pre-deploy artifacts (additive-only).

## Test plan

- [x] `pytest tests/test_order_book_rationale.py` — 29 tests pass (3 new: fields-projected, fields-none-on-legacy, partial-log-safe)
- [x] `pytest` full suite — 995 pass
- [ ] After deploy, first Monday morning planner produces a rationale artifact with the new fields populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)