### PR TITLE
fix(ibkr): retry the initial IB Gateway connect, not just reconnect

### DIFF
--- a/executor/ibkr.py
+++ b/executor/ibkr.py
@@ -32,9 +32,7 @@ class IBKRClient:
         self._client_id = client_id
         self._reconnect_attempts = reconnect_attempts
         logger.info(f"Connecting to IB Gateway at {host}:{port} (clientId={client_id})")
-        self.ib.connect(host, port, clientId=client_id, timeout=20)
-        if not self.ib.isConnected():
-            raise RuntimeError("Failed to connect to IB Gateway")
+        self._connect()
         logger.info("Connected to IB Gateway")
 
     def ensure_connected(self) -> None:
@@ -42,15 +40,36 @@ class IBKRClient:
         if self.ib.isConnected():
             return
         logger.warning("IB Gateway connection lost — attempting reconnect")
-        self._reconnect()
+        self._connect()
 
-    @retry(max_attempts=3, retryable=(Exception,), label="ibkr_connect")
-    def _reconnect(self) -> None:
-        """Attempt a single IB Gateway reconnect (retried by @retry)."""
-        self.ib.connect(self._host, self._port,
-                        clientId=self._client_id, timeout=20)
-        if not self.ib.isConnected():
-            raise RuntimeError("IB Gateway connect returned but isConnected() is False")
+    def _connect(self) -> None:
+        """Establish (or re-establish) the IB Gateway connection with
+        exponential-backoff retry.
+
+        Both the initial connect (constructor) and every later reconnect route
+        through here, so they share identical resilience — the morning planner
+        gets the same retry the daemon already had. A timed-out handshake (e.g.
+        an IB Gateway ``reqExecutions`` stall mid-connect — the 2026-06-05
+        weekday-SF failure) leaves a half-open socket with the clientId still
+        registered on the gateway; ``disconnect()`` before each attempt clears
+        that stale state so the retry doesn't fail on "clientId already in use".
+        Raises loud after all attempts are exhausted — a genuinely-down gateway
+        must still surface (no silent degrade).
+        """
+        @retry(max_attempts=self._reconnect_attempts, retryable=(Exception,),
+               label="ibkr_connect")
+        def _attempt() -> None:
+            if self.ib.isConnected():
+                return
+            # idempotent on a fresh/clean IB object; clears half-open state
+            # left by a timed-out handshake so the reconnect's clientId is free
+            self.ib.disconnect()
+            self.ib.connect(self._host, self._port,
+                            clientId=self._client_id, timeout=20)
+            if not self.ib.isConnected():
+                raise RuntimeError("IB Gateway connect returned but isConnected() is False")
+
+        _attempt()
 
     # ── Account ───────────────────────────────────────────────────────────────
 

--- a/executor/retry.py
+++ b/executor/retry.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import functools
 import logging
+import random
 import time
 
 _logger = logging.getLogger(__name__)
 
 
-def retry(max_attempts=3, backoff_base=2, retryable=(Exception,), label=None):
-    """Exponential backoff retry decorator for transient failures."""
+def retry(max_attempts=3, backoff_base=2, retryable=(Exception,), label=None,
+          jitter=True):
+    """Exponential backoff retry decorator for transient failures.
+
+    Backoff is ``backoff_base ** attempt`` seconds. With ``jitter=True`` (the
+    default, SOTA) a random fraction in ``[0, delay)`` is added so concurrent
+    retriers (e.g. planner + daemon both reconnecting after a gateway blip)
+    don't synchronize their attempts and re-collide.
+    """
     def decorator(fn):
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
@@ -23,7 +31,9 @@ def retry(max_attempts=3, backoff_base=2, retryable=(Exception,), label=None):
                         _logger.error("[retry:%s] Failed after %d attempts: %s", tag, max_attempts, e)
                         raise
                     delay = backoff_base ** attempt
-                    _logger.warning("[retry:%s] Attempt %d/%d failed: %s — retrying in %ds", tag, attempt, max_attempts, e, delay)
+                    if jitter:
+                        delay += random.uniform(0, delay)
+                    _logger.warning("[retry:%s] Attempt %d/%d failed: %s — retrying in %.1fs", tag, attempt, max_attempts, e, delay)
                     time.sleep(delay)
         return wrapper
     return decorator

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -5,6 +5,8 @@ IB connection logic is mocked; these tests cover the parsing layer only.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 from executor.ibkr import IBKRClient
 
 
@@ -51,3 +53,50 @@ class TestAccruedDividendsBySymbol:
         ])
         result = client.get_accrued_dividends_by_symbol()
         assert result == {"AAPL": 7.50}
+
+
+class TestInitialConnectRetry:
+    """The constructor must retry a transient connect failure, not hard-fail.
+
+    Regression for the 2026-06-05 weekday-SF failure: the morning planner's
+    only IB touchpoint is ``IBKRClient.__init__``, which used to do a single
+    bare ``connect()``. An IB Gateway ``reqExecutions`` stall mid-handshake
+    raised ``TimeoutError`` and nuked the whole pipeline.
+    """
+
+    def _fake_ib(self, monkeypatch, connect_side_effect):
+        import executor.ibkr as ibkr_mod
+        import executor.retry as retry_mod
+        fake_ib = MagicMock()
+        fake_ib.connect.side_effect = connect_side_effect
+        monkeypatch.setattr(ibkr_mod, "IB", lambda: fake_ib)
+        monkeypatch.setattr(retry_mod.time, "sleep", lambda _s: None)  # no real backoff
+        return fake_ib
+
+    def test_retries_then_succeeds(self, monkeypatch):
+        state = {"connected": False, "calls": 0}
+
+        def connect_side(*_a, **_k):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise TimeoutError("reqExecutions stalled mid-handshake")
+            state["connected"] = True
+
+        fake_ib = self._fake_ib(monkeypatch, connect_side)
+        fake_ib.isConnected.side_effect = lambda: state["connected"]
+
+        client = IBKRClient()  # must not raise
+
+        assert state["calls"] == 2  # one transient failure, one success
+        assert client.ib.isConnected()
+        # half-open socket / stale clientId cleared before the retry
+        assert fake_ib.disconnect.called
+
+    def test_raises_after_exhausting_attempts(self, monkeypatch):
+        fake_ib = self._fake_ib(monkeypatch, TimeoutError("gateway down"))
+        fake_ib.isConnected.return_value = False
+
+        with pytest.raises(TimeoutError):
+            IBKRClient(reconnect_attempts=2)
+
+        assert fake_ib.connect.call_count == 2  # honors reconnect_attempts, then raises loud


### PR DESCRIPTION
## Why

The morning daily weekday Step Function **failed on 2026-06-05** at `RunMorningPlanner`. Root cause from the SSM stdout:

```
File ".../executor/ibkr.py", line 35, in __init__
    self.ib.connect(host, port, clientId=client_id, timeout=20)
  ...
File ".../ib_insync/ib.py", line 1782, in connectAsync
    await asyncio.wait_for(self.reqExecutionsAsync(), timeout)
TimeoutError
```

The IB Gateway connection *succeeded* (logged on, pulled all positions + portfolio), then the final handshake step `reqExecutionsAsync()` stalled past the 20s timeout → `TimeoutError` → planner exited 1 → SF `HandleFailure` → **no order book written, daemon never started, no trading for the day.**

`IBKRClient.__init__` did a single **bare** `connect(timeout=20)` with no retry. Meanwhile `daemon.py` already wraps construction in a backoff retry loop, and the reconnect path (`ensure_connected` → `_reconnect`) was already `@retry`-decorated. **The initial connect was the one unprotected site left — and it's the morning planner's sole IB touchpoint.**

## What

- **`executor/ibkr.py`** — route both the constructor and `ensure_connected()` through a single `_connect()` that retries with exponential backoff (honoring `reconnect_attempts`, previously ignored by the fixed-`max_attempts` decorator). `disconnect()` before each attempt clears the half-open socket / stale clientId a timed-out handshake leaves, so the retry doesn't fail on "clientId already in use". Still **raises loud after exhausting attempts** — a genuinely-down gateway must surface (honors the no-silent-fails rule; this is resilience-on-transient, not a swallow).
- **`executor/retry.py`** — add jitter (default on) per the SOTA retry rule, so concurrent retriers don't synchronize.
- **`tests/test_ibkr.py`** — regression tests: constructor retries a transient `TimeoutError` then succeeds; raises after exhausting attempts.

Net: a `reqExecutions` blip now costs a few seconds of backoff instead of nuking the weekday SF. Planner, daemon, EOD reconcile, and backtester fallback all get connection resilience by construction.

## Test

`python -m pytest tests/` → **1070 passed**.

## Recovery

Today's run was recovered out-of-band via `recovery-260605-ibkr-connect-timeout` weekday-SF execution (independent of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)