### PR TITLE
feat(executor): hold-book safeguard on predictor distribution-gate fail

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -25,7 +25,7 @@ import logging
 import os
 import sys
 import time as _time
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -633,6 +633,41 @@ def _write_order_book_summary(
         logger.info("Order book summary written to s3://%s/%s", signals_bucket, key)
     except Exception as e:
         logger.warning("Failed to write order book summary (non-fatal): %s", e)
+
+
+def _write_hold_book_flag(
+    bucket: str, run_date: str, predictions_date: str | None, gate: dict
+) -> None:
+    """Persist a dashboard-readable record that the hold-book safeguard fired
+    this run (predictor distribution gate flagged "strongly biased" → optimizer
+    rebalance suppressed → current book held). Writes both a dated artifact and
+    a ``latest.json`` pointer under ``executor/hold_book_flags/`` so the console
+    can banner the discrepancy for operator review. Best-effort — the caller
+    swallows failures so an audit-artifact write never blocks the planner.
+    """
+    import boto3 as _boto3
+
+    payload = json.dumps(
+        {
+            "run_date": run_date,
+            "predictions_date": predictions_date,
+            "held": True,
+            "reason": gate.get("reason"),
+            "failed_check": gate.get("failed_check"),
+            "gate_metrics": gate.get("metrics"),
+            "written_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        },
+        indent=2,
+    )
+    _s3 = _boto3.client("s3")
+    for _key in (
+        f"executor/hold_book_flags/{run_date}.json",
+        "executor/hold_book_flags/latest.json",
+    ):
+        _s3.put_object(
+            Bucket=bucket, Key=_key, Body=payload.encode(),
+            ContentType="application/json",
+        )
 
 
 def _write_stops_and_finalize(
@@ -1571,7 +1606,35 @@ def run(
                 apply_optimizer_targets_to_orderbook,
                 is_log_usable,
             )
-            if is_log_usable(shadow_log):
+            from executor.signal_reader import read_distribution_gate
+            # ── Hold-book safeguard (2026-06-01 decision) ─────────────────────
+            # If the predictor's output-distribution gate flagged this batch
+            # "strongly biased", DO NOT let the optimizer rotate the book off
+            # it — hold the current positions and surface the discrepancy for
+            # operator review. Stops are still written below; the daemon's
+            # hard-risk overrides (drawdown forced-exit, catastrophic gap stop)
+            # remain active. Fail-open: a missing/None gate proceeds normally;
+            # only an explicit passed=False holds. Origin: the 6/1 8-model
+            # level-biased recalibration (89.7% DOWN-skew) flushed the book to
+            # SPY on its first inference before this safeguard existed.
+            _gate = read_distribution_gate(signals_bucket)
+            _gate_failed = _gate is not None and _gate.get("passed") is False
+            if _gate_failed:
+                logger.warning(
+                    "HOLD-BOOK SAFEGUARD ACTIVE: predictor output_distribution_gate "
+                    "FAILED (check=%s) for predictions %s — suppressing optimizer "
+                    "rebalance; current book retained (stops written; daemon "
+                    "hard-risk overrides remain active). reason=%s",
+                    _gate.get("failed_check"), predictions_date, _gate.get("reason"),
+                )
+                try:
+                    _write_hold_book_flag(signals_bucket, run_date, predictions_date, _gate)
+                except Exception as _hb_err:
+                    logger.warning(
+                        "hold-book flag artifact write failed (non-blocking): %s",
+                        _hb_err,
+                    )
+            elif is_log_usable(shadow_log):
                 opt_entries, opt_exits = apply_optimizer_targets_to_orderbook(
                     log=shadow_log,
                     ob=ob,

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -208,6 +208,28 @@ def read_predictions(s3_bucket: str) -> tuple[dict[str, dict], str | None]:
         raise
 
 
+def read_distribution_gate(s3_bucket: str) -> dict | None:
+    """Read the predictor ``output_distribution_gate`` block from
+    ``predictor/predictions/latest.json``.
+
+    Returns the gate dict (``passed`` / ``failed_check`` / ``reason`` /
+    ``metrics`` / ...) or ``None`` when absent — older predictions written
+    before the block was surfaced (2026-06-01), or no predictions at all.
+    Callers MUST treat ``None`` as "no gate signal" and proceed normally
+    (fail-open): only an explicit ``passed is False`` triggers the hold-book
+    safeguard, never a missing gate. See the 2026-06-01 hold-book decision.
+    """
+    s3 = boto3.client("s3")
+    try:
+        obj = s3.get_object(Bucket=s3_bucket, Key="predictor/predictions/latest.json")
+        data = json.loads(obj["Body"].read())
+        return data.get("output_distribution_gate")
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "NoSuchKey":
+            return None
+        raise
+
+
 def read_signals(s3_bucket: str, run_date: str | None = None) -> dict:
     """
     Download signals/{date}/signals.json from S3.

--- a/tests/test_signal_reader_distribution_gate.py
+++ b/tests/test_signal_reader_distribution_gate.py
@@ -1,0 +1,68 @@
+"""Tests for read_distribution_gate — the executor's reader for the predictor
+output-distribution gate block that drives the hold-book safeguard (2026-06-01).
+
+The gate block is carried on predictions/latest.json (surfaced 2026-06-01 in the
+predictor's write_output stage). The executor reads it and, if passed is False
+("strongly biased" batch), holds the current book instead of letting the
+optimizer rotate off the flagged predictions.
+
+Fail-open contract: a missing gate (older predictions / no predictions) returns
+None, and the caller must NOT hold-book on None — only an explicit passed=False.
+"""
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import ClientError
+
+from executor.signal_reader import read_distribution_gate
+
+
+def _fake_s3(payload: dict):
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": io.BytesIO(json.dumps(payload).encode())}
+    return s3
+
+
+def test_returns_gate_block_when_failed():
+    payload = {
+        "date": "2026-06-01",
+        "output_distribution_gate": {
+            "passed": False,
+            "failed_check": "direction_skew",
+            "reason": "direction skew 89.66% exceeds 85%",
+            "metrics": {"direction_skew": 0.8966, "n_up": 3, "n_down": 26},
+        },
+        "predictions": [],
+    }
+    with patch("executor.signal_reader.boto3.client", return_value=_fake_s3(payload)):
+        gate = read_distribution_gate("bucket")
+    assert gate is not None
+    assert gate["passed"] is False
+    assert gate["failed_check"] == "direction_skew"
+
+
+def test_returns_gate_block_when_passed():
+    payload = {"output_distribution_gate": {"passed": True}, "predictions": []}
+    with patch("executor.signal_reader.boto3.client", return_value=_fake_s3(payload)):
+        gate = read_distribution_gate("bucket")
+    assert gate is not None and gate["passed"] is True
+
+
+def test_missing_gate_returns_none_fail_open():
+    """Older predictions without the block → None (caller proceeds normally)."""
+    payload = {"date": "2026-05-29", "predictions": [{"ticker": "AAPL"}]}
+    with patch("executor.signal_reader.boto3.client", return_value=_fake_s3(payload)):
+        assert read_distribution_gate("bucket") is None
+
+
+def test_no_predictions_object_returns_none():
+    """NoSuchKey → None, never raises (fail-open)."""
+    s3 = MagicMock()
+    s3.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey", "Message": "Not Found"}}, "GetObject"
+    )
+    with patch("executor.signal_reader.boto3.client", return_value=s3):
+        assert read_distribution_gate("bucket") is None


### PR DESCRIPTION
Activates the consumer-cutover for the 2026-06-01 hold-book decision: a **strongly-biased** predictor batch (output_distribution_gate `passed=False`) no longer drives an optimizer rotation — the planner **holds the current book** and flags the discrepancy for operator review.

**Behavior**
- `read_distribution_gate()` reads the gate off predictions/latest.json; **fail-open** (None → proceed normally; only explicit `passed=False` holds).
- main.py optimizer path: gate-fail → skip `apply_optimizer_targets_to_orderbook` → book held (stops still written; daemon hard-risk overrides — drawdown forced-exit, catastrophic gap stop — remain active).
- `_write_hold_book_flag` → `executor/hold_book_flags/{date}.json` (+latest) for the dashboard banner (separate PR).

**Origin:** the 6/1 8-model level-biased recalibration (89.7% DOWN-skew) flushed the book to SPY on its first inference before this existed. Depends on the predictor PR surfacing the gate into predictions.json.

4 new tests; full executor suite **1065 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)