### PR TITLE
feat(executor): barrier_win_prob position-sizing consumer, shipped dormant (Task B2)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -118,6 +118,20 @@ regime_sizing_scale: 0.05        # per-σ sensitivity; +1σ → 1.05× tilt
 regime_sizing_floor: 0.70        # clamp lower bound on the multiplier
 regime_sizing_ceil:  1.30        # clamp upper bound on the multiplier
 
+# ── Barrier-win-probability sizing (Task B2, meta-labeling consumer) ────────
+# Off by default; ships DORMANT. When ON, position_sizer multiplies the raw
+# weight by ``barrier_win_prob_sizing_min + barrier_win_prob_sizing_range *
+# barrier_win_prob`` (clamped: bwp∈[0,1] → adj∈[min, min+range]; bwp=0.5→1.0).
+# ``barrier_win_prob`` = the predictor's calibrated P(profit/upper barrier
+# touched before stop/lower barrier), emitted observe-only in predictions.json
+# (alpha-engine-predictor Task B1). Operator flips
+# ``barrier_win_prob_sizing_enabled: true`` only after the field has soaked
+# ≥1 Saturday cycle AND the backtester sweep (Task B3) justifies the weight.
+# Missing field (pre-B1 predictions) → 1.0× (graceful degrade).
+barrier_win_prob_sizing_enabled: false  # gate-off by default; flip after soak + sweep
+barrier_win_prob_sizing_min:   0.70     # multiplier at bwp=0 (and floor)
+barrier_win_prob_sizing_range: 0.60     # span; bwp=0.5→1.0×, bwp=1.0→1.30×
+
 # ── Regime-aware drawdown tiers (Stage D' Wire 3, regime-v3-260514) ─────────
 # Off by default; ships dormant. When ON, the SOFT graduated-drawdown tier
 # thresholds are scaled by ``1.0 + intensity_z * regime_drawdown_scale``

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -728,6 +728,11 @@ def decide_entries(
             feature_coverage=coverage_map.get(ticker),
             stance=pred_data.get("stance"),
             regime_intensity_z=regime_intensity_z,
+            # Task B2 (dormant): predictor's observe-only calibrated
+            # P(up barrier before down). Missing on pre-B1 predictions →
+            # None → 1.0× multiplier (graceful degrade); only affects sizing
+            # once ``barrier_win_prob_sizing_enabled`` is flipped on.
+            barrier_win_prob=pred_data.get("barrier_win_prob"),
         )
 
         # Emit executor:position_sizer DecisionArtifact (L2308 PR 2).

--- a/executor/main.py
+++ b/executor/main.py
@@ -96,6 +96,10 @@ _PARAM_MAP = {
     "correlation_block_threshold": ("correlation_block_threshold",),
     "profit_take_pct": ("strategy", "exit_manager", "profit_take_pct"),
     "momentum_exit_threshold": ("strategy", "exit_manager", "momentum_exit_threshold"),
+    # Task B2 (dormant): barrier-win-prob sizing weights. The enable flag
+    # itself is a bool, handled with the other non-numeric special keys below.
+    "barrier_win_prob_sizing_min": ("barrier_win_prob_sizing_min",),
+    "barrier_win_prob_sizing_range": ("barrier_win_prob_sizing_range",),
 }
 
 
@@ -117,6 +121,8 @@ _PARAM_VALIDATORS = {
     "correlation_block_threshold": (float, 0.3,  1.0),
     "profit_take_pct":             (float, 0.05, 1.0),
     "momentum_exit_threshold":     (float, -50,  0),
+    "barrier_win_prob_sizing_min":   (float, 0.3, 1.0),
+    "barrier_win_prob_sizing_range": (float, 0.1, 1.0),
 }
 
 _EXECUTOR_PARAMS_CACHE_PATH = Path(__file__).resolve().parent.parent / "config" / ".executor_params_cache.json"
@@ -143,6 +149,7 @@ def _load_executor_params_from_s3(bucket: str) -> dict | None:
         # Advisory schema validation (log warnings, never block)
         _unknown_keys = [k for k in data if k not in _PARAM_MAP and k not in (
             "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
+            "barrier_win_prob_sizing_enabled",
             "updated_at", "best_sharpe", "best_alpha", "improvement_pct",
             "n_combos_tested", "manual_override",
         )]
@@ -150,8 +157,13 @@ def _load_executor_params_from_s3(bucket: str) -> dict | None:
             logger.warning("executor_params.json contains unknown keys: %s", _unknown_keys)
         # Only keep safe-to-override params (numeric) + special non-numeric params
         safe = {k: v for k, v in data.items() if k in _PARAM_MAP}
-        # Phase 4 non-numeric params: disabled_triggers (list), p_up sizing (bool)
-        for special_key in ("disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend"):
+        # Phase 4 non-numeric params: disabled_triggers (list), p_up sizing (bool).
+        # Task B2: barrier_win_prob_sizing_enabled (bool) — the dormant sizing
+        # consumer's master switch, flipped via S3 after soak + backtester sweep.
+        for special_key in (
+            "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
+            "barrier_win_prob_sizing_enabled",
+        ):
             if special_key in data:
                 safe[special_key] = data[special_key]
         if safe:

--- a/executor/position_sizer.py
+++ b/executor/position_sizer.py
@@ -72,6 +72,7 @@ def compute_position_size(
     feature_coverage: float | None = None,
     stance: str | None = None,
     regime_intensity_z: float | None = None,
+    barrier_win_prob: float | None = None,
 ) -> dict:
     """
     Compute position size for a new ENTER order.
@@ -220,11 +221,34 @@ def compute_position_size(
     else:
         regime_adj = 1.0
 
+    # Barrier-win-probability sizing (Task B2 — meta-labeling consumer).
+    # Reads the predictor's calibrated ``barrier_win_prob`` = P(profit/upper
+    # barrier touched before stop/lower barrier). Linear map centered at the
+    # 0.5 coin-flip → 1.0×, mirroring the p_up precedent above:
+    #   adj = min + range * bwp  →  bwp=0.5→1.0, bwp=0→min, bwp=1→min+range.
+    # Default OFF (ships DORMANT): the predictor emits the field observe-only
+    # (Task B1); the operator flips ``barrier_win_prob_sizing_enabled`` ON only
+    # after the field has soaked ≥1 Saturday cycle AND the backtester sweep
+    # (Task B3) justifies the weight. Composes multiplicatively; clamped so a
+    # bad/extreme probability cannot blow up size (and the final
+    # ``min(raw_weight, max_pct)`` caps it regardless). Falls through to 1.0×
+    # when the field is absent (pre-B1 predictions) — graceful degrade.
+    if (
+        config.get("barrier_win_prob_sizing_enabled", False)
+        and barrier_win_prob is not None
+    ):
+        bwp = max(0.0, min(1.0, barrier_win_prob))
+        bwp_min = config.get("barrier_win_prob_sizing_min", 0.70)
+        bwp_range = config.get("barrier_win_prob_sizing_range", 0.60)
+        barrier_win_prob_adj = bwp_min + bwp_range * bwp
+    else:
+        barrier_win_prob_adj = 1.0
+
     max_pct = config.get("max_position_pct", 0.05)
     raw_weight = (base_weight * sector_adj * conviction_adj * upside_adj
                   * drawdown_multiplier * atr_adj * confidence_adj
                   * staleness_adj * earnings_adj * coverage_adj
-                  * stance_adj * regime_adj)
+                  * stance_adj * regime_adj * barrier_win_prob_adj)
     position_weight = min(raw_weight, max_pct)
 
     # ATR volatility cap: ensure ATR constraint is not overridden by other
@@ -248,6 +272,7 @@ def compute_position_size(
         f"confidence_adj={confidence_adj} staleness_adj={staleness_adj} "
         f"earnings_adj={earnings_adj} coverage_adj={coverage_adj} "
         f"stance_adj={stance_adj} regime_adj={regime_adj} "
+        f"barrier_win_prob_adj={barrier_win_prob_adj} "
         f"→ {position_weight:.3f} NAV = ${dollar_size:.0f} = {shares} shares"
     )
 
@@ -266,4 +291,5 @@ def compute_position_size(
         "coverage_adj": coverage_adj,
         "stance_adj": stance_adj,
         "regime_adj": regime_adj,
+        "barrier_win_prob_adj": barrier_win_prob_adj,
     }

--- a/tests/test_position_sizer.py
+++ b/tests/test_position_sizer.py
@@ -579,3 +579,70 @@ class TestStanceConditionalSizing:
         r_value = self._sizing("value")
         assert r_value["dollar_size"] < r_momentum["dollar_size"]
         assert r_value["dollar_size"] / r_momentum["dollar_size"] == pytest.approx(0.7, rel=1e-3)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Barrier-win-probability sizing (Task B2 — meta-labeling consumer, dormant)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBarrierWinProbSizing:
+
+    def _adj(self, *, enabled, bwp, **cfg_overrides):
+        cfg = _base_config(barrier_win_prob_sizing_enabled=enabled, **cfg_overrides)
+        return compute_position_size(
+            ticker="AAPL",
+            portfolio_nav=100_000,
+            enter_signals=[{"ticker": "AAPL"}],
+            signal=_base_signal(),
+            sector_rating="market_weight",
+            current_price=150.0,
+            config=cfg,
+            barrier_win_prob=bwp,
+        )["barrier_win_prob_adj"]
+
+    def test_dormant_by_default(self):
+        """Flag absent → no adjustment even when bwp is provided."""
+        assert self._adj(enabled=False, bwp=0.9) == 1.0
+
+    def test_coinflip_is_neutral(self):
+        """bwp=0.5 → 1.0× (min 0.70 + range 0.60 * 0.5)."""
+        assert self._adj(enabled=True, bwp=0.5) == pytest.approx(1.0)
+
+    def test_certain_win_max_multiplier(self):
+        assert self._adj(enabled=True, bwp=1.0) == pytest.approx(1.30)
+
+    def test_certain_loss_min_multiplier(self):
+        assert self._adj(enabled=True, bwp=0.0) == pytest.approx(0.70)
+
+    def test_missing_field_graceful_degrade(self):
+        """Enabled but no bwp on the prediction (pre-B1) → 1.0×."""
+        assert self._adj(enabled=True, bwp=None) == 1.0
+
+    def test_clamps_out_of_range(self):
+        # bwp > 1 clamps to 1 → 1.30; bwp < 0 clamps to 0 → 0.70
+        assert self._adj(enabled=True, bwp=5.0) == pytest.approx(1.30)
+        assert self._adj(enabled=True, bwp=-3.0) == pytest.approx(0.70)
+
+    def test_custom_min_and_range(self):
+        # min=0.5, range=1.0 → bwp=1.0 → 1.5×
+        assert self._adj(
+            enabled=True, bwp=1.0,
+            barrier_win_prob_sizing_min=0.5,
+            barrier_win_prob_sizing_range=1.0,
+        ) == pytest.approx(1.5)
+
+    def test_downsizes_position_when_low_prob(self):
+        """End-to-end: a low-barrier-prob pick sizes smaller than a high one."""
+        enter = [{"ticker": f"T{i}"} for i in range(40)]  # base 0.025 < cap
+
+        def _pp(bwp):
+            return compute_position_size(
+                ticker="AAPL", portfolio_nav=100_000, enter_signals=enter,
+                signal=_base_signal(), sector_rating="market_weight",
+                current_price=150.0,
+                config=_base_config(barrier_win_prob_sizing_enabled=True),
+                barrier_win_prob=bwp,
+            )["position_pct"]
+
+        assert _pp(0.1) < _pp(0.9)


### PR DESCRIPTION
## What

Executor-side of **Task B** (meta-labeling for sizing), ae-config #374. Consumes the predictor's observe-only `barrier_win_prob` (calibrated P(profit/upper barrier touched before stop/lower barrier), shipped in predictor #211) as a **position-sizing multiplier**. **Ships DORMANT** — `barrier_win_prob_sizing_enabled: false` by default; mirrors the dormant `regime_sizing` wire precedent.

## Changes

- **`position_sizer.py`** — new `barrier_win_prob` param + `barrier_win_prob_adj` multiplier: `min + range * bwp`, clamped (bwp∈[0,1] → adj∈[min, min+range]; **bwp=0.5 → 1.0×**, mirroring the existing `p_up` precedent). Composes multiplicatively; the final `min(raw_weight, max_pct)` caps it regardless. Missing field (pre-B1 predictions) or flag off → **1.0× graceful degrade**.
- **`deciders.py`** — reads `pred_data.get("barrier_win_prob")`, passes through.
- **`main.py`** — `_PARAM_MAP` + validators for the two sweepable weights; enable flag added to the non-numeric special-key handling so the backtester (Task B3) / operator can flip it via S3 `config/executor_params.json`.
- **`risk.yaml.example`** — documented dormant config block.

## Safety

- **Dormant**: gate-off by default → zero behavior change on merge.
- **Clamped**: a bad/extreme probability cannot blow up size; capped by `max_position_pct` regardless.
- **Graceful degrade**: pre-B1 predictions (no field) → 1.0×.

## Flip criteria (NOT met yet)

`barrier_win_prob` soaked ≥1 Saturday training cycle **AND** the backtester sweep (Task B3) justifies the weight. Until then this is inert.

## Tests

`TestBarrierWinProbSizing` (+9): default-off, neutral@0.5, min/max clamps, graceful degrade, custom min/range, end-to-end downsizing. **Full executor suite: 1039 passed.** (Branch rebased onto current `main` incl. #227.)

> Note: `python executor/main.py --dry-run` is a deploy-time check (needs local `risk.yaml` + IB); not run here. Dormant flag means no runtime change regardless.

## Next

B3 — backtester sweep + resolve the `predictions_by_ticker={}` gap so the flip is data-justified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)