### PR TITLE
fix(iam): ssm:SendCommand on account-less AWS-RunShellScript ARN (unblocks spot SSM)

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-send.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-ssm-send.json
@@ -5,7 +5,10 @@
       "Sid": "SendCommandRunShellScriptDocument",
       "Effect": "Allow",
       "Action": "ssm:SendCommand",
-      "Resource": "arn:aws:ssm:us-east-1:711398986525:document/AWS-RunShellScript"
+      "Resource": [
+        "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
+        "arn:aws:ssm:us-east-1:711398986525:document/AWS-RunShellScript"
+      ]
     },
     {
       "Sid": "SendCommandToAlphaEngineTaggedInstances",


### PR DESCRIPTION
## What

The executor role's `alpha-engine-ssm-send` policy granted `ssm:SendCommand` only on the **account-scoped** document ARN `…:711398986525:document/AWS-RunShellScript`. AWS evaluates `SendCommand` against the **AWS-owned document's account-less ARN** `…::document/AWS-RunShellScript`, so the grant didn't match → `AccessDenied` on the document.

Surfaced launching the one-off factor-momentum backfill spot (the instance-tag statement matched once the spot was named `alpha-engine-*`; the *document* grant was the remaining denial). Fix: grant **both** the account-less and account-scoped ARNs.

```json
"Resource": [
  "arn:aws:ssm:us-east-1::document/AWS-RunShellScript",
  "arn:aws:ssm:us-east-1:711398986525:document/AWS-RunShellScript"
]
```

## Safety

Does **not** broaden which instances are targetable — the `Name=alpha-engine-*` condition on the instance statement is unchanged. This only matches the AWS-managed document. 

## Process

Applied to the live `alpha-engine-executor-role` via `apply.sh --role … --policy alpha-engine-ssm-send` **pre-merge** (per the IAM-grant discipline), so live == codified and the drift-check passes.

## Why it matters beyond the one-off

The **weekly Saturday SF's DataPhase1** spot uses the same role + `AWS-RunShellScript` document via the same `ssm_dispatcher`, so this likely closes a latent `SendCommand` gap there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)