### PR TITLE
feat(executor): optimizer sole exit authority + real-time risk overlay & intraday re-solve

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -236,6 +236,13 @@ strategy:
     momentum_exit_threshold: -15.0  # 20d momentum % (backtester-tunable: [-20.0, -15.0, -10.0])
     momentum_exit_rsi: 30           # RSI(14) threshold
 
+    # Catastrophic single-name gap stop — the ONLY intraday exit allowed when
+    # use_portfolio_optimizer=true (optimizer owns the book). A true hard-risk
+    # control; the alpha rules above are suppressed under the optimizer. Fires
+    # on a large drop vs the gap reference price (recent close at planning time).
+    catastrophic_gap_stop_enabled: true
+    catastrophic_gap_stop_pct: 0.15  # 15% drop from reference triggers full exit (backtester-tunable)
+
   graduated_drawdown:
     enabled: true
     tiers:
@@ -365,6 +372,25 @@ portfolio_optimizer:
   # Minimum position pct — weights below this are clipped to 0 (clean output;
   # avoid tiny stub positions like today's UNP 0.1% NAV residual).
   min_position_pct: 0.005
+
+  # ── Intraday reconcile-to-target (daemon real-time risk overlay) ──────────
+  # When the optimizer owns the book, hard-risk exits free cash intraday with
+  # no same-day redeploy path (incident 2026-05-29 → 22% idle cash, SPY 0).
+  # The daemon reuses the morning Σ + alpha_hat (cached in the optimizer shadow
+  # log) to re-solve and redeploy that cash to the sleeve same-day.
+  intraday_resolve_enabled: true
+  # Real-time drawdown overlay: poll live NAV vs peak each tick; force de-risk
+  # exits + suppress redeploy in a drawdown (reuses compute_drawdown_multiplier,
+  # identical to the morning planner). Disable to revert to morning-only DD.
+  intraday_drawdown_overlay_enabled: true
+  # Min freed cash (fraction of NAV, net of pending entries) before a re-solve
+  # fires — avoids churning on trivial deltas.
+  intraday_resolve_min_freed_cash_pct: 0.01
+  # Stop re-solving past this ET time so redeploy buys can still fill before
+  # the 3:55 PM time-expiry; later-freed cash carries to the next planner.
+  intraday_resolve_cutoff_et: "15:30"
+  # Per-day backstop on re-solves (churn guard).
+  intraday_resolve_max_per_day: 5
 
 # ── Paths (adjust to your deployment) ───────────────────────────────────────
 db_path: "/path/to/trades.db"

--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -46,6 +46,13 @@ from executor.decision_capture import (
 from executor.entry_triggers import EntryTriggerEngine
 from executor.ibkr import IBKRClient
 from executor.intraday_exit_manager import IntradayExitManager
+from executor.intraday_resolve import (
+    available_redeploy_cash,
+    build_redeploy_entry,
+    compute_drawdown_overlay,
+    select_forced_exits,
+    solve_redeploy,
+)
 from executor.intraday_snapshot import (
     IntradaySnapshotWriter,
     compute_surveillance_universe,
@@ -84,6 +91,42 @@ MARKET_OPEN_MINUTE = 30
 # ``_execute_entry`` (decision-capture wiring, L2308) can read it without
 # threading the tz through every call site.
 _ET = pytz.timezone("US/Eastern")
+
+
+def _within_resolve_window(cutoff_et: str) -> bool:
+    """True if the current ET time is before the intraday re-solve cutoff.
+
+    Past the cutoff, freed cash can't reliably fill before the 3:55 PM ET
+    time-expiry, so we stop re-solving and let it carry to tomorrow's planner.
+    """
+    try:
+        hh, mm = (int(x) for x in cutoff_et.split(":"))
+    except (ValueError, AttributeError):
+        hh, mm = 15, 30
+    now = datetime.now(_ET)
+    return (now.hour, now.minute) < (hh, mm)
+
+
+def _load_optimizer_shadow_log(bucket: str) -> dict | None:
+    """Load the morning optimizer shadow log (target weights + cached daily Σ
+    + alpha_hat) for the intraday re-solve. Returns None on ANY failure — the
+    caller treats a missing log as 'cannot redeploy' and leaves cash idle (the
+    re-solve is load-bearing; it never silently no-ops as if it succeeded)."""
+    try:
+        import boto3
+        s3 = boto3.client("s3")
+        obj = s3.get_object(
+            Bucket=bucket, Key="predictor/optimizer_shadow/latest.json",
+        )
+        return json.loads(obj["Body"].read())
+    except Exception as e:
+        logger.error(
+            "Could not load optimizer shadow log for intraday re-solve "
+            "(redeploy disabled, freed cash stays idle until next planner): %s",
+            e,
+        )
+        return None
+
 
 # Connection retry limits
 MAX_RECONNECT_BACKOFF_SECS = 300
@@ -363,6 +406,31 @@ def run_daemon(dry_run: bool = False) -> None:
     client_id = strategy_config.get("intraday_client_id", 2)
     poll_interval = strategy_config.get("intraday_poll_interval_sec", 60)
     run_date = date.today().isoformat()
+
+    # ── Intraday reconcile-to-target state (optimizer authority) ─────────────
+    # When the optimizer owns the book, hard-risk exits (catastrophic gap stop,
+    # drawdown forced-exit) free cash intraday with no same-day redeploy path —
+    # the bug that left the book at 22% cash / SPY 0 on 2026-05-29. This state
+    # drives the real-time drawdown overlay + event-driven re-solve that
+    # redeploys freed cash back to the sleeve. See executor/intraday_resolve.py.
+    use_optimizer = bool(config.get("use_portfolio_optimizer", False))
+    _opt_cfg = config.get("portfolio_optimizer", {}) or {}
+    resolve_enabled = use_optimizer and bool(_opt_cfg.get("intraday_resolve_enabled", True))
+    overlay_enabled = bool(_opt_cfg.get("intraday_drawdown_overlay_enabled", True))
+    resolve_min_freed_pct = float(_opt_cfg.get("intraday_resolve_min_freed_cash_pct", 0.01))
+    resolve_cutoff_et = str(_opt_cfg.get("intraday_resolve_cutoff_et", "15:30"))
+    resolve_max_per_day = int(_opt_cfg.get("intraday_resolve_max_per_day", 5))
+    _stopped_out_today: set[str] = set()   # gap-stopped + dd-forced names (no same-day rebuy)
+    _dd_forced_today: set[str] = set()     # subset force-exited by the drawdown overlay
+    _hard_risk_exit_seen = False           # event flag: a hard-risk exit freed cash → re-solve
+    _resolve_count = 0
+    _shadow_log_cache: dict | None = None
+    if resolve_enabled:
+        logger.info(
+            "Intraday reconcile ENABLED — drawdown overlay + event-driven "
+            "re-solve (min_freed=%.1f%% NAV, cutoff=%s ET, max/day=%d)",
+            resolve_min_freed_pct * 100, resolve_cutoff_et, resolve_max_per_day,
+        )
 
     logger.info(
         "Intraday daemon starting | date=%s | dry_run=%s | clientId=%d | poll=%ds",
@@ -891,19 +959,29 @@ def run_daemon(dry_run: bool = False) -> None:
                 if not price_state:
                     continue
 
-                # Check for trail update first
-                trail_update = exit_mgr.should_update_trail(stop, price_state["last"])
-                if trail_update:
-                    new_high, new_stop = trail_update
-                    order_book.update_stop_high_water(ticker, new_high, new_stop)
-                    order_book.save()
-                    logger.debug(
-                        "Trail updated %s: high=$%.2f stop=$%.2f",
-                        ticker, new_high, new_stop,
-                    )
+                # Dispatch on the record's stop_kind (written by the morning
+                # planner). ``catastrophic_gap_only`` (optimizer owns the book)
+                # runs ONLY the hard-risk catastrophic gap stop — the alpha
+                # rules (trailing-stop / profit-take / collapse) and the trail
+                # ratchet are suppressed by construction. ``alpha``/absent runs
+                # the full legacy IntradayExitManager. Carrying the authority
+                # in the data (not a daemon flag) is the hard-to-misuse form.
+                if stop.get("stop_kind") == "catastrophic_gap_only":
+                    exit_signal = exit_mgr.check_catastrophic_gap(stop, price_state)
+                else:
+                    # Check for trail update first
+                    trail_update = exit_mgr.should_update_trail(stop, price_state["last"])
+                    if trail_update:
+                        new_high, new_stop = trail_update
+                        order_book.update_stop_high_water(ticker, new_high, new_stop)
+                        order_book.save()
+                        logger.debug(
+                            "Trail updated %s: high=$%.2f stop=$%.2f",
+                            ticker, new_high, new_stop,
+                        )
 
-                # Check exit rules
-                exit_signal = exit_mgr.evaluate(stop, price_state)
+                    # Check exit rules
+                    exit_signal = exit_mgr.evaluate(stop, price_state)
                 if exit_signal:
                     try:
                         _execute_exit(
@@ -913,6 +991,13 @@ def run_daemon(dry_run: bool = False) -> None:
                         if not dry_run:
                             trades_executed += 1
                             executed_tickers.add(exit_signal.get("ticker"))
+                            # A catastrophic gap stop is a hard-risk exit: the
+                            # name must NOT be re-bought same-day (morning alpha
+                            # is still positive), and the freed cash triggers an
+                            # event-driven re-solve in the reconcile block below.
+                            if exit_signal.get("reason") == "catastrophic_gap_stop":
+                                _stopped_out_today.add(exit_signal.get("ticker"))
+                                _hard_risk_exit_seen = True
                             # Emit executor:exit_rules DecisionArtifact
                             # (L2308 PR 4 — daemon-side intraday exits).
                             # Lands AFTER the fill succeeded (mirrors PR 1
@@ -948,6 +1033,122 @@ def run_daemon(dry_run: bool = False) -> None:
                         logger.warning("Connection lost during exit %s: %s — reconnecting", exit_signal.get("ticker"), e)
                         ibkr, monitor = _reconnect(ibkr, monitor, order_book, config, client_id)
                         break
+
+            # ── Intraday reconcile-to-target (optimizer owns the book) ────────
+            # Real-time drawdown overlay (force de-risk + suppress redeploy) and
+            # event-driven re-solve that redeploys cash freed by hard-risk exits
+            # back to the sleeve same-day. Reuses the morning Σ + alpha_hat from
+            # the optimizer shadow log → zero new alpha look-ahead. Guarded so a
+            # reconcile failure never kills the daemon (cash just carries to the
+            # next morning planner); the re-solve itself fails loud (no silent
+            # no-op-as-success). Runs after exits / before entries so freshly
+            # enqueued redeploy buys get a fill attempt this same tick.
+            if resolve_enabled and not dry_run:
+                try:
+                    nav = ibkr.get_portfolio_nav()
+                    try:
+                        peak = ibkr.get_peak_nav(conn) or nav
+                    except Exception:
+                        peak = nav
+                    positions = ibkr.get_positions()
+                    overlay = compute_drawdown_overlay(nav, peak, config, strategy_config)
+                    if not overlay_enabled:
+                        # Overlay off: no intraday forced exits, no drawdown
+                        # redeploy suppression — redeploy purely event-driven.
+                        overlay = {**overlay, "forced_exit_count": 0, "redeploy_suppressed": False}
+
+                    # (a) Drawdown de-risk: force-exit lowest-conviction names.
+                    # Independent of the shadow log so de-risking works even if
+                    # the log is missing. Ranking has no scores here → falls back
+                    # to smallest-position-first (conservative).
+                    if overlay["forced_exit_count"] > 0:
+                        for fx in select_forced_exits(
+                            positions, {}, _stopped_out_today | _dd_forced_today,
+                            overlay["forced_exit_count"],
+                        ):
+                            ps = monitor.get_price(fx["ticker"])
+                            if not ps:
+                                continue
+                            _execute_exit(ibkr, conn, order_book, fx, ps, run_date,
+                                          dry_run, monitor=monitor)
+                            _dd_forced_today.add(fx["ticker"])
+                            _stopped_out_today.add(fx["ticker"])
+                            _hard_risk_exit_seen = True
+                            trades_executed += 1
+                            executed_tickers.add(fx["ticker"])
+                            logger.warning(
+                                "INTRADAY DRAWDOWN FORCED EXIT: %s (%s)",
+                                fx["ticker"], overlay["tier_desc"],
+                            )
+
+                    # (b) Redeploy freed cash — only when NOT de-risking, only in
+                    # response to a hard-risk exit, within the fill window, and
+                    # under the per-day cap.
+                    if (
+                        _hard_risk_exit_seen
+                        and not overlay["redeploy_suppressed"]
+                        and _resolve_count < resolve_max_per_day
+                        and _within_resolve_window(resolve_cutoff_et)
+                    ):
+                        if _shadow_log_cache is None:
+                            _shadow_log_cache = _load_optimizer_shadow_log(config["signals_bucket"])
+                        if _shadow_log_cache is not None:
+                            sleeve = float((_shadow_log_cache.get("optimizer_cfg") or {}).get("cash_sleeve_pct", 0.03))
+                            pending_dollars = sum(
+                                (e.get("dollar_size") or (e.get("shares", 0) * (e.get("current_price") or 0)))
+                                for e in order_book.pending_entries()
+                            )
+                            avail = available_redeploy_cash(
+                                _shadow_log_cache["tickers"], positions, nav,
+                                sleeve, pending_dollars,
+                            )
+                            if avail > resolve_min_freed_pct * nav:
+                                res = solve_redeploy(
+                                    shadow_log=_shadow_log_cache,
+                                    current_positions=positions,
+                                    nav=nav,
+                                    stopped_out=_stopped_out_today,
+                                )
+                                _resolve_count += 1
+                                # Event consumed: only re-solve again when a NEW
+                                # hard-risk exit fires (coalesces same-tick stops,
+                                # prevents per-tick churn).
+                                _hard_risk_exit_seen = False
+                                if res["status"] not in ("optimal", "optimal_inaccurate"):
+                                    logger.error(
+                                        "Intraday re-solve status=%r — NOT redeploying; "
+                                        "~$%.0f freed cash left idle for next planner",
+                                        res["status"], avail,
+                                    )
+                                else:
+                                    n_enq = 0
+                                    for b in res["buys"]:
+                                        if b["ticker"] in _stopped_out_today:
+                                            continue
+                                        ps = monitor.get_price(b["ticker"])
+                                        px = ps.get("last") if ps else None
+                                        if not px or px <= 0:
+                                            continue
+                                        sh = int(b["delta_dollars"] // px)
+                                        if sh <= 0:
+                                            continue
+                                        order_book.add_entry(build_redeploy_entry(
+                                            b["ticker"], sh, px, b["target_weight"], run_date,
+                                            pullback_pct=strategy_config.get("intraday_pullback_pct", 0.02),
+                                        ))
+                                        n_enq += 1
+                                    if n_enq:
+                                        order_book.save()
+                                    logger.info(
+                                        "Intraday re-solve #%d: enqueued %d redeploy buy(s) "
+                                        "for ~$%.0f freed cash (vol_ann=%s)",
+                                        _resolve_count, n_enq, avail, res.get("vol_ann"),
+                                    )
+                except Exception as _rec_err:
+                    logger.error(
+                        "Intraday reconcile error (freed cash may stay idle until "
+                        "the next morning planner): %s", _rec_err, exc_info=True,
+                    )
 
             # ── Check entries ────────────────────────────────────────
             if strategy_config.get("intraday_entry_triggers_enabled", True):

--- a/executor/intraday_exit_manager.py
+++ b/executor/intraday_exit_manager.py
@@ -99,6 +99,40 @@ class IntradayExitManager:
             return current_price, new_stop
         return None
 
+    def check_catastrophic_gap(self, stop: dict, price_state: dict) -> dict | None:
+        """Hard-risk per-name catastrophic gap stop (full EXIT).
+
+        Fires when price falls at least ``catastrophic_gap_stop_pct`` below the
+        record's ``gap_reference_price`` (most recent close at planning time,
+        falling back to entry_price). This is the ONLY intraday exit allowed
+        when the optimizer owns the book — a true risk control, distinct from
+        the retired alpha rules (trailing-stop / profit-take / collapse). The
+        optimizer otherwise reconciles the book; this catches the acute
+        single-name crater the optimizer can't react to until next morning.
+        """
+        if not self._config.get("catastrophic_gap_stop_enabled", True):
+            return None
+        current_price = price_state.get("last")
+        if not current_price or current_price <= 0:
+            return None
+        ref = stop.get("gap_reference_price") or stop.get("entry_price")
+        if not ref or ref <= 0:
+            return None
+        threshold = self._config.get("catastrophic_gap_stop_pct", 0.15)
+        drop = (ref - current_price) / ref
+        if drop >= threshold:
+            return {
+                "ticker": stop["ticker"],
+                "action": "EXIT",
+                "shares": stop.get("shares", 0),
+                "reason": "catastrophic_gap_stop",
+                "detail": (
+                    f"price ${current_price:.2f} <= {(1 - threshold):.0%} of "
+                    f"reference ${ref:.2f} (drop {drop:.1%} >= {threshold:.1%})"
+                ),
+            }
+        return None
+
     # ── Private rule checks ──────────────────────────────────────────────────
 
     def _check_trailing_stop(self, stop: dict, current_price: float) -> dict | None:

--- a/executor/intraday_resolve.py
+++ b/executor/intraday_resolve.py
@@ -1,0 +1,275 @@
+"""Intraday reconcile-to-target: real-time drawdown overlay + event-driven
+optimizer re-solve to redeploy cash freed by hard-risk exits.
+
+Background (incident 2026-05-29): under ``use_portfolio_optimizer`` the
+optimizer plans a fully-invested book ONCE in the morning, but hard-risk
+exits fire intraday and free cash with no same-day path to redeploy it — the
+portfolio drifted to 22% idle cash with SPY at 0. This module is the daemon's
+"execution + real-time risk" layer:
+
+  1. ``compute_drawdown_overlay`` — reuses the SAME
+     ``risk_guard.compute_drawdown_multiplier`` the morning planner uses
+     (no divergent logic), evaluated live each tick. Drawdown tiers force
+     de-risking exits AND suppress redeploy (freed cash stays cash — the
+     point of a circuit breaker).
+  2. ``solve_redeploy`` — event-driven optimizer re-solve reusing the MORNING
+     alpha_hat + DAILY covariance cached in the optimizer shadow log (both
+     daily-stable → zero new alpha look-ahead), against LIVE positions, to
+     redeploy excess cash back toward the 3% sleeve.
+
+All functions here are pure (no IB / no S3) so the daemon stays a thin wiring
+layer and the logic is unit-testable. See plan toasty-brewing-glacier.md.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from executor.portfolio_optimizer import solve_target_weights
+from executor.risk_guard import compute_drawdown_multiplier
+
+logger = logging.getLogger(__name__)
+
+_SPY = "SPY"
+_CASH = "CASH"
+_OK_STATUSES = {"optimal", "optimal_inaccurate"}
+
+
+def compute_drawdown_overlay(
+    nav: float,
+    peak_nav: float,
+    config: dict,
+    strategy_config: dict,
+    regime_intensity_z: float | None = None,
+) -> dict:
+    """Return the intraday drawdown posture.
+
+    Reuses ``compute_drawdown_multiplier`` verbatim so morning-planner and
+    intraday behaviour are identical. ``forced_exit_count`` mirrors the
+    morning §2g tiering. ``redeploy_suppressed`` is True in any drawdown tier
+    (multiplier < 1.0): while de-risking, cash freed by hard-risk exits must
+    stay cash rather than be redeployed by the re-solve.
+    """
+    multiplier, tier_desc = compute_drawdown_multiplier(
+        portfolio_nav=nav,
+        peak_nav=peak_nav,
+        config=config,
+        regime_intensity_z=regime_intensity_z,
+    )
+    forced_exit_count = 0
+    if strategy_config.get("drawdown_forced_exit_enabled", True) and multiplier < 1.0:
+        if multiplier <= 0.25:
+            forced_exit_count = int(strategy_config.get("drawdown_forced_exit_tier3_count", 2))
+        elif multiplier <= 0.50:
+            forced_exit_count = int(strategy_config.get("drawdown_forced_exit_tier2_count", 1))
+    return {
+        "multiplier": float(multiplier),
+        "tier_desc": tier_desc,
+        "forced_exit_count": forced_exit_count,
+        "redeploy_suppressed": multiplier < 1.0,
+    }
+
+
+def select_forced_exits(
+    current_positions: dict[str, dict],
+    signals_by_ticker: dict[str, dict],
+    already_exited: set[str],
+    target_count: int,
+) -> list[dict]:
+    """Lowest-conviction held names to force-exit, mirroring main.py §2g.
+
+    Idempotent: returns only NEW names beyond ``already_exited``, up to the
+    remaining headroom to reach ``target_count`` total forced exits.
+    """
+    if target_count <= 0:
+        return []
+    remaining = target_count - len(already_exited)
+    if remaining <= 0:
+        return []
+
+    def _rank(item):
+        t, pos = item
+        score = (signals_by_ticker.get(t, {}) or {}).get("score") or 50
+        return (score, pos.get("market_value", 0))
+
+    out: list[dict] = []
+    for t, pos in sorted(current_positions.items(), key=_rank):
+        if t in already_exited:
+            continue
+        shares = int(pos.get("shares", 0))
+        if shares > 0:
+            out.append({
+                "ticker": t,
+                "action": "EXIT",
+                "shares": shares,
+                "reason": "drawdown_forced_exit",
+                "detail": f"intraday drawdown de-risk ({target_count} forced exit(s) for tier)",
+            })
+        if len(out) >= remaining:
+            break
+    return out
+
+
+def w_prev_from_live(
+    tickers: list[str],
+    current_positions: dict[str, dict],
+    nav: float,
+    cash_idx: int,
+) -> np.ndarray:
+    """Current weights from LIVE positions (self-correcting idempotency).
+
+    Already-filled redeploy buys show up here, so a subsequent re-solve won't
+    re-buy them (the turnover band suppresses the now-zero delta).
+    """
+    w = np.zeros(len(tickers))
+    if nav <= 0:
+        w[cash_idx] = 1.0
+        return w
+    invested = 0.0
+    for i, t in enumerate(tickers):
+        if i == cash_idx:
+            continue
+        pos = current_positions.get(t)
+        if pos:
+            wi = float(pos.get("market_value", 0.0)) / nav
+            w[i] = wi
+            invested += wi
+    w[cash_idx] = max(0.0, 1.0 - invested)
+    return w
+
+
+def available_redeploy_cash(
+    tickers: list[str],
+    current_positions: dict[str, dict],
+    nav: float,
+    sleeve_pct: float,
+    pending_entry_dollars: float,
+) -> float:
+    """Cash above the target sleeve that is genuinely free to redeploy.
+
+    Subtracts still-pending entry dollars (morning entries AND already-enqueued
+    redeploy entries) so (a) we don't over-deploy past the sleeve while morning
+    entries are unfilled, and (b) the redeploy is idempotent — once buys are
+    enqueued they count here and the gate closes on the next tick.
+    """
+    cash_idx = tickers.index(_CASH)
+    w = w_prev_from_live(tickers, current_positions, nav, cash_idx)
+    excess = (w[cash_idx] - sleeve_pct) * nav
+    return excess - max(0.0, pending_entry_dollars)
+
+
+def solve_redeploy(
+    *,
+    shadow_log: dict,
+    current_positions: dict[str, dict],
+    nav: float,
+    stopped_out: set[str],
+) -> dict:
+    """Re-solve the optimizer reusing the morning Σ + alpha_hat (cached in the
+    shadow log) against LIVE positions, to redeploy freed cash to the sleeve.
+
+    Returns ``{status, buys, target_weights, vol_ann}``. ``buys`` is a list of
+    ``{ticker, delta_weight, delta_dollars, target_weight}`` for names whose
+    target exceeds the current live weight by more than the rebalance band. On
+    a non-optimal solve, ``buys`` is empty — the caller MUST leave cash idle
+    and log loud (the re-solve is load-bearing; it never silently no-ops as if
+    it had succeeded).
+    """
+    tickers = list(shadow_log["tickers"])
+    spy_idx = tickers.index(_SPY)
+    cash_idx = tickers.index(_CASH)
+
+    alpha_hat = np.asarray(shadow_log["alpha_hat"], dtype=float)
+    eligibility = np.asarray(shadow_log["eligibility"], dtype=bool).copy()
+    stance_caps = np.asarray(shadow_log["stance_caps"], dtype=float)
+    sectors = list(shadow_log["sectors"])
+    covariance = np.asarray(shadow_log["covariance_daily"], dtype=float)
+    cfg = dict(shadow_log.get("optimizer_cfg") or {})
+
+    au = shadow_log.get("alpha_uncertainty")
+    alpha_uncertainty = None
+    if au is not None:
+        alpha_uncertainty = np.asarray(
+            [np.nan if x is None else float(x) for x in au], dtype=float,
+        )
+
+    # Exclude same-day stopped-out names: the morning alpha is still positive
+    # for a name a gap stop just exited, so without this the re-solve would
+    # immediately re-buy it and undo the stop. Reuses the eligibility pin.
+    for t in stopped_out:
+        if t in tickers:
+            eligibility[tickers.index(t)] = False
+
+    w_prev = w_prev_from_live(tickers, current_positions, nav, cash_idx)
+
+    result = solve_target_weights(
+        tickers=tickers,
+        alpha_hat=alpha_hat,
+        returns_panel=None,
+        w_prev=w_prev,
+        sectors=sectors,
+        stance_caps=stance_caps,
+        eligibility=eligibility,
+        spy_idx=spy_idx,
+        cash_idx=cash_idx,
+        cfg=cfg,
+        alpha_uncertainty=alpha_uncertainty,
+        covariance=covariance,
+    )
+    status = result.diagnostics.get("status")
+    vol_ann = result.diagnostics.get("portfolio_vol_ann")
+    if status not in _OK_STATUSES:
+        return {"status": status, "buys": [], "target_weights": None, "vol_ann": vol_ann}
+
+    band = float(cfg.get("rebalance_band_pct", 0.005))
+    buys: list[dict] = []
+    for i, t in enumerate(tickers):
+        if i == cash_idx:
+            continue
+        dw = float(result.weights[i] - w_prev[i])
+        if dw > band:
+            buys.append({
+                "ticker": t,
+                "delta_weight": dw,
+                "delta_dollars": dw * nav,
+                "target_weight": float(result.weights[i]),
+            })
+    return {
+        "status": status,
+        "buys": buys,
+        "target_weights": [float(x) for x in result.weights],
+        "vol_ann": vol_ann,
+    }
+
+
+def build_redeploy_entry(
+    ticker: str,
+    shares: int,
+    price: float,
+    target_weight: float,
+    run_date: str,
+    pullback_pct: float = 0.02,
+) -> dict:
+    """Build a minimal order-book entry for an intraday redeploy buy.
+
+    Fills via the normal entry-trigger path (pullback / graduated / 3:55 ET
+    time-expiry) — NOT an immediate market order — so we don't chase into a
+    volatile name; the expiry guarantees same-day deployment.
+    """
+    return {
+        "ticker": ticker,
+        "signal": "ENTER",
+        "shares": int(shares),
+        "current_price": float(price),
+        "triggers": {
+            "pullback_pct": float(pullback_pct),
+            "vwap_discount": None,
+            "vwap": None,
+            "support_level": None,
+        },
+        "sizing_source": "optimizer_redeploy",
+        "sizing_factors": {"optimizer_target_weight": float(target_weight)},
+        "status": "pending",
+    }

--- a/executor/main.py
+++ b/executor/main.py
@@ -645,8 +645,17 @@ def _write_stops_and_finalize(
     run_date: str,
     blocked_entries: list[dict] | None = None,
     signals_bucket: str | None = None,
+    use_optimizer: bool = False,
 ) -> None:
-    """Write stop records for held positions, detect shorts, save order book, notify."""
+    """Write stop records for held positions, detect shorts, save order book, notify.
+
+    ``use_optimizer`` controls the ``stop_kind`` written on each stop record.
+    When True (optimizer is the sole portfolio-exit authority), stops are
+    marked ``catastrophic_gap_only`` — the daemon runs ONLY the per-name
+    catastrophic gap stop against them and suppresses the alpha rules
+    (trailing-stop, profit-take, collapse). When False, stops are marked
+    ``alpha`` and the daemon runs the full legacy IntradayExitManager.
+    """
     # ATR previously computed inline via _compute_atr(ticker_hist). Since
     # 2026-04-16 the executor reads atr_14_pct from the feature-store map
     # (load_atr_14_pct in main()) — same definition the predictor and sizing
@@ -678,7 +687,7 @@ def _write_stops_and_finalize(
             continue
         atr_val = ticker_atr_pct * entry_price
         stop_price = round(entry_price - atr_val * atr_mult, 2)
-        ob.add_stop({
+        stop_record = {
             "ticker": t,
             "entry_price": entry_price,
             "current_stop": stop_price,
@@ -687,7 +696,25 @@ def _write_stops_and_finalize(
             "high_water": entry_price,
             "entry_date": (conn and get_entry_dates(conn, [t]).get(t)) or run_date,
             "shares": pos_shares,
-        })
+        }
+        # ``stop_kind`` lets the daemon dispatch which exit checks run against
+        # this record. Under the optimizer, the only intraday exit allowed is
+        # the catastrophic single-name gap stop; alpha rules are suppressed.
+        # ``gap_reference_price`` anchors the gap check on the most recent
+        # close (gap-down detection), falling back to entry_price.
+        if use_optimizer:
+            stop_record["stop_kind"] = "catastrophic_gap_only"
+            gap_ref = entry_price
+            hist = (price_histories or {}).get(t)
+            if hist is not None and len(hist):
+                try:
+                    gap_ref = float(hist["close"].iloc[-1])
+                except (KeyError, IndexError, ValueError, TypeError):
+                    gap_ref = entry_price
+            stop_record["gap_reference_price"] = gap_ref
+        else:
+            stop_record["stop_kind"] = "alpha"
+        ob.add_stop(stop_record)
 
     # Detect short positions and add urgent cover orders
     for t, pos in current_pos.items():
@@ -1267,16 +1294,46 @@ def run(
         if "SPY" in (price_histories or {}):
             sector_etf_histories["SPY"] = price_histories["SPY"]
     
-        strategy_exits = evaluate_exits(
-            current_positions=current_positions,
-            signals_by_ticker=signals_by_ticker,
-            run_date=run_date,
-            price_histories=price_histories or {},
-            ibkr_client=ibkr,
-            strategy_config=strategy_config,
-            sector_etf_histories=sector_etf_histories or None,
-        )
-    
+        # Resolve the optimizer-authority flags once, early. Under
+        # ``use_portfolio_optimizer`` the optimizer is the SOLE authority for
+        # portfolio-level exits — it emits target-0 / scale-down SELLs in
+        # step 5b. ``optimizer_owns_exits`` additionally requires live mode
+        # (not simulate / not dry_run) because the optimizer cutover that
+        # GENERATES those SELLs only runs live (see step 5b gating). Gating
+        # the suppression on the same condition guarantees we never end up in
+        # a state where legacy exits are off AND optimizer exits are not
+        # generated (which would mean no exits at all). In simulate/dry_run
+        # the legacy path is unchanged — preserving backtester parity.
+        #
+        # Legacy "alpha" strategy exits (ATR trailing-stop, fallback_stop,
+        # profit_take, momentum_exit, time_decay_*, catalyst_hard_exit) fight
+        # the optimizer's target book and are suppressed BY CONSTRUCTION —
+        # incident 2026-05-29: the full SPY core was time-decay-exited and
+        # COST/RGEN were stopped/profit-taken while the optimizer wanted to
+        # keep them, dumping ~$196k to idle cash. Only hard-risk overrides
+        # survive: drawdown forced-exit (§2g below) and the daemon's
+        # catastrophic gap stop.
+        use_optimizer = bool(config.get("use_portfolio_optimizer", False))
+        optimizer_owns_exits = use_optimizer and not simulate and not dry_run
+        if optimizer_owns_exits:
+            strategy_exits = []
+            logger.info(
+                "use_portfolio_optimizer=True — suppressing legacy alpha "
+                "strategy exits; optimizer owns portfolio exits (drawdown "
+                "forced-exit + catastrophic gap stop remain as hard-risk "
+                "overrides)"
+            )
+        else:
+            strategy_exits = evaluate_exits(
+                current_positions=current_positions,
+                signals_by_ticker=signals_by_ticker,
+                run_date=run_date,
+                price_histories=price_histories or {},
+                ibkr_client=ibkr,
+                strategy_config=strategy_config,
+                sector_etf_histories=sector_etf_histories or None,
+            )
+
         if strategy_exits:
             logger.info(
                 f"Strategy layer generated {len(strategy_exits)} exit signal(s): "
@@ -1366,10 +1423,11 @@ def run(
         # ── 3. Process ENTER signals ─────────────────────────────────────────────
         # Cutover flag (PR 5 of portfolio-optimizer-260511): when true, the
         # legacy 1/n entry planner is skipped — the optimizer's MVO solution
-        # in step 5b drives the order book directly. Research EXIT / REDUCE
-        # signals + strategy_exits + drawdown forced exits still fire in
-        # step 4–5 below as protective overrides.
-        use_optimizer = bool(config.get("use_portfolio_optimizer", False))
+        # in step 5b drives the order book directly. ``use_optimizer`` /
+        # ``optimizer_owns_exits`` resolved once at §2d above. Under the
+        # optimizer, legacy research EXIT/REDUCE and alpha strategy exits are
+        # suppressed (the optimizer emits target-0/scale-down SELLs instead);
+        # only drawdown forced-exit + the catastrophic gap stop remain.
         if use_optimizer and not simulate and not dry_run:
             logger.info(
                 "use_portfolio_optimizer=True — skipping legacy _plan_entries; "
@@ -1435,8 +1493,17 @@ def run(
                     )
 
         # ── 4–5. Process EXIT and REDUCE signals ────────────────────────────────
+        # Under the optimizer, research EXIT is already handled via eligibility
+        # (signal=="EXIT" → ineligible → optimizer emits a target-0 SELL), and
+        # research REDUCE genuinely CONFLICTS — the optimizer may want to hold
+        # or even add to a name research is trimming. Suppress both legacy
+        # research-driven exit paths; only drawdown_forced_exit (carried in
+        # strategy_exits) and the optimizer's own SELLs remain.
+        exit_signals_in = signals
+        if optimizer_owns_exits:
+            exit_signals_in = {**signals, "exit": [], "reduce": []}
         exit_orders = _plan_exits_and_reduces(
-            signals=signals,
+            signals=exit_signals_in,
             strategy_exits=strategy_exits,
             predictions_by_ticker=predictions_by_ticker,
             current_positions=current_positions,
@@ -1545,7 +1612,7 @@ def run(
         # ── 6. Write stop records and save order book for daemon ────────────────
         if not simulate and not dry_run:
             try:
-                _write_stops_and_finalize(ibkr, ob, price_histories, atr_map, strategy_config, conn, run_date, blocked_entries, signals_bucket)
+                _write_stops_and_finalize(ibkr, ob, price_histories, atr_map, strategy_config, conn, run_date, blocked_entries, signals_bucket, use_optimizer=use_optimizer)
             except Exception as e:
                 logger.warning("Failed to write order book: %s", e)
 

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -33,6 +33,7 @@ import pandas as pd
 
 from executor.portfolio_optimizer import (
     OPTIMIZER_CONFIG_DEFAULTS,
+    _estimate_covariance_daily,
     solve_target_weights,
 )
 
@@ -127,6 +128,11 @@ def _build_and_solve(
         tickers, predictions_by_ticker, spy_idx, cash_idx,
     )
     returns_panel = _build_returns_panel(tickers, price_histories, cash_idx)
+    # Σ_daily (pre-horizon) is persisted below for the daemon's intraday
+    # re-solve. Computed deterministically from the SAME panel + cfg the morning
+    # solve uses internally, so the cached matrix is bit-identical to what
+    # solve_target_weights estimates — the re-solve is mechanism-identical.
+    sigma_daily = _estimate_covariance_daily(returns_panel, optimizer_cfg)
     w_prev = _build_w_prev(tickers, current_positions, portfolio_nav, cash_idx, optimizer_cfg)
     sectors = _build_sectors(tickers, signals_by_ticker, spy_idx, cash_idx)
     stance_caps = _build_stance_caps(
@@ -192,6 +198,7 @@ def _build_and_solve(
         "eligibility_reasons": list(eligibility_reasons),
         "stance_caps": [float(x) for x in stance_caps],
         "sectors": sectors,
+        "covariance_daily": [[float(x) for x in row] for row in sigma_daily],
         "would_be_trades": would_be_trades,
         "diagnostics": result.diagnostics,
         "legacy_orders": [_redact_order(o) for o in legacy_orders],

--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -58,7 +58,7 @@ class OptimizerResult:
 def solve_target_weights(
     tickers: list[str],
     alpha_hat: np.ndarray,
-    returns_panel: np.ndarray,
+    returns_panel: np.ndarray | None,
     w_prev: np.ndarray,
     sectors: list[str],
     stance_caps: np.ndarray,
@@ -68,6 +68,7 @@ def solve_target_weights(
     cfg: dict,
     *,
     alpha_uncertainty: np.ndarray | None = None,
+    covariance: np.ndarray | None = None,
 ) -> OptimizerResult:
     """
     Solve the constrained MVO and return target weights + diagnostics.
@@ -106,6 +107,16 @@ def solve_target_weights(
             covers the partial-rollout case during the 1-week soak between
             B.1 landing and the first BayesianRidge model being promoted
             in production. None ↔ no penalty regardless of γ.
+        covariance: optional shape (N,N) DAILY covariance matrix Σ_daily
+            (pre-horizon-scaling). When provided, the returns-panel estimator
+            step is skipped and this matrix is used directly (horizon scaling
+            still applied: Σ_H = H · Σ_daily). This is the intraday-re-solve
+            path: the daemon reuses the morning Σ (cached in the optimizer
+            shadow log) so an event-driven re-solve after a hard-risk exit is
+            mechanism-identical to the morning solve and adds zero alpha
+            look-ahead (Σ is daily-stable). ``returns_panel`` may be None when
+            ``covariance`` is provided. None ↔ estimate Σ from returns_panel
+            as before.
 
     Returns:
         OptimizerResult with weights (length N, sums to 1, sleeve pinned) and
@@ -116,13 +127,27 @@ def solve_target_weights(
     absorbing the residual) and diagnostics["status"] = "infeasible_fallback".
     """
     cfg = {**OPTIMIZER_CONFIG_DEFAULTS, **cfg}
+    N = len(tickers)
     _validate_inputs(
         tickers, alpha_hat, returns_panel, w_prev,
         sectors, stance_caps, eligibility, spy_idx, cash_idx,
+        covariance_provided=covariance is not None,
     )
 
-    N = len(tickers)
-    sigma = _estimate_covariance(returns_panel, cfg)
+    if covariance is not None:
+        # Intraday re-solve: reuse the morning DAILY Σ instead of re-estimating.
+        # Apply the SAME horizon scaling the estimator path applies (Σ_H =
+        # H · Σ_daily); persisting/injecting an already-horizon-scaled Σ here
+        # would double-scale and silently corrupt every vol diagnostic + the
+        # vol-target SOC constraint — guarded by _validate_covariance + the
+        # caller's vol-parity assertion.
+        sigma_daily = _validate_covariance(covariance, N)
+        horizon = int(cfg.get("sigma_horizon_days", 1))
+        if horizon < 1:
+            raise ValueError(f"sigma_horizon_days must be ≥ 1; got {horizon}")
+        sigma = horizon * sigma_daily
+    else:
+        sigma = _estimate_covariance(returns_panel, cfg)
     omega_diag, alpha_unc_used = _resolve_alpha_uncertainty(alpha_uncertainty, N, cfg)
 
     try:
@@ -280,6 +305,7 @@ def _validate_inputs(
     eligibility: np.ndarray,
     spy_idx: int,
     cash_idx: int,
+    covariance_provided: bool = False,
 ) -> None:
     N = len(tickers)
     if N == 0:
@@ -292,10 +318,16 @@ def _validate_inputs(
     ):
         if arr.shape != (N,):
             raise ValueError(f"{name} shape {arr.shape} != ({N},)")
-    if returns_panel.ndim != 2 or returns_panel.shape[1] != N:
-        raise ValueError(
-            f"returns_panel shape {returns_panel.shape} incompatible with N={N}"
-        )
+    # ``returns_panel`` is only required when estimating Σ from history. In the
+    # intraday re-solve path the caller supplies a precomputed covariance and
+    # may pass returns_panel=None.
+    if not covariance_provided:
+        if returns_panel is None:
+            raise ValueError("returns_panel is required when covariance is not provided")
+        if returns_panel.ndim != 2 or returns_panel.shape[1] != N:
+            raise ValueError(
+                f"returns_panel shape {returns_panel.shape} incompatible with N={N}"
+            )
     if len(sectors) != N:
         raise ValueError(f"sectors length {len(sectors)} != N={N}")
     if not (0 <= spy_idx < N) or not (0 <= cash_idx < N):
@@ -335,12 +367,35 @@ def _ewma_covariance(returns: np.ndarray, lambda_decay: float) -> np.ndarray:
     return (R.T * weights) @ R
 
 
-def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
-    """Return covariance at horizon ``cfg["sigma_horizon_days"]``.
+def _validate_covariance(cov: np.ndarray, N: int) -> np.ndarray:
+    """Validate + symmetrize a precomputed DAILY covariance for the re-solve.
 
-    Estimates Σ_daily via the configured estimator, then scales by horizon-days
-    under i.i.d. log-return assumption: Σ_H = H · Σ_daily. Default H=1 preserves
-    legacy daily Σ bit-identical (1 × Σ = Σ).
+    JSON round-tripping can introduce tiny asymmetry / non-PSD perturbations.
+    Symmetrize (0.5·(Σ+Σᵀ)) and fail LOUD on shape mismatch, non-finite
+    entries, or a materially negative eigenvalue — a silently mis-shaped Σ
+    would corrupt the entire vol math (vol-target SOC + every vol diagnostic).
+    """
+    cov = np.asarray(cov, dtype=float)
+    if cov.shape != (N, N):
+        raise ValueError(f"covariance shape {cov.shape} != ({N}, {N})")
+    if not np.all(np.isfinite(cov)):
+        raise ValueError("covariance contains non-finite entries")
+    cov = 0.5 * (cov + cov.T)
+    min_eig = float(np.linalg.eigvalsh(cov).min())
+    tol = -1e-8 * max(1.0, float(np.trace(cov)) / N)
+    if min_eig < tol:
+        raise ValueError(
+            f"covariance is not PSD (min eigenvalue {min_eig:.3e} < tol {tol:.3e})"
+        )
+    return cov
+
+
+def _estimate_covariance_daily(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
+    """Estimate the DAILY covariance Σ_daily (pre-horizon-scaling).
+
+    Split out of ``_estimate_covariance`` so the optimizer shadow log can
+    persist Σ_daily for an intraday re-solve (see ``solve_target_weights``'s
+    ``covariance`` argument). Horizon scaling lives in ``_estimate_covariance``.
 
     Estimators (cfg["covariance_shrinkage"]):
       * "ledoit_wolf" (default): Ledoit-Wolf 2004 constant-correlation shrinkage
@@ -385,6 +440,17 @@ def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
     else:
         raise ValueError(f"Unknown covariance_shrinkage: {estimator}")
 
+    return sigma_daily
+
+
+def _estimate_covariance(returns_panel: np.ndarray, cfg: dict) -> np.ndarray:
+    """Return covariance at horizon ``cfg["sigma_horizon_days"]``.
+
+    Estimates Σ_daily via ``_estimate_covariance_daily``, then scales by
+    horizon-days under i.i.d. log-return assumption: Σ_H = H · Σ_daily.
+    Default H=1 preserves legacy daily Σ bit-identical (1 × Σ = Σ).
+    """
+    sigma_daily = _estimate_covariance_daily(returns_panel, cfg)
     horizon = int(cfg.get("sigma_horizon_days", 1))
     if horizon < 1:
         raise ValueError(f"sigma_horizon_days must be ≥ 1; got {horizon}")

--- a/executor/strategies/config.py
+++ b/executor/strategies/config.py
@@ -36,6 +36,13 @@ MOMENTUM_EXIT_RSI = 30           # RSI(14) threshold
 FALLBACK_STOP_ENABLED = True
 FALLBACK_STOP_PCT = 0.10          # 10% loss from entry triggers exit
 
+# Catastrophic single-name gap stop — the ONLY intraday exit allowed when the
+# optimizer owns the book (stop_kind="catastrophic_gap_only"). A true hard-risk
+# control distinct from the retired alpha rules (trailing-stop/profit-take/
+# collapse). Fires on a large drop vs the gap reference price (recent close).
+CATASTROPHIC_GAP_STOP_ENABLED = True
+CATASTROPHIC_GAP_STOP_PCT = 0.15  # 15% drop from reference triggers full exit
+
 # ── Bracket stop defaults ────────────────────────────────────────────────────
 BRACKET_STOP_ENABLED = True
 BRACKET_TRAIL_ATR_MULTIPLE = 2.0   # trailing stop = ATR * this value
@@ -122,6 +129,10 @@ def load_strategy_config(config: dict) -> dict:
         # Fallback stop (when ATR unavailable)
         "fallback_stop_enabled": exit_cfg.get("fallback_stop_enabled", FALLBACK_STOP_ENABLED),
         "fallback_stop_pct": exit_cfg.get("fallback_stop_pct", FALLBACK_STOP_PCT),
+
+        # Catastrophic single-name gap stop (optimizer-mode hard-risk override)
+        "catastrophic_gap_stop_enabled": exit_cfg.get("catastrophic_gap_stop_enabled", CATASTROPHIC_GAP_STOP_ENABLED),
+        "catastrophic_gap_stop_pct": exit_cfg.get("catastrophic_gap_stop_pct", CATASTROPHIC_GAP_STOP_PCT),
 
         # Graduated drawdown
         "graduated_drawdown_enabled": drawdown_cfg.get("enabled", GRADUATED_DRAWDOWN_ENABLED),

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -230,6 +230,51 @@ class TestIntradayExitManager:
         # Tightened to 1.5x ATR = 7.5, so stop = 155 - 7.5 = 147.5
         assert new_stop == 147.5
 
+    # ── Catastrophic gap stop (optimizer-mode hard-risk override) ────────────
+    def test_catastrophic_gap_fires(self):
+        mgr = self._mgr()  # default pct 0.15
+        result = mgr.check_catastrophic_gap(
+            {"ticker": "AAPL", "gap_reference_price": 200.0, "shares": 10},
+            {"last": 169.0},  # -15.5% from reference
+        )
+        assert result is not None
+        assert result["action"] == "EXIT"
+        assert result["reason"] == "catastrophic_gap_stop"
+        assert result["shares"] == 10
+
+    def test_catastrophic_gap_no_fire_above_threshold(self):
+        mgr = self._mgr()
+        result = mgr.check_catastrophic_gap(
+            {"ticker": "AAPL", "gap_reference_price": 200.0, "shares": 10},
+            {"last": 175.0},  # -12.5% — above the 15% threshold
+        )
+        assert result is None
+
+    def test_catastrophic_gap_falls_back_to_entry_price(self):
+        mgr = self._mgr()
+        result = mgr.check_catastrophic_gap(
+            {"ticker": "AAPL", "entry_price": 100.0, "shares": 10},  # no gap_reference_price
+            {"last": 80.0},  # -20% from entry
+        )
+        assert result is not None
+        assert result["reason"] == "catastrophic_gap_stop"
+
+    def test_catastrophic_gap_disabled(self):
+        mgr = self._mgr(catastrophic_gap_stop_enabled=False)
+        result = mgr.check_catastrophic_gap(
+            {"ticker": "AAPL", "gap_reference_price": 200.0, "shares": 10},
+            {"last": 150.0},  # -25% but disabled
+        )
+        assert result is None
+
+    def test_catastrophic_gap_custom_threshold(self):
+        mgr = self._mgr(catastrophic_gap_stop_pct=0.10)
+        result = mgr.check_catastrophic_gap(
+            {"ticker": "AAPL", "gap_reference_price": 200.0, "shares": 10},
+            {"last": 178.0},  # -11% — fires at 10% threshold
+        )
+        assert result is not None
+
 
 # ---------------------------------------------------------------------------
 # market_hours

--- a/tests/test_intraday_resolve.py
+++ b/tests/test_intraday_resolve.py
@@ -1,0 +1,173 @@
+"""Unit tests for executor/intraday_resolve.py — the daemon's intraday
+reconcile-to-target layer (real-time drawdown overlay + event-driven re-solve).
+
+Covers the 2026-05-29 fix: under the optimizer, cash freed intraday by
+hard-risk exits is redeployed back to the sleeve same-day, and a real-time
+drawdown overlay can force de-risking + suppress redeploy.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from executor.portfolio_optimizer import (
+    OPTIMIZER_CONFIG_DEFAULTS,
+    _estimate_covariance_daily,
+)
+from executor.intraday_resolve import (
+    available_redeploy_cash,
+    build_redeploy_entry,
+    compute_drawdown_overlay,
+    select_forced_exits,
+    solve_redeploy,
+    w_prev_from_live,
+)
+
+
+# ── Drawdown overlay ─────────────────────────────────────────────────────────
+
+def _dd_config():
+    return {
+        "drawdown_circuit_breaker": 0.08,
+        "strategy": {
+            "graduated_drawdown": {
+                "enabled": True,
+                "tiers": [
+                    [-0.02, 1.00, "0 to -2%"],
+                    [-0.04, 0.50, "-2 to -4%"],
+                    [-0.06, 0.25, "-4 to -6%"],
+                ],
+            },
+        },
+    }
+
+
+def _strategy_config():
+    from executor.strategies.config import load_strategy_config
+    return load_strategy_config(_dd_config())
+
+
+def test_overlay_no_drawdown_allows_redeploy():
+    overlay = compute_drawdown_overlay(1_000_000, 1_000_000, _dd_config(), _strategy_config())
+    assert overlay["multiplier"] == pytest.approx(1.0)
+    assert overlay["forced_exit_count"] == 0
+    assert overlay["redeploy_suppressed"] is False
+
+
+def test_overlay_deep_drawdown_forces_exits_and_suppresses_redeploy():
+    # -7% from peak → deepest soft tier (mult 0.25) → tier3 forced exits.
+    overlay = compute_drawdown_overlay(930_000, 1_000_000, _dd_config(), _strategy_config())
+    assert overlay["multiplier"] <= 0.25
+    assert overlay["forced_exit_count"] == 2  # tier3 default
+    assert overlay["redeploy_suppressed"] is True
+
+
+# ── Forced-exit selection ────────────────────────────────────────────────────
+
+def test_select_forced_exits_lowest_conviction_first_and_idempotent():
+    positions = {
+        "AAA": {"shares": 10, "market_value": 1000},
+        "BBB": {"shares": 10, "market_value": 5000},
+        "CCC": {"shares": 10, "market_value": 9000},
+    }
+    signals = {"AAA": {"score": 80}, "BBB": {"score": 40}, "CCC": {"score": 90}}
+    out = select_forced_exits(positions, signals, set(), target_count=2)
+    tickers = [o["ticker"] for o in out]
+    assert tickers == ["BBB", "AAA"]  # lowest score first, then next-lowest
+    assert all(o["reason"] == "drawdown_forced_exit" for o in out)
+    # Idempotent: with one already exited, only the remaining headroom returns.
+    out2 = select_forced_exits(positions, signals, {"BBB"}, target_count=2)
+    assert [o["ticker"] for o in out2] == ["AAA"]
+    # Target already met → nothing.
+    assert select_forced_exits(positions, signals, {"BBB", "AAA"}, 2) == []
+
+
+# ── Live weights / available cash ────────────────────────────────────────────
+
+def test_w_prev_from_live_and_available_cash():
+    tickers = ["AAA", "BBB", "SPY", "CASH"]
+    positions = {"AAA": {"market_value": 80_000}, "SPY": {"market_value": 100_000}}
+    nav = 1_000_000.0
+    w = w_prev_from_live(tickers, positions, nav, cash_idx=3)
+    assert w[0] == pytest.approx(0.08)
+    assert w[2] == pytest.approx(0.10)
+    assert w[3] == pytest.approx(1.0 - 0.18)  # cash absorbs the rest
+    # Excess over a 3% sleeve, net of pending entries.
+    avail = available_redeploy_cash(tickers, positions, nav, sleeve_pct=0.03, pending_entry_dollars=0.0)
+    assert avail == pytest.approx((0.82 - 0.03) * nav)
+    avail2 = available_redeploy_cash(tickers, positions, nav, 0.03, pending_entry_dollars=200_000)
+    assert avail2 == pytest.approx((0.82 - 0.03) * nav - 200_000)
+
+
+# ── solve_redeploy ───────────────────────────────────────────────────────────
+
+def _shadow_log(n_active=2, seed=1):
+    tickers = [f"T{i}" for i in range(n_active)] + ["SPY", "CASH"]
+    N = len(tickers)
+    cash_idx = N - 1
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(0.0, 0.01, size=(250, N))
+    returns[:, cash_idx] = 0.0
+    cfg = {**OPTIMIZER_CONFIG_DEFAULTS}
+    sigma_daily = _estimate_covariance_daily(returns, cfg)
+    alpha_hat = [0.05, 0.04, 0.03][:n_active] + [0.0, -1e-6]  # active picks + SPY + CASH
+    stance = [0.08] * n_active + [1.0, 1.0]
+    sectors = ["tech"] * n_active + ["__benchmark__", "__cash__"]
+    return {
+        "tickers": tickers,
+        "alpha_hat": alpha_hat,
+        "eligibility": [True] * N,
+        "stance_caps": stance,
+        "sectors": sectors,
+        "covariance_daily": [[float(x) for x in row] for row in sigma_daily],
+        "alpha_uncertainty": None,
+        "optimizer_cfg": cfg,
+    }
+
+
+def test_solve_redeploy_deploys_excess_cash():
+    log = _shadow_log(n_active=2)
+    # Lots of idle cash: only T0 held at 8%, rest cash.
+    positions = {"T0": {"market_value": 80_000}}
+    res = solve_redeploy(shadow_log=log, current_positions=positions, nav=1_000_000.0, stopped_out=set())
+    assert res["status"] in ("optimal", "optimal_inaccurate")
+    buy_tickers = {b["ticker"] for b in res["buys"]}
+    # Should redeploy into T1 and SPY (T0 already at target cap).
+    assert "SPY" in buy_tickers
+    assert "T1" in buy_tickers
+    assert "CASH" not in buy_tickers
+
+
+def test_solve_redeploy_excludes_stopped_out_name():
+    log = _shadow_log(n_active=2)
+    positions = {"T0": {"market_value": 80_000}}
+    res = solve_redeploy(
+        shadow_log=log, current_positions=positions, nav=1_000_000.0,
+        stopped_out={"T1"},
+    )
+    assert res["status"] in ("optimal", "optimal_inaccurate")
+    assert "T1" not in {b["ticker"] for b in res["buys"]}, \
+        "A name a gap stop just exited must not be re-bought same-day"
+
+
+def test_solve_redeploy_nonoptimal_returns_no_buys():
+    log = _shadow_log(n_active=2)
+    # Make it infeasible: caps too small to reach 0.97 with cash pinned at 0.03.
+    log["stance_caps"] = [0.01, 0.01, 0.01, 1.0]
+    positions = {"T0": {"market_value": 80_000}}
+    res = solve_redeploy(shadow_log=log, current_positions=positions, nav=1_000_000.0, stopped_out=set())
+    assert res["status"] not in ("optimal", "optimal_inaccurate")
+    assert res["buys"] == []
+
+
+# ── Redeploy entry record ────────────────────────────────────────────────────
+
+def test_build_redeploy_entry_shape():
+    e = build_redeploy_entry("SPY", 100, 755.0, 0.81, "2026-05-29")
+    assert e["ticker"] == "SPY"
+    assert e["signal"] == "ENTER"
+    assert e["shares"] == 100
+    assert e["sizing_source"] == "optimizer_redeploy"
+    assert e["status"] == "pending"
+    assert e["triggers"]["vwap"] is None

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -860,3 +860,119 @@ def test_uncertainty_penalty_composes_with_horizon_and_ewma():
     assert result.diagnostics["status"] in ("optimal", "optimal_inaccurate")
     assert result.diagnostics["alpha_uncertainty_penalty_used"] is True
     assert result.weights[0] < result.weights[1]
+
+
+# ── Covariance-injection re-solve path (intraday reconcile) ──────────────────
+# The daemon's intraday re-solve reuses the morning DAILY covariance Σ cached in
+# the optimizer shadow log instead of re-estimating from a returns panel. These
+# tests pin that the injected path is mechanism-identical to the estimated path.
+
+from executor.portfolio_optimizer import (  # noqa: E402
+    _estimate_covariance_daily,
+    _validate_covariance,
+)
+
+
+def _solved_pair(u: dict):
+    """Solve once estimating Σ from the panel, once injecting Σ_daily from the
+    SAME panel. Returns (estimated_result, injected_result)."""
+    u["stance_caps"][u["spy_idx"]] = 1.0
+    u["stance_caps"][u["cash_idx"]] = 1.0
+    cfg_full = {**OPTIMIZER_CONFIG_DEFAULTS, **u["cfg"]}
+    sigma_daily = _estimate_covariance_daily(u["returns_panel"], cfg_full)
+    est = solve_target_weights(**u)
+    inj_kwargs = {**u, "returns_panel": None, "covariance": sigma_daily}
+    inj = solve_target_weights(**inj_kwargs)
+    return est, inj, sigma_daily
+
+
+def test_covariance_injection_matches_estimated_path():
+    """covariance=None vs covariance=Σ_daily (same panel) → identical output."""
+    u = _baseline_universe(n_active=3)
+    u["alpha_hat"][0] = 0.05
+    u["alpha_hat"][1] = 0.03
+    u["alpha_hat"][2] = -0.02
+    est, inj, _ = _solved_pair(u)
+    np.testing.assert_allclose(est.weights, inj.weights, atol=1e-9)
+    assert inj.diagnostics["portfolio_vol_ann"] == pytest.approx(
+        est.diagnostics["portfolio_vol_ann"], rel=1e-9,
+    )
+    assert inj.diagnostics["status"] == est.diagnostics["status"]
+
+
+def test_covariance_injection_horizon_aware():
+    """Injected Σ_daily honors sigma_horizon_days exactly like the estimator."""
+    u = _baseline_universe(n_active=3)
+    u["alpha_hat"][0] = 0.05
+    u["alpha_hat"][1] = 0.03
+    u["cfg"] = {"sigma_horizon_days": 21}
+    est, inj, _ = _solved_pair(u)
+    np.testing.assert_allclose(est.weights, inj.weights, atol=1e-9)
+    assert inj.diagnostics["portfolio_vol_ann"] == pytest.approx(
+        est.diagnostics["portfolio_vol_ann"], rel=1e-9,
+    )
+
+
+def test_covariance_injection_json_roundtrip():
+    """Σ persisted to JSON (shadow log) and reloaded still re-solves identically."""
+    import json
+    u = _baseline_universe(n_active=3)
+    u["alpha_hat"][0] = 0.05
+    u["alpha_hat"][1] = 0.03
+    u["stance_caps"][u["spy_idx"]] = 1.0
+    u["stance_caps"][u["cash_idx"]] = 1.0
+    cfg_full = {**OPTIMIZER_CONFIG_DEFAULTS, **u["cfg"]}
+    sigma_daily = _estimate_covariance_daily(u["returns_panel"], cfg_full)
+
+    in_mem = solve_target_weights(**{**u, "returns_panel": None, "covariance": sigma_daily})
+    serialized = json.loads(json.dumps([[float(x) for x in row] for row in sigma_daily]))
+    reloaded = np.asarray(serialized, dtype=float)
+    round_tripped = solve_target_weights(**{**u, "returns_panel": None, "covariance": reloaded})
+    np.testing.assert_allclose(in_mem.weights, round_tripped.weights, atol=1e-9)
+
+
+def test_validate_covariance_rejects_bad_shape():
+    with pytest.raises(ValueError, match="covariance shape"):
+        _validate_covariance(np.eye(4), 5)
+
+
+def test_validate_covariance_rejects_non_finite():
+    bad = np.eye(3)
+    bad[0, 0] = np.nan
+    with pytest.raises(ValueError, match="non-finite"):
+        _validate_covariance(bad, 3)
+
+
+def test_validate_covariance_rejects_non_psd():
+    # Symmetric but indefinite (negative eigenvalue).
+    bad = np.array([[1.0, 2.0, 0.0], [2.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+    with pytest.raises(ValueError, match="not PSD"):
+        _validate_covariance(bad, 3)
+
+
+def test_validate_covariance_symmetrizes_tiny_asymmetry():
+    sym = np.array([[1.0, 0.2, 0.1], [0.2, 1.0, 0.3], [0.1, 0.3, 1.0]])
+    nearly = sym.copy()
+    nearly[0, 1] += 1e-12  # JSON-roundtrip-scale asymmetry
+    out = _validate_covariance(nearly, 3)
+    np.testing.assert_allclose(out, out.T, atol=0.0)  # exactly symmetric
+
+
+def test_covariance_provided_allows_none_returns_panel():
+    """returns_panel=None is valid when covariance is supplied."""
+    u = _baseline_universe(n_active=2)
+    u["alpha_hat"][0] = 0.04
+    u["stance_caps"][u["spy_idx"]] = 1.0
+    u["stance_caps"][u["cash_idx"]] = 1.0
+    cfg_full = {**OPTIMIZER_CONFIG_DEFAULTS, **u["cfg"]}
+    sigma_daily = _estimate_covariance_daily(u["returns_panel"], cfg_full)
+    res = solve_target_weights(**{**u, "returns_panel": None, "covariance": sigma_daily})
+    assert res.diagnostics["status"] in ("optimal", "optimal_inaccurate")
+
+
+def test_missing_returns_panel_without_covariance_raises():
+    u = _baseline_universe(n_active=2)
+    u["stance_caps"][u["spy_idx"]] = 1.0
+    u["stance_caps"][u["cash_idx"]] = 1.0
+    with pytest.raises(ValueError, match="returns_panel is required"):
+        solve_target_weights(**{**u, "returns_panel": None})


### PR DESCRIPTION
## Why
On **2026-05-29** the portfolio ended at **22.3% cash with SPY fully exited** (target: 3% sleeve + SPY core). Root cause: **two control regimes fighting**. The optimizer (`use_portfolio_optimizer: true`) plans a fully-invested book once each morning, but the daemon's legacy *alpha* exits fired intraday and liquidated positions the optimizer wanted to keep:

| Ticker | Optimizer wanted | Daemon did | Reason |
|---|---|---|---|
| SPY | trim 14 sh -> 7% | **EXIT all 111 sh** | `time_decay_exit` (held 10d) |
| COST | hold 8% | **EXIT all 82 sh** | `intraday_trailing_stop` |
| RGEN | hold 8% | **REDUCE 267 sh** | `intraday_profit_take` |

Freed ~$196k; only ~$105k of morning buys redeployed -> cash ballooned, SPY -> 0. The optimizer itself was correct (`status: optimal`, target cash 3%, SPY 7%).

This PR makes the optimizer the **sole authority** for portfolio-level entries *and* exits, and gives the daemon a **real-time risk overlay + reconcile-to-target re-solve** so cash freed intraday by hard-risk exits is redeployed same-day.

## Phase 1 — optimizer is sole exit authority
- `main.py`: under `optimizer_owns_exits` (use_portfolio_optimizer & live), suppress **all** legacy alpha strategy exits (ATR trailing-stop, fallback_stop, profit_take, momentum_exit, time_decay_*, catalyst_hard_exit) by construction, plus legacy research EXIT/REDUCE (EXIT already maps to optimizer target-0 via eligibility; REDUCE genuinely conflicts). Only **drawdown forced-exit** + the **new catastrophic gap stop** survive. Suppression is in the shell, not `deciders.py` -> backtester parity untouched.
- `_write_stops_and_finalize` tags each stop with `stop_kind` (`catastrophic_gap_only` under the optimizer, `alpha` legacy); daemon dispatches on it so alpha rules are structurally dead under the optimizer.

## Phase 2 — real-time risk overlay + reconcile-to-target
- `solve_target_weights` gains an optional precomputed **daily covariance** (validated/symmetrized/PSD-checked, horizon-scaled identically to the estimator path); `optimizer_shadow` persists `covariance_daily` so an intraday re-solve is **mechanism-identical** to the morning solve.
- New `executor/intraday_resolve.py`:
  - **Real-time drawdown overlay** reusing `compute_drawdown_multiplier` (identical to morning): force de-risk + **suppress redeploy** in a drawdown.
  - **Event-driven re-solve** reusing morning alpha_hat + Sigma (daily-stable -> zero new look-ahead) against **live positions**, redeploying excess cash to the sleeve. Excludes same-day **stopped-out** names (eligibility pin), w_prev from live (idempotent), **fails loud** on non-optimal solves, gated by freed-cash threshold + 15:30 ET cutoff + per-day cap. Redeploy buys fill via normal entry triggers (+ 3:55 expiry), not market orders.
- New per-name **catastrophic gap stop** in `intraday_exit_manager` (default -15%).

## Config (new keys; defaults preserve current behavior — only active when use_portfolio_optimizer)
`strategy.exit_manager.catastrophic_gap_stop_enabled/_pct`; `portfolio_optimizer.intraday_resolve_enabled`, `intraday_drawdown_overlay_enabled`, `intraday_resolve_min_freed_cash_pct`, `intraday_resolve_cutoff_et`, `intraday_resolve_max_per_day`.

## Tests — full suite 1061 passing
- `test_portfolio_optimizer.py`: covariance-injection **parity** / horizon / JSON round-trip / PSD+shape validation / returns_panel-optional.
- `test_intraday_resolve.py` (new): overlay tiers, forced-exit selection, live-weight/available-cash, solve_redeploy deploy/exclude-stopped-out/non-optimal.
- `test_intraday.py`: gap stop fires/no-fire/fallback/disabled/custom-threshold.
- `test_decider_parity.py` unchanged (suppression is in the shell).

## Notes
- Behavioral coverage via unit tests; full live dry-run needs IB Gateway + ArcticDB (EC2-only). Legacy (optimizer-off) behavior is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)