### PR TITLE
feat(daemon): write open-IB-orders snapshot to S3 each tick

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -50,6 +50,7 @@ from executor.intraday_snapshot import (
     IntradaySnapshotWriter,
     compute_surveillance_universe,
 )
+from executor.open_orders_artifact import OpenOrdersSnapshotWriter
 from executor.daemon_state_logger import get_logger as _get_decision_logger
 from executor.market_hours import is_market_hours
 from executor.notifier import send_daemon_status, send_trade_alert
@@ -519,6 +520,15 @@ def run_daemon(dry_run: bool = False) -> None:
         daemon_pid=os.getpid(),
     )
 
+    # Open-IB-orders snapshot writer — publishes trades/open_orders/latest.json
+    # each tick so the dashboard's reconciliation table can render the
+    # "Working $" column alongside the optimizer's "Planned $". Same
+    # fire-and-forget contract as IntradaySnapshotWriter.
+    open_orders_writer = OpenOrdersSnapshotWriter(
+        bucket=config["signals_bucket"],
+        daemon_pid=os.getpid(),
+    )
+
     n_urgent = len(order_book.pending_urgent_exits())
     send_daemon_status(
         f"\u2705 *Daemon started*\n"
@@ -828,6 +838,23 @@ def run_daemon(dry_run: bool = False) -> None:
                 # swallow S3 errors. This catch ensures no unexpected
                 # exception from the writer leaks into the trade loop.
                 logger.warning("intraday snapshot writer raised: %s", _snap_err)
+
+            # ── Open-IB-orders snapshot ──────────────────────────────
+            # Refresh trades/open_orders/latest.json each tick so the
+            # dashboard's reconciliation view sees the current working-
+            # order state. Fire-and-forget; same defensive try/except
+            # belt as the price snapshot writer above.
+            try:
+                if ibkr.ib.isConnected():
+                    open_orders_writer.write(
+                        ibkr.ib.openTrades(),
+                        calendar_date=run_date,
+                        trading_day=run_date,
+                    )
+            except Exception as _oo_err:  # noqa: BLE001
+                logger.warning(
+                    "open-orders snapshot writer raised: %s", _oo_err,
+                )
 
             # ── Heartbeat ─────────────────────────────────────────────
             _elapsed = _time.time() - _last_heartbeat

--- a/executor/open_orders_artifact.py
+++ b/executor/open_orders_artifact.py
@@ -1,0 +1,217 @@
+"""
+Open-IB-orders snapshot writer for the order-book rationale reconciliation.
+
+Publishes a single artifact from the daemon's IB order state to S3 each
+poll tick:
+
+- ``s3://{bucket}/trades/open_orders/latest.json`` — current open-order
+  state at IB: per-order ticker, action, shares, remaining, order type,
+  limit/aux price, status, and IB order IDs.
+
+The dashboard's order-book reconciliation view (page 16) reads this
+artifact to render the "Working $" column alongside the existing
+"Planned $" — answering the operator question *"is the daemon
+following through on the optimizer's plan?"*. Planned $ comes from
+the morning-planner shadow log; Working $ from this artifact;
+together they expose the gap between intent and live order state.
+
+**Failure semantics.** Mirrors ``executor/intraday_snapshot.py``:
+S3 writes are fire-and-forget — failures log at WARNING and never
+raise. This is observability hung off the daemon's primary order-
+execution loop; the primary path records its own failures via
+``trade_logger`` SQLite + Telegram, so a stale snapshot here cannot
+mask a real execution failure. Stale snapshots also surface to the
+surveillance Lambda via daemon heartbeat staleness ([[reference: the
+existing IntradaySnapshotWriter design]]).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+
+logger = logging.getLogger(__name__)
+
+# Single rolling snapshot — operators want "what's open right now," not
+# a per-tick archive. trades.db carries the full intraday event log for
+# forensics; this artifact is a flat read for the dashboard.
+OPEN_ORDERS_LATEST_KEY = "trades/open_orders/latest.json"
+
+# IB order statuses that count as "working" (capital at risk in an open
+# order). Sourced from ib_insync's OrderStatus.Statuses — the active set
+# (orders the broker has accepted and is working) is everything except
+# the terminal states. We enumerate explicitly so a new IB status value
+# doesn't get silently re-classified.
+_WORKING_STATUSES = frozenset({
+    "PendingSubmit",
+    "PendingCancel",
+    "PreSubmitted",
+    "Submitted",
+    "ApiPending",
+})
+
+
+def _coerce_float(value: Any) -> float | None:
+    """Return float for finite numeric inputs, else None.
+
+    IB sometimes returns 0.0 or NaN for unused price fields (lmtPrice
+    on a market order, auxPrice on a limit). Coerce defensively so the
+    JSON payload is clean for the dashboard.
+    """
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    return f
+
+
+def _trade_to_record(trade: Any) -> dict[str, Any] | None:
+    """Project an ib_insync ``Trade`` (or duck-type) to a JSON-safe record.
+
+    Returns None if the trade lacks the minimum identifying fields
+    (ticker, action, totalQuantity) — defensive against partial Trade
+    objects that show up briefly during order-edit races.
+    """
+    contract = getattr(trade, "contract", None)
+    order = getattr(trade, "order", None)
+    status_obj = getattr(trade, "orderStatus", None)
+    if contract is None or order is None:
+        return None
+    ticker = getattr(contract, "symbol", None)
+    action = getattr(order, "action", None)
+    total_qty = getattr(order, "totalQuantity", None)
+    if not ticker or not action or total_qty is None:
+        return None
+
+    try:
+        total_shares = int(total_qty)
+    except (TypeError, ValueError):
+        return None
+    filled = 0
+    if status_obj is not None:
+        try:
+            filled = int(getattr(status_obj, "filled", 0) or 0)
+        except (TypeError, ValueError):
+            filled = 0
+    remaining = max(total_shares - filled, 0)
+    status = getattr(status_obj, "status", "") if status_obj is not None else ""
+
+    return {
+        "ticker": ticker,
+        "action": action,
+        "shares": total_shares,
+        "filled": filled,
+        "remaining": remaining,
+        "order_type": getattr(order, "orderType", None),
+        "limit_price": _coerce_float(getattr(order, "lmtPrice", None)),
+        "aux_price": _coerce_float(getattr(order, "auxPrice", None)),
+        "status": status,
+        "ib_order_id": getattr(order, "orderId", None),
+        "parent_id": getattr(order, "parentId", None) or None,
+        "is_working": status in _WORKING_STATUSES,
+    }
+
+
+def build_open_orders_snapshot(
+    open_trades: Iterable[Any],
+    *,
+    calendar_date: str,
+    trading_day: str,
+    written_at_utc: str | None = None,
+    daemon_pid: int | None = None,
+) -> dict[str, Any]:
+    """Build the JSON-serializable open-orders snapshot payload.
+
+    Pure function — no I/O, no clock reads when ``written_at_utc`` is
+    injected. Tests pass IB-Trade duck types; production passes
+    ``ibkr.ib.openTrades()`` directly.
+    """
+    ts = written_at_utc
+    if ts is None:
+        ts = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    records: list[dict[str, Any]] = []
+    for t in open_trades:
+        rec = _trade_to_record(t)
+        if rec is not None:
+            records.append(rec)
+    # Stable sort: working orders first (those carry capital), then by
+    # ticker for predictable display. The dashboard re-sorts by impact
+    # anyway, but this keeps the artifact diff-friendly across ticks.
+    records.sort(key=lambda r: (not r["is_working"], r["ticker"]))
+
+    return {
+        "written_at_utc": ts,
+        "calendar_date": calendar_date,
+        "trading_day": trading_day,
+        "daemon_pid": daemon_pid if daemon_pid is not None else os.getpid(),
+        "n_open_orders": len(records),
+        "n_working": sum(1 for r in records if r["is_working"]),
+        "open_orders": records,
+    }
+
+
+class OpenOrdersSnapshotWriter:
+    """Writes the daemon's current open-IB-order state to S3 each tick.
+
+    Fire-and-forget — S3 write failures log at WARNING and never raise.
+    Mirrors ``IntradaySnapshotWriter`` to keep the daemon's order-loop
+    observability surfaces uniform.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        daemon_pid: int | None = None,
+        s3_client: Any | None = None,
+    ) -> None:
+        self._bucket = bucket
+        self._daemon_pid = daemon_pid if daemon_pid is not None else os.getpid()
+        self._s3 = s3_client if s3_client is not None else boto3.client("s3")
+
+    def write(
+        self,
+        open_trades: Iterable[Any],
+        *,
+        calendar_date: str,
+        trading_day: str,
+    ) -> bool:
+        """Publish the snapshot to S3. Returns True on success, False on
+        any boto error (logged).
+        """
+        payload = build_open_orders_snapshot(
+            open_trades,
+            calendar_date=calendar_date,
+            trading_day=trading_day,
+            daemon_pid=self._daemon_pid,
+        )
+        try:
+            self._s3.put_object(
+                Bucket=self._bucket,
+                Key=OPEN_ORDERS_LATEST_KEY,
+                Body=json.dumps(payload, default=str).encode("utf-8"),
+                ContentType="application/json",
+            )
+            return True
+        except (ClientError, BotoCoreError) as e:
+            # Acceptable swallow per CLAUDE.md "secondary observability"
+            # carve-out: the daemon's primary execution path records its
+            # own failures via trade_logger SQLite + Telegram. A stale
+            # snapshot surfaces to the surveillance Lambda via daemon
+            # heartbeat staleness — there is no silent-failure mode.
+            logger.warning(
+                "open-orders snapshot write to s3://%s/%s failed (%s)",
+                self._bucket, OPEN_ORDERS_LATEST_KEY, type(e).__name__,
+            )
+            return False

--- a/tests/test_open_orders_artifact.py
+++ b/tests/test_open_orders_artifact.py
@@ -1,0 +1,267 @@
+"""Tests for executor.open_orders_artifact.
+
+Covers the pure snapshot builder's projection of ib_insync Trade duck
+types, the status-based working/terminal classification, the S3 writer
+contract, and the fail-loud-but-fire-and-forget S3 failure handling.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from executor.open_orders_artifact import (
+    OPEN_ORDERS_LATEST_KEY,
+    OpenOrdersSnapshotWriter,
+    build_open_orders_snapshot,
+)
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+def _trade(
+    ticker: str,
+    action: str,
+    qty: int,
+    *,
+    filled: int = 0,
+    status: str = "Submitted",
+    order_type: str = "LMT",
+    lmt: float | None = 50.0,
+    aux: float | None = None,
+    order_id: int = 1,
+    parent_id: int | None = None,
+):
+    """Build an ib_insync.Trade duck-type from primitives."""
+    contract = SimpleNamespace(symbol=ticker)
+    order = SimpleNamespace(
+        action=action,
+        totalQuantity=qty,
+        orderType=order_type,
+        lmtPrice=lmt,
+        auxPrice=aux,
+        orderId=order_id,
+        parentId=parent_id,
+    )
+    status_obj = SimpleNamespace(status=status, filled=filled)
+    return SimpleNamespace(contract=contract, order=order, orderStatus=status_obj)
+
+
+# ── pure builder ─────────────────────────────────────────────────────────
+
+
+def test_snapshot_projects_minimum_fields_per_order():
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 100, status="Submitted", lmt=185.5)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+        written_at_utc="2026-05-27T18:00:00Z",
+    )
+    assert payload["n_open_orders"] == 1
+    assert payload["n_working"] == 1
+    rec = payload["open_orders"][0]
+    assert rec["ticker"] == "AAPL"
+    assert rec["action"] == "BUY"
+    assert rec["shares"] == 100
+    assert rec["filled"] == 0
+    assert rec["remaining"] == 100
+    assert rec["order_type"] == "LMT"
+    assert rec["limit_price"] == 185.5
+    assert rec["status"] == "Submitted"
+    assert rec["is_working"] is True
+
+
+def test_partial_fill_reflected_in_remaining():
+    payload = build_open_orders_snapshot(
+        [_trade("MSFT", "SELL", 50, filled=20, status="Submitted")],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    rec = payload["open_orders"][0]
+    assert rec["filled"] == 20
+    assert rec["remaining"] == 30
+
+
+def test_filled_status_marked_not_working_but_still_recorded():
+    # A trade that finished filling this tick still shows up in
+    # openTrades() briefly. Record it but mark is_working=False so
+    # the dashboard doesn't double-count it against the optimizer plan.
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 100, filled=100, status="Filled")],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["n_open_orders"] == 1
+    assert payload["n_working"] == 0
+    assert payload["open_orders"][0]["is_working"] is False
+
+
+def test_cancelled_status_marked_not_working():
+    payload = build_open_orders_snapshot(
+        [_trade("XOM", "BUY", 100, status="Cancelled")],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["n_working"] == 0
+
+
+@pytest.mark.parametrize("status", [
+    "PendingSubmit", "PendingCancel", "PreSubmitted", "Submitted", "ApiPending",
+])
+def test_each_working_status_classifies_as_working(status: str):
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 1, status=status)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["n_working"] == 1
+
+
+def test_records_sorted_working_first_then_by_ticker():
+    trades = [
+        _trade("ZZZ", "BUY", 1, status="Filled"),       # terminal, last
+        _trade("MSFT", "BUY", 1, status="Submitted"),   # working, alpha
+        _trade("AAPL", "BUY", 1, status="Submitted"),   # working, alpha
+    ]
+    payload = build_open_orders_snapshot(
+        trades,
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    tickers = [r["ticker"] for r in payload["open_orders"]]
+    assert tickers == ["AAPL", "MSFT", "ZZZ"]
+
+
+def test_stop_order_carries_aux_price_no_limit():
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "SELL", 100, order_type="STP", lmt=0.0, aux=180.0)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    rec = payload["open_orders"][0]
+    assert rec["order_type"] == "STP"
+    assert rec["aux_price"] == 180.0
+
+
+def test_market_order_emits_none_limit_price():
+    # IB market orders sometimes return lmtPrice=0.0 — preserve the
+    # numeric 0.0 (it's a legitimate input value); only NaN coerces to
+    # None. Tested explicitly so a future "treat 0 as missing" change
+    # is caught.
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 100, order_type="MKT", lmt=0.0)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["open_orders"][0]["limit_price"] == 0.0
+
+
+def test_nan_price_coerced_to_none():
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 100, lmt=float("nan"))],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["open_orders"][0]["limit_price"] is None
+
+
+def test_bracket_child_carries_parent_id():
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "SELL", 100, order_type="STP", parent_id=42)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["open_orders"][0]["parent_id"] == 42
+
+
+def test_partial_trade_object_skipped_not_crashed():
+    # Mid-edit race: a Trade object briefly missing a totalQuantity.
+    # Must not raise — skip silently and keep the surviving records.
+    bad = SimpleNamespace(
+        contract=SimpleNamespace(symbol="AAPL"),
+        order=SimpleNamespace(action="BUY", totalQuantity=None),
+        orderStatus=SimpleNamespace(status="Submitted", filled=0),
+    )
+    good = _trade("MSFT", "BUY", 50)
+    payload = build_open_orders_snapshot(
+        [bad, good],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert payload["n_open_orders"] == 1
+    assert payload["open_orders"][0]["ticker"] == "MSFT"
+
+
+def test_empty_open_trades_emits_zero_count():
+    payload = build_open_orders_snapshot(
+        [],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+        written_at_utc="2026-05-27T13:00:00Z",
+    )
+    assert payload["n_open_orders"] == 0
+    assert payload["n_working"] == 0
+    assert payload["open_orders"] == []
+    assert payload["written_at_utc"] == "2026-05-27T13:00:00Z"
+
+
+def test_payload_is_audit_stable_and_serializable():
+    payload = build_open_orders_snapshot(
+        [_trade("AAPL", "BUY", 100), _trade("MSFT", "SELL", 50, status="Filled")],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+        written_at_utc="2026-05-27T18:00:00Z",
+        daemon_pid=12345,
+    )
+    # Round-trip JSON to confirm everything is serializable.
+    round_trip = json.loads(json.dumps(payload, default=str))
+    assert round_trip == json.loads(json.dumps(payload, default=str))
+    assert round_trip["daemon_pid"] == 12345
+
+
+# ── S3 writer ────────────────────────────────────────────────────────────
+
+
+class _StubS3:
+    def __init__(self):
+        self.store: dict[tuple[str, str], bytes] = {}
+
+    def put_object(self, *, Bucket, Key, Body, ContentType=None):
+        self.store[(Bucket, Key)] = Body
+
+
+def test_writer_publishes_to_canonical_key():
+    s3 = _StubS3()
+    writer = OpenOrdersSnapshotWriter(
+        bucket="alpha-engine-research", s3_client=s3, daemon_pid=99,
+    )
+    ok = writer.write(
+        [_trade("AAPL", "BUY", 100)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert ok is True
+    body = json.loads(s3.store[("alpha-engine-research", OPEN_ORDERS_LATEST_KEY)])
+    assert body["n_open_orders"] == 1
+    assert body["daemon_pid"] == 99
+
+
+def test_writer_swallows_s3_failure_returns_false():
+    # Fire-and-forget: writer must NEVER raise, only return False so the
+    # daemon's order-loop tick continues uninterrupted.
+    fake_s3 = MagicMock()
+    fake_s3.put_object.side_effect = ClientError(
+        {"Error": {"Code": "Throttling", "Message": "rate limit"}},
+        "PutObject",
+    )
+    writer = OpenOrdersSnapshotWriter(bucket="b", s3_client=fake_s3)
+    ok = writer.write(
+        [_trade("AAPL", "BUY", 100)],
+        calendar_date="2026-05-27",
+        trading_day="2026-05-27",
+    )
+    assert ok is False  # No exception propagated


### PR DESCRIPTION
## Summary

Adds the daemon-side open-IB-orders S3 snapshot — closes the deferred piece called out in the [\`alpha-engine-dashboard#130\`](https://github.com/cipher813/alpha-engine-dashboard/pull/130) page caption: *"intraday fills + open daemon orders are not yet reflected here."*

**New module:** \`executor/open_orders_artifact.py\` — pure builder \`build_open_orders_snapshot\` + \`OpenOrdersSnapshotWriter\` mirroring the \`IntradaySnapshotWriter\` pattern. Writes:

\`\`\`
s3://{bucket}/trades/open_orders/latest.json
\`\`\`

Per-order fields: \`ticker\`, \`action\`, \`shares\`, \`filled\`, \`remaining\`, \`order_type\`, \`limit_price\`, \`aux_price\`, \`status\`, \`ib_order_id\`, \`parent_id\`, \`is_working\`.

Per-record \`is_working\` boolean separates active statuses (Submitted / PreSubmitted / PendingSubmit / PendingCancel / ApiPending) from terminal (Filled / Cancelled / etc.) so the dashboard's reconciliation view can show "working capital at risk" without double-counting a just-filled order.

**Daemon wiring:** one call per tick, next to the existing \`IntradaySnapshotWriter.write\` — same fire-and-forget contract, same defensive try/except belt. Only writes when \`ibkr.ib.isConnected()\` to avoid noise during disconnected ticks.

## Failure semantics

Falls under the [[feedback_no_silent_fails]] "secondary observability" carve-out:
- (a) **Failure mode swallowed:** S3 throttle / network blip on PutObject
- (c) **Recording surface:** the daemon's primary execution path records its own failures via \`trade_logger\` SQLite + Telegram. Stale snapshots also surface to the surveillance Lambda via daemon heartbeat staleness (mirrors \`IntradaySnapshotWriter\`).

## Cross-repo dependency

Consumer (follows): \`alpha-engine-dashboard\` adds a \`Working \$\` column to the reconciliation table on page 16 and updates \`Residual \$\` to be \`Δ\$ - Planned \$ - Working \$\`. Wired separately so this PR can ship + soak first.

## Test plan

- [x] \`pytest tests/test_open_orders_artifact.py\` — 19 new tests covering: builder projection, partial-fill remaining math, terminal-vs-working classification across every status, stop/market/limit price handling, NaN coercion, bracket parent_id, partial-Trade-object skip, empty input, audit-stable serialization, writer canonical-key write, fire-and-forget S3 failure swallowing
- [x] \`pytest\` full alpha-engine suite — 1021 pass
- [x] Executor dry-run gate (pre-push hook)
- [ ] After deploy, verify \`trades/open_orders/latest.json\` populated during a live daemon tick
- [ ] After deploy, verify file size ≤ a few KB (no excessive write volume)

🤖 Generated with [Claude Code](https://claude.com/claude-code)