### PR TITLE
refactor(arcticdb): delegate _open_*_library to lib chokepoint (L2771 part 1/5)

### DIFF
--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -57,16 +57,15 @@ def _open_universe_library(signals_bucket: str):
     those live in the `macro` library; use ``_open_macro_library`` for
     those.
 
-    Hard-fails on connection/library errors per feedback_no_silent_fails.
+    Thin wrapper over ``alpha_engine_lib.arcticdb.open_universe_lib`` —
+    the lib chokepoint (L2771) centralizes the S3 URI construction and
+    `get_library` error-wrapping across all alpha-engine consumers.
+    Kept as a local wrapper so the existing callers' import surface
+    stays unchanged and so the macOS allocator-prime invariant
+    (``import arcticdb`` at module top, BEFORE pandas) is preserved.
     """
-    adb = _arcticdb  # already imported at module top for macOS allocator prime
-    region = os.environ.get("AWS_REGION", "us-east-1")
-    uri = (
-        f"s3s://s3.{region}.amazonaws.com:{signals_bucket}"
-        f"?path_prefix=arcticdb&aws_auth=true"
-    )
-    arctic = adb.Arctic(uri)
-    return arctic.get_library("universe")
+    from alpha_engine_lib.arcticdb import open_universe_lib
+    return open_universe_lib(signals_bucket)
 
 
 def _open_macro_library(signals_bucket: str):
@@ -77,16 +76,11 @@ def _open_macro_library(signals_bucket: str):
     and builders.backfill. SPY in particular is what the morning
     freshness gate and EOD reconcile check.
 
-    Hard-fails on connection/library errors per feedback_no_silent_fails.
+    Thin wrapper over ``alpha_engine_lib.arcticdb.open_macro_lib`` —
+    see ``_open_universe_library`` above for the rationale.
     """
-    adb = _arcticdb
-    region = os.environ.get("AWS_REGION", "us-east-1")
-    uri = (
-        f"s3s://s3.{region}.amazonaws.com:{signals_bucket}"
-        f"?path_prefix=arcticdb&aws_auth=true"
-    )
-    arctic = adb.Arctic(uri)
-    return arctic.get_library("macro")
+    from alpha_engine_lib.arcticdb import open_macro_lib
+    return open_macro_lib(signals_bucket)
 
 
 def load_price_histories(


### PR DESCRIPTION
## Summary
Thin out `executor/price_cache.py::_open_universe_library` + `_open_macro_library` to delegate to the existing `alpha_engine_lib.arcticdb.open_universe_lib` / `open_macro_lib` chokepoint.

Local wrappers are RETAINED (not deleted) to keep two invariants intact:
1. Existing callers' import surface unchanged (`load_price_histories`, `load_atr_14_pct`, `eod_reconcile.run`, etc.).
2. Module-top `import arcticdb as _arcticdb` (line 23) keeps the macOS allocator-prime ordering — pyarrow must not load before arcticdb's bundled `aws-c-common`, else `aws_fatal_assert` segfaults on first `get_library()`.

Both wrappers now contain a single `from alpha_engine_lib.arcticdb import open_universe_lib` + delegation call.

## Why
ROADMAP **L2771** — lift the duplicated `adb.Arctic(uri).get_library(...)` boilerplate to the lib chokepoint that already exists since v0.1.4. The 2026-04-21 SNDK incident was an escape-bug in a hand-built S3 URI string; centralizing the URI construction prevents that bug class structurally.

This is **part 1 of 5** — sibling PRs follow in ae-data + ae-predictor + ae-research + ae-backtester.

## Composes with
- PR #224 (L1346 c SPY-special-case retirement, OPEN) — both edit `price_cache.py`. Textual merge conflict will be trivial (different sections).

## Test plan
- [x] Full suite green: `1021 passed`
- [ ] Sibling PRs in 4 other repos to fully close L2771

🤖 Generated with [Claude Code](https://claude.com/claude-code)