### PR TITLE
feat(optimizer): turnover governor — gradual-by-default rebalance + large-move approval flag

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -362,6 +362,19 @@ portfolio_optimizer:
   # Backtester-tunable via param sweep; cutover gated by B.5. See
   # optimizer-sota-upgrades-260526.md §B.3.
   alpha_uncertainty_penalty: 0.0
+  # ── Turnover governor (gradual-rebalance guardrail) ───────────────────
+  # SAFETY guardrail, NOT backtester-tuned. The book WALKS to the optimizer's
+  # target over several days rather than jumping in one session: when a
+  # single-day target implies one-way turnover above max_daily_turnover, the
+  # step from current weights toward target is scaled down so executed
+  # turnover == the cap (the remaining distance closes over subsequent daily
+  # re-solves). Defaults ON (fail-safe — a tighter cap only slows rebalancing,
+  # never worsens a trade). Set max_daily_turnover: null to disable.
+  max_daily_turnover: 0.20          # ≤20% one-way turnover executed per day
+  # When the REQUESTED (uncapped) one-way turnover exceeds this, the planner
+  # emits a WARN + SNS/Telegram alert for operator approval to accelerate —
+  # the move is still executed gradually under the cap regardless.
+  large_move_turnover_flag: 0.35
   # Σ horizon in trading days. 1 (default) = legacy daily Σ, bit-identical to
   # pre-260526 behavior. Set to 21 to align Σ with the canonical 21d log-domain
   # α̂; under i.i.d. log-returns Σ_H = H · Σ_daily, with vol-target SOC and

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -158,6 +158,46 @@ def _build_and_solve(
         alpha_uncertainty=alpha_uncertainty,
     )
 
+    # Turnover-governor large-move flag: the optimizer requested a one-way
+    # rebalance above large_move_turnover_flag. It is ALREADY executed
+    # gradually under the max_daily_turnover cap (the primary guardrail);
+    # this alert surfaces the aggressive request for operator approval to
+    # accelerate. Alert-publish is best-effort secondary observability — the
+    # cap already protected the book, so a publish failure must never block
+    # the planner. See [[feedback_no_silent_fails]] (recording surface = the
+    # WARN log + the shadow-log governor fields below).
+    if result.diagnostics.get("large_move_flagged"):
+        _req = result.diagnostics.get("requested_turnover_one_way", 0.0)
+        _cap = optimizer_cfg.get("max_daily_turnover")
+        _flag = optimizer_cfg.get("large_move_turnover_flag")
+        logger.warning(
+            "Optimizer large-move flag: requested one-way turnover %.1f%% "
+            "> flag %.0f%% — executing gradually under the %.0f%%/day cap "
+            "(run_date=%s)",
+            _req * 100, (_flag or 0) * 100, (_cap or 0) * 100, run_date,
+        )
+        try:
+            from alpha_engine_lib import alerts as _alerts
+            _alerts.publish(
+                message=(
+                    f"[executor] Optimizer requested a large rebalance: "
+                    f"one-way turnover {_req:.1%} exceeds the {_flag:.0%} flag "
+                    f"(run_date={run_date}). The book is being moved GRADUALLY "
+                    f"under the {_cap:.0%}/day cap — no single-day jump. Review "
+                    f"and approve acceleration if the reallocation is intended."
+                ),
+                severity="WARN",
+                source="alpha-engine/executor/optimizer_shadow.py",
+                sns=True,
+                telegram=True,
+                dedup_key=f"optimizer_large_move_{run_date}",
+            )
+        except Exception as _alert_err:  # noqa: BLE001 — secondary observability
+            logger.warning(
+                "large-move alert publish failed (non-fatal, cap already "
+                "applied): %s", _alert_err,
+            )
+
     would_be_trades = _compute_trade_deltas(
         tickers, result.weights, w_prev, portfolio_nav, optimizer_cfg,
     )

--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -209,10 +209,12 @@ def solve_target_weights(
         return OptimizerResult(weights=weights, diagnostics=diagnostics)
 
     weights = _clip_and_renormalize(weights, effective_caps, cash_idx, cfg)
+    weights, governor = _apply_turnover_governor(weights, w_prev, cfg)
     diagnostics = _build_diagnostics(
         weights, w_prev, sigma, alpha_hat, spy_idx, status, cfg,
         omega_diag=omega_diag, alpha_unc_used=alpha_unc_used,
     )
+    diagnostics.update(governor)
     return OptimizerResult(weights=weights, diagnostics=diagnostics)
 
 
@@ -248,6 +250,25 @@ OPTIMIZER_CONFIG_DEFAULTS: dict = {
     # preserves bit-identical legacy MVO behavior. Backtester-tunable.
     # See optimizer-sota-upgrades-260526.md §B.3.
     "alpha_uncertainty_penalty": 0.0,
+    # ── Turnover governor (gradual-rebalance guardrail) ──────────────────
+    # SAFETY guardrail — NOT an alpha knob, NOT backtester-tuned. Caps the
+    # one-way turnover the book may execute in a single day by scaling the
+    # step from w_prev toward the optimizer's target, so the portfolio WALKS
+    # to the target over several daily re-solves instead of jumping in one
+    # session. Institutional books rebalance gradually; a large single-day
+    # reallocation is the rare exception that should be operator-reviewed,
+    # not the default. Defaults ON (unlike the optional α̂-uncertainty term)
+    # because it's a fail-safe — a too-tight cap only slows rebalancing, it
+    # can never produce a worse trade.
+    #   max_daily_turnover: one-way turnover cap/day (None → governor OFF,
+    #     bit-identical legacy behavior).
+    #   large_move_turnover_flag: when REQUESTED (uncapped) one-way turnover
+    #     exceeds this, the solve sets large_move_flagged so the planner
+    #     alerts for approval. The move is STILL executed gradually under the
+    #     cap — flagging never bypasses the cap, and the cap never waits on
+    #     the flag.
+    "max_daily_turnover": 0.20,
+    "large_move_turnover_flag": 0.35,
 }
 
 
@@ -506,6 +527,58 @@ def _clip_and_renormalize(
     if total > 0:
         weights = weights / total
     return weights
+
+
+def _apply_turnover_governor(
+    weights: np.ndarray, w_prev: np.ndarray, cfg: dict
+) -> tuple[np.ndarray, dict]:
+    """Cap one-way daily turnover by scaling the step ``w_prev → weights``.
+
+    Gradual-rebalance guardrail: institutional books walk to the target over
+    several days rather than jumping. When the optimizer's target implies a
+    one-way turnover above ``max_daily_turnover``, take a PARTIAL step toward
+    it — ``w_exec = w_prev + (w_target - w_prev) · (cap / requested)`` — which
+    bounds executed one-way turnover to the cap while preserving direction.
+    The scaled vector is a convex combination of two cap-feasible points
+    (``w_prev`` and the clipped ``weights``), so it stays within all linear
+    constraints (Σw=1, sector caps, per-name caps). The book converges to the
+    target over subsequent daily re-solves.
+
+    A REQUESTED (pre-cap) turnover above ``large_move_turnover_flag`` sets
+    ``large_move_flagged`` so the planner alerts for operator approval — the
+    move is never executed in one jump regardless, only surfaced.
+
+    Returns ``(possibly-scaled weights, governor diagnostics)``. With
+    ``max_daily_turnover=None`` the step is returned unchanged (legacy).
+    """
+    requested = float(np.sum(np.abs(weights - w_prev)) / 2)
+    cap = cfg.get("max_daily_turnover")
+    flag = cfg.get("large_move_turnover_flag")
+    gov: dict = {
+        "requested_turnover_one_way": requested,
+        "turnover_capped": False,
+        "large_move_flagged": bool(flag is not None and requested > flag),
+    }
+    if cap is not None and cap > 0 and requested > cap:
+        # The scaling (a convex combination of w_prev and the target) only
+        # preserves Σw=1 when w_prev is itself a normalized portfolio. In
+        # production w_prev = positions/NAV + cash sentinel and always sums to
+        # 1; if it doesn't, scaling would silently de-normalize the book, so
+        # leave the step ungoverned and surface the anomaly rather than corrupt
+        # the weights. See [[feedback_no_silent_fails]].
+        if abs(float(w_prev.sum()) - 1.0) > 1e-6:
+            logger.warning(
+                "turnover governor SKIPPED: w_prev sums to %.4f (≠ 1) — cannot "
+                "scale without de-normalizing; executing the full target step "
+                "(requested one-way turnover %.3f).",
+                float(w_prev.sum()), requested,
+            )
+        else:
+            scale = cap / requested
+            weights = w_prev + (weights - w_prev) * scale
+            gov["turnover_capped"] = True
+            gov["turnover_scale_applied"] = float(scale)
+    return weights, gov
 
 
 def _build_diagnostics(

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -62,7 +62,11 @@ def _baseline_universe(
         "eligibility": np.ones(N, dtype=bool),
         "spy_idx": spy_idx,
         "cash_idx": cash_idx,
-        "cfg": {},
+        # These fixtures test the MVO TARGET (w_prev=zeros → full target).
+        # Disable the turnover governor (a separate concern — it caps the
+        # STEP toward the target) so target assertions stay bit-identical;
+        # the governor is exercised directly in TestTurnoverGovernor.
+        "cfg": {"max_daily_turnover": None},
     }
 
 
@@ -976,3 +980,81 @@ def test_missing_returns_panel_without_covariance_raises():
     u["stance_caps"][u["cash_idx"]] = 1.0
     with pytest.raises(ValueError, match="returns_panel is required"):
         solve_target_weights(**{**u, "returns_panel": None})
+
+
+class TestTurnoverGovernor:
+    """Gradual-rebalance guardrail: the book walks to the optimizer's target
+    over several days; a single-day target above the cap is scaled down, and a
+    large REQUESTED move is flagged for operator approval (still executed
+    gradually). See executor/portfolio_optimizer.py::_apply_turnover_governor.
+    """
+
+    def _solve_from_prev(self, prev_active=0.0, cap=0.20, flag=0.35):
+        # One active name with strong α̂ so the MVO wants a large allocation.
+        # w_prev sums to 1 (the production invariant: positions/NAV + cash
+        # sentinel) — prev_active in the name, the rest in cash. From all-cash
+        # (prev_active=0) the MVO target is a ~0.97 one-way jump.
+        u = _baseline_universe(n_active=1)
+        u["alpha_hat"][0] = 0.08
+        w_prev = np.zeros(len(u["tickers"]))
+        w_prev[0] = prev_active
+        w_prev[u["cash_idx"]] = 1.0 - prev_active
+        u["w_prev"] = w_prev
+        u["cfg"] = {"max_daily_turnover": cap, "large_move_turnover_flag": flag}
+        return _solve(u)
+
+    def test_small_move_below_cap_is_not_governed(self):
+        # Already near target → requested turnover < cap → untouched + no flag.
+        u = _baseline_universe(n_active=1)
+        u["alpha_hat"][0] = 0.08
+        # Seed w_prev close to the expected target (0.08 / 0.89 SPY / 0.03 cash).
+        w_prev = np.zeros(len(u["tickers"]))
+        w_prev[0] = 0.075
+        w_prev[u["spy_idx"]] = 0.895
+        w_prev[u["cash_idx"]] = 0.03
+        u["w_prev"] = w_prev
+        u["cfg"] = {"max_daily_turnover": 0.20, "large_move_turnover_flag": 0.35}
+        result = _solve(u)
+        assert result.diagnostics["turnover_capped"] is False
+        assert result.diagnostics["large_move_flagged"] is False
+        assert result.diagnostics["turnover_one_way"] < 0.20
+
+    def test_large_target_is_capped_to_max_daily_turnover(self):
+        # From all-cash (w_prev=0) the MVO target is a ~0.5 turnover jump;
+        # the governor must scale executed one-way turnover down to the cap.
+        N = 3  # T0, SPY, CASH
+        result = self._solve_from_prev(cap=0.20)
+        d = result.diagnostics
+        assert d["turnover_capped"] is True
+        assert d["requested_turnover_one_way"] > 0.20
+        # executed turnover lands at the cap (within solver/clip tolerance)
+        assert d["turnover_one_way"] == pytest.approx(0.20, abs=1e-3)
+
+    def test_capped_weights_stay_feasible(self):
+        # Scaled step = convex combo of two feasible points → Σw=1 preserved.
+        N = 3
+        result = self._solve_from_prev(cap=0.20)
+        assert result.weights.sum() == pytest.approx(1.0, abs=1e-6)
+        assert np.all(result.weights >= -1e-9)
+
+    def test_large_requested_move_sets_flag(self):
+        # Requested turnover ~0.5 > 0.35 flag → flagged (but still capped).
+        N = 3
+        result = self._solve_from_prev(cap=0.20, flag=0.35)
+        assert result.diagnostics["large_move_flagged"] is True
+        assert result.diagnostics["turnover_capped"] is True  # cap independent of flag
+
+    def test_flag_without_cap_does_not_scale(self):
+        # flag set, cap disabled → flagged but weights untouched (cap is the
+        # only thing that scales; flagging never bypasses or replaces it).
+        N = 3
+        result = self._solve_from_prev(cap=None, flag=0.35)
+        assert result.diagnostics["large_move_flagged"] is True
+        assert result.diagnostics["turnover_capped"] is False
+
+    def test_governor_disabled_is_bit_identical(self):
+        # max_daily_turnover=None → no governor; turnover_capped False, no scale.
+        N = 3
+        result = self._solve_from_prev(cap=None, flag=None)
+        assert result.diagnostics["turnover_capped"] is False
+        assert result.diagnostics["large_move_flagged"] is False


### PR DESCRIPTION
## Why
The book should **walk** to the optimizer's target over several days, not jump in one session; a large single-day reallocation is the rare exception that merits operator review. This is also the **executor half of the auto-promote safety design** — it caps any large book move a freshly-promoted predictor would request, so a bad model can never flush the book in one session. **Must be live before auto-promote takes effect (6/13).**

## What
Two guardrails in the MVO kernel (`solve_target_weights`), so both the **morning planner** and the **intraday daemon re-solve** inherit them:

1. **Gradual-by-default** (`max_daily_turnover`, default **0.20**): when a single-day target implies one-way turnover above the cap, the step `w_prev → target` is scaled so executed turnover == the cap. The scaled vector is a **convex combination of two cap-feasible points**, so Σw=1, sector caps, and per-name caps are all preserved. The book converges over subsequent daily re-solves. Guarded: a non-normalized `w_prev` (Σ≠1) is left ungoverned + WARN-logged rather than silently de-normalized.
2. **Large-move flag** (`large_move_turnover_flag`, default **0.35**): when the *requested* (uncapped) turnover exceeds the flag, the planner emits a WARN + SNS/Telegram alert for approval to accelerate. The move is **still executed gradually under the cap** — flagging never bypasses the cap, and the cap never waits on the flag.

Defaults **ON** (unlike the optional α̂-uncertainty term) because it's a fail-safe — a tighter cap only slows rebalancing, never worsens a trade. Governor diagnostics flow into the optimizer shadow log for observability; `risk.yaml.example` documents both knobs.

## Design notes
- **No vertical/time barrier in execution** — per the discussion, exits stay thesis- and risk-driven (a re-affirmed A+ name compounds uninterrupted; forced calendar sales are anti-alpha and anti-LTCG). The triple-barrier stays where it belongs, in the predictor's *labeling*.
- "Hold the excess for approval" = the always-on cap structurally prevents a single-day jump (the excess closes over days); the flag is the approval prompt. No stateful block-until-approved gate (cap + alert is the SOTA-scoped safeguard).

## Tests
`TestTurnoverGovernor` — cap scaling to the bound, feasibility (Σw=1) preserved, large-move flag, cap/flag independence, disabled=legacy. Existing MVO-target tests pinned to the ungoverned target. **Full executor suite: 1076 passed.**

(Local `main.py --dry-run` needs the gitignored `risk.yaml` + IB — validate on the trading EC2 post-merge per CLAUDE.md step 7.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)