### PR TITLE
feat(obr): flag optimizer-targeted-but-dropped as an ERROR state (L4501)

### DIFF
--- a/executor/optimizer_cutover.py
+++ b/executor/optimizer_cutover.py
@@ -125,12 +125,12 @@ def apply_optimizer_targets_to_orderbook(
         if current_price is None:
             # Every price source failed (no live snapshot after retries AND
             # no usable price history). The optimizer's target cannot be
-            # sized, so it is dropped for this run — but LOUDLY. Dropping a
-            # producer's allocation (esp. its largest target) with only a
-            # debug log is the silent-degrade failure this fix exists to
-            # kill (L4500). WARN names the lost allocation; the CW metric +
-            # alarm gives the drop a recording surface the operator can see.
-            logger.warning(
+            # sized, so it is dropped for this run — and this is an ERROR,
+            # not a benign skip: the optimizer's allocation (esp. its
+            # largest target) is LOST. Logged at ERROR + CW alarm + the
+            # OBR surfaces the ticker as no_action_optimizer_dropped (an
+            # error state). Per [[feedback_no_silent_fails]] (L4500/L4501).
+            logger.error(
                 "optimizer_cutover: DROPPING %s %s target_weight=%.4f $%.2f — "
                 "no price after %d ibkr attempts and no usable price_histories "
                 "close. Optimizer allocation LOST for this run; emitting "

--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -65,20 +65,38 @@ STATE_HELD = "held"
 # always emits one of the two sub-states below. Consumers reading
 # pre-1.2.0 artifacts may still encounter the bare slug.
 STATE_NO_ACTION = "no_action"
-# Sub-states (schema 1.2.0+) — the only ways a ticker can land in the
+# Sub-states (schema 1.2.0+) — the ways a ticker can land in the
 # no-action bucket post-filter are:
 #   1. Research ENTER + optimizer eligible + target ≈ 0 → optimizer_zero
-#      (the "we looked and chose not to" case)
-#   2. Anything else → unknown (should be 0; flags a producer bug)
+#      (the "we looked and chose not to allocate" case — benign)
+#   2. Research ENTER + optimizer assigned a NON-ZERO target but NO order
+#      was created (not approved / blocked / held) → optimizer_dropped.
+#      The optimizer WANTED this position and the allocation was lost
+#      downstream (e.g. a price-resolve failure in optimizer_cutover).
+#      This is an ERROR, not a benign no-action — surfaced distinctly so
+#      the console flags it loudly. (2026-06-04: AMD, the optimizer's
+#      10% top pick, was dropped this way on a transient IBKR price miss.)
+#   3. No optimizer view at all (legacy non-optimizer run / signal
+#      silently dropped upstream) → unknown.
 # Research HOLD / EXIT / REDUCE on a non-held ticker is filtered out
 # of the considered universe entirely — those rows are dead signals
 # (no possible order-book interaction) and would only add noise.
 STATE_NO_ACTION_OPTIMIZER_ZERO = "no_action_optimizer_zero_weight"
+STATE_NO_ACTION_OPTIMIZER_DROPPED = "no_action_optimizer_dropped"
 STATE_NO_ACTION_UNKNOWN = "no_action_unknown"
 
 _NO_ACTION_STATES = frozenset({
     STATE_NO_ACTION,
     STATE_NO_ACTION_OPTIMIZER_ZERO,
+    STATE_NO_ACTION_OPTIMIZER_DROPPED,
+    STATE_NO_ACTION_UNKNOWN,
+})
+
+# Error-severity terminal states — an operator MUST look at these. The
+# console renders them as errors (banner + red row) and they sort to the
+# top of the no-action cluster.
+_ERROR_STATES = frozenset({
+    STATE_NO_ACTION_OPTIMIZER_DROPPED,
     STATE_NO_ACTION_UNKNOWN,
 })
 
@@ -89,10 +107,13 @@ _STATE_ORDER = {
     STATE_PREDICTOR_VETOED: 3,
     STATE_RISK_BLOCKED: 4,
     STATE_HELD: 5,
-    STATE_NO_ACTION_OPTIMIZER_ZERO: 6,
+    # Error states sort FIRST within the no-action cluster so the operator
+    # sees the dropped allocation before the benign optimizer-zero rows.
+    STATE_NO_ACTION_OPTIMIZER_DROPPED: 6,
     STATE_NO_ACTION_UNKNOWN: 7,
+    STATE_NO_ACTION_OPTIMIZER_ZERO: 8,
     # Compatibility — legacy aggregate slug sorts with the others.
-    STATE_NO_ACTION: 7,
+    STATE_NO_ACTION: 8,
 }
 
 # risk_events rules emitted when the *predictor* (not research/risk)
@@ -224,9 +245,13 @@ def _classify_no_action(
     optimizer view (when present) supplies the explanation.
 
       - Optimizer view present, target ≈ 0 → optimizer_zero_weight
-        (the "we looked and chose not to allocate" case).
-      - Anything else → unknown — should be 0 in production; surfacing
-        distinctly lets the dashboard flag a producer bug.
+        (the "we looked and chose not to allocate" case — benign).
+      - Optimizer view present, target ≥ ε but no order/block/held →
+        optimizer_dropped — the optimizer WANTED this position and the
+        allocation was lost downstream (price-resolve failure, etc.).
+        An ERROR, surfaced distinctly so the console flags it loudly.
+      - No optimizer view at all → unknown (legacy non-optimizer run or
+        a signal silently dropped upstream).
 
     Returns the sub-state slug + a short human-readable detail string
     appended to the decision chain so the per-ticker drill-down
@@ -234,10 +259,20 @@ def _classify_no_action(
     """
     if isinstance(opt_view, Mapping):
         tgt = opt_view.get("target_weight")
-        if isinstance(tgt, (int, float)) and abs(tgt) < _OPTIMIZER_TARGET_ZERO_EPSILON:
+        if isinstance(tgt, (int, float)):
+            if abs(tgt) < _OPTIMIZER_TARGET_ZERO_EPSILON:
+                return (
+                    STATE_NO_ACTION_OPTIMIZER_ZERO,
+                    "optimizer eligible but assigned ~0 target weight",
+                )
+            # Non-zero target that never became an order — the allocation
+            # was dropped downstream. ERROR. See [[feedback_no_silent_fails]].
             return (
-                STATE_NO_ACTION_OPTIMIZER_ZERO,
-                "optimizer eligible but assigned ~0 target weight",
+                STATE_NO_ACTION_OPTIMIZER_DROPPED,
+                f"ERROR: optimizer targeted {tgt * 100:.2f}% but no order was "
+                f"created (not approved / blocked / held) — allocation dropped "
+                f"downstream; check the AlphaEngine/Executor/"
+                f"optimizer_target_dropped alarm + executor log",
             )
     return (
         STATE_NO_ACTION_UNKNOWN,
@@ -559,6 +594,17 @@ def build_order_book_rationale(
                 })
         else:
             state, _na_detail = _classify_no_action(opt_view=opt_view)
+            if state == STATE_NO_ACTION_OPTIMIZER_DROPPED:
+                # Recording surface #2 (the producer-side CW alarm in
+                # optimizer_cutover is #1): an ERROR in the planner log so
+                # the dropped allocation is never silent. [[feedback_no_silent_fails]]
+                logger.error(
+                    "order_book_rationale: %s — optimizer targeted %s but no "
+                    "order was created (allocation DROPPED). %s",
+                    ticker,
+                    (opt_view or {}).get("target_weight"),
+                    _na_detail,
+                )
             chain.append({
                 "stage": "no_action",
                 "result": state,

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -18,6 +18,7 @@ from executor.order_book_rationale import (
     STATE_APPROVED_ENTRY,
     STATE_HELD,
     STATE_NO_ACTION,
+    STATE_NO_ACTION_OPTIMIZER_DROPPED,
     STATE_NO_ACTION_OPTIMIZER_ZERO,
     STATE_NO_ACTION_UNKNOWN,
     STATE_PREDICTOR_VETOED,
@@ -908,6 +909,38 @@ class TestNoActionSubStates:
         # surface the weights inline with the sub-state.
         assert f["optimizer"]["target_weight"] == 0.0
         assert f["optimizer"]["eligible"] is True
+
+    def test_research_enter_nonzero_target_no_order_classified_dropped(self):
+        # The ERROR case (L4501 / the 2026-06-04 AMD incident): research
+        # ENTER, optimizer assigned a NON-ZERO target (10%), eligible —
+        # but no approved-entry / block / held record exists. The
+        # allocation was dropped downstream (price-resolve failure in
+        # optimizer_cutover). Must classify as the distinct ERROR
+        # sub-state, NOT the benign optimizer_zero or generic unknown.
+        shadow = {
+            "tickers": ["AMD"],
+            "current_weights": [0.0],
+            "target_weights": [0.10],
+            "alpha_hat": [0.0316],
+            "eligibility": [True],
+            "eligibility_reasons": [None],
+        }
+        payload = build_order_book_rationale(
+            signals={"enter": [_sig("AMD", "ENTER", score=75.2)],
+                     "exit": [], "reduce": [], "hold": []},
+            predictions_by_ticker={},
+            optimizer_shadow_log=shadow,
+            **self._base_kwargs(),
+        )
+        amd = next(r for r in payload["tickers"] if r["ticker"] == "AMD")
+        assert amd["terminal_state"] == STATE_NO_ACTION_OPTIMIZER_DROPPED
+        na = next(s for s in amd["decision_chain"] if s["stage"] == "no_action")
+        assert "ERROR" in na["detail"]
+        assert "10.00%" in na["detail"]  # the targeted weight is named
+        assert amd["optimizer"]["target_weight"] == 0.10
+        # Counted distinctly in the summary so the console can banner it.
+        assert payload["summary"]["n_no_action_optimizer_dropped"] == 1
+        assert "n_no_action_unknown" not in payload["summary"]
 
     def test_research_enter_without_optimizer_view_classified_unknown(self):
         # Defensive — should be rare in production. Research said ENTER,


### PR DESCRIPTION
## Problem (L4501 — companion to the AMD investigation)

When the optimizer assigns a **non-zero** target weight but no order is created (the ticker is not approved / blocked / held), `build_order_book_rationale` bucketed it as the generic `no_action_unknown` — with a hardcoded detail that falsely read *"research ENTER signal with no order, block, or **optimizer view**"* even though an optimizer view with a non-zero target was right there. That was the exact **2026-06-04 AMD** case: the optimizer's 10% top pick, dropped on a transient IBKR price miss, showed up as a muted "unknown (investigate)" row.

That condition is a **producer ERROR** — the optimizer's allocation was lost — not a benign no-action. Per your direction, it now surfaces as an error at every layer.

## Changes

**`executor/order_book_rationale.py`**
- New terminal sub-state **`STATE_NO_ACTION_OPTIMIZER_DROPPED`**: `opt_view` present, `|target| ≥ ε`, no order/block/held. Detail names the targeted weight (`"ERROR: optimizer targeted 10.00% but no order was created …"`) and points at the `optimizer_target_dropped` alarm. `no_action_unknown` is now reserved strictly for the genuine no-optimizer-view legacy fall-through.
- Error states (`optimizer_dropped`, `unknown`) sort to the **top of the no-action cluster** so the operator sees them first.
- The builder logs an **ERROR** when it classifies a dropped allocation (recording surface #2; the CloudWatch alarm in `optimizer_cutover` is #1).
- Summary auto-counts the new state as `n_no_action_optimizer_dropped`.

**`executor/optimizer_cutover.py`**
- The true-drop path (`no_price_all_sources`, from L4500) log upgraded **WARN → ERROR** — a lost allocation is an error. The fallback-priced case stays WARN (degraded but recovered, target preserved).

## Tests
`+1` — `test_research_enter_nonzero_target_no_order_classified_dropped` (asserts the dropped state, the ERROR detail naming the 10% weight, and the distinct summary count). Existing `optimizer_zero` / `unknown` / chain tests unaffected. Full executor suite green.

## Deploy / contract
Additive S3-schema change (new `terminal_state` string value) — backward-compatible. Old dashboards render the new state with default styling until the consumer PR ships; either deploy order is safe. Consumer (red row + page-top error banner): **alpha-engine-dashboard** PR (separate).

Closes ROADMAP **L4501** (alpha-engine-config #468). Companion: **L4500** (alpha-engine #234, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)