### PR TITLE
feat(executor): position loss-floor (MAE stop) — value-stance falling-knife guard (L4549a)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -243,6 +243,17 @@ strategy:
     catastrophic_gap_stop_enabled: true
     catastrophic_gap_stop_pct: 0.15  # 15% drop from reference triggers full exit (backtester-tunable)
 
+    # Position loss floor (MAE stop) — STANCE-AGNOSTIC hard-risk override that
+    # survives the optimizer (like catastrophic_gap above). Full EXIT when a
+    # held position's loss from avg cost breaches the floor, regardless of
+    # stance / catalyst / Research signal. The cumulative-drawdown sibling of
+    # the single-move catastrophic gap stop. Closes the value-stance falling-
+    # knife gap (L4549a). Cold-start -0.15 cuts the COIN-class knife; the
+    # backtester tunes it within a protective band (loose end is the safeguard).
+    # NOTE: never add position_loss_floor_pct to the per-stance exit overrides.
+    position_loss_floor_enabled: true
+    position_loss_floor_pct: -0.15  # loss from avg cost (<= this negative decimal) → full EXIT (backtester-tunable)
+
   graduated_drawdown:
     enabled: true
     tiers:

--- a/executor/main.py
+++ b/executor/main.py
@@ -39,7 +39,11 @@ from executor.position_sizer import compute_position_size
 from executor.risk_guard import check_order, compute_drawdown_multiplier
 from executor.signal_reader import get_actionable_signals, read_signals_with_fallback
 from executor.strategies.config import load_strategy_config
-from executor.strategies.exit_manager import evaluate_exits, SECTOR_ETF_MAP
+from executor.strategies.exit_manager import (
+    evaluate_exits,
+    check_position_loss_floor,
+    SECTOR_ETF_MAP,
+)
 from executor.price_cache import (
     _MACRO_SYMBOLS,
     load_atr_14_pct,
@@ -1374,7 +1378,46 @@ def run(
                 f"Strategy layer generated {len(strategy_exits)} exit signal(s): "
                 + ", ".join(f"{s['ticker']}({s['action']}: {s['reason']})" for s in strategy_exits)
             )
-    
+
+        # ── 2f'. Position loss-floor (MAE) hard-risk exits ────────────────────
+        # Stance-agnostic maximum-adverse-excursion floor: cut any held
+        # position whose loss from avg cost breaches position_loss_floor_pct.
+        # Runs UNCONDITIONALLY — like drawdown forced-exit (§2g) and the
+        # catastrophic gap stop, this is a hard-risk override that survives the
+        # optimizer (``optimizer_owns_exits`` suppresses *alpha* strategy exits,
+        # NOT risk floors). Closes the falling-knife gap that let COIN bleed
+        # -19% un-cut while ranked #1 (L4549a). The non-optimizer path already
+        # evaluates the floor inside evaluate_exits; the dedup below prevents a
+        # double-add there. Price falls back to last mark (market_value/shares)
+        # when live pricing is unavailable pre-open, so the floor still fires.
+        if strategy_config.get("position_loss_floor_enabled", True) and current_positions:
+            floor_existing_exits = (
+                {s["ticker"] for s in signals.get("exit", [])}
+                | {s["ticker"] for s in strategy_exits if s["action"] == "EXIT"}
+            )
+            for t, pos in current_positions.items():
+                if t in floor_existing_exits:
+                    continue
+                if int(pos.get("shares", 0)) <= 0:
+                    continue
+                px = ibkr.get_current_price(t)
+                if px is None:
+                    shares = pos.get("shares") or 0
+                    mv = pos.get("market_value")
+                    px = (mv / shares) if (mv and shares) else None
+                floor_exit = check_position_loss_floor(
+                    ticker=t,
+                    current_price=px,
+                    avg_cost=pos.get("avg_cost"),
+                    strategy_config=strategy_config,
+                )
+                if floor_exit:
+                    strategy_exits.append(floor_exit)
+                    logger.info(
+                        f"POSITION LOSS FLOOR EXIT (hard-risk override): {t} — "
+                        f"{floor_exit['detail']}"
+                    )
+
         enter_signals = signals["enter"]
 
         # Initialize order book for the day (daemon reads this after main.py completes).

--- a/executor/strategies/config.py
+++ b/executor/strategies/config.py
@@ -43,6 +43,18 @@ FALLBACK_STOP_PCT = 0.10          # 10% loss from entry triggers exit
 CATASTROPHIC_GAP_STOP_ENABLED = True
 CATASTROPHIC_GAP_STOP_PCT = 0.15  # 15% drop from reference triggers full exit
 
+# Position loss floor (MAE stop) — hard-risk, STANCE-AGNOSTIC maximum-adverse-
+# excursion floor. Full EXIT when a held position's loss from avg cost breaches
+# the floor, regardless of stance / catalyst / Research signal. The cumulative-
+# drawdown sibling of the single-move catastrophic gap stop. Closes the falling-
+# knife gap (L4549a) where a value-stance name (COIN) bled -19% un-cut because
+# the value gate skips the momentum veto AND the value exit overrides loosen ATR
+# to 4.5x / time-decay to 30d. Cold-start -0.15 cuts the COIN-class knife now;
+# the backtester tunes it within a protective band thereafter. MUST stay out of
+# STANCE_EXIT_OVERRIDES — a risk floor the value loosening cannot subordinate.
+POSITION_LOSS_FLOOR_ENABLED = True
+POSITION_LOSS_FLOOR_PCT = -0.15  # loss from avg cost (<= this, a negative decimal) → full EXIT
+
 # ── Bracket stop defaults ────────────────────────────────────────────────────
 BRACKET_STOP_ENABLED = True
 BRACKET_TRAIL_ATR_MULTIPLE = 2.0   # trailing stop = ATR * this value
@@ -133,6 +145,10 @@ def load_strategy_config(config: dict) -> dict:
         # Catastrophic single-name gap stop (optimizer-mode hard-risk override)
         "catastrophic_gap_stop_enabled": exit_cfg.get("catastrophic_gap_stop_enabled", CATASTROPHIC_GAP_STOP_ENABLED),
         "catastrophic_gap_stop_pct": exit_cfg.get("catastrophic_gap_stop_pct", CATASTROPHIC_GAP_STOP_PCT),
+
+        # Position loss floor / MAE stop (stance-agnostic hard-risk override)
+        "position_loss_floor_enabled": exit_cfg.get("position_loss_floor_enabled", POSITION_LOSS_FLOOR_ENABLED),
+        "position_loss_floor_pct": exit_cfg.get("position_loss_floor_pct", POSITION_LOSS_FLOOR_PCT),
 
         # Graduated drawdown
         "graduated_drawdown_enabled": drawdown_cfg.get("enabled", GRADUATED_DRAWDOWN_ENABLED),

--- a/executor/strategies/exit_manager.py
+++ b/executor/strategies/exit_manager.py
@@ -543,6 +543,59 @@ def check_momentum_exit(
     return None
 
 
+def check_position_loss_floor(
+    ticker: str,
+    current_price: float | None,
+    avg_cost: float | None,
+    strategy_config: dict,
+) -> dict | None:
+    """Hard-risk maximum-adverse-excursion (MAE) floor — full EXIT.
+
+    Fires when a held position's loss from average cost breaches
+    ``position_loss_floor_pct`` (a negative decimal, e.g. -0.15). This is
+    the cumulative-drawdown sibling of the intraday ``catastrophic_gap_stop``
+    (single-move): it cuts a falling-knife position whose thesis has been
+    wrong by too much, regardless of stance / catalyst / Research signal.
+
+    STANCE-AGNOSTIC AND HARD: ``position_loss_floor_pct`` must NEVER be added
+    to ``STANCE_EXIT_OVERRIDES`` — the floor is a risk backstop the value
+    stance's loosened ATR (4.5x) / time-decay (30d) must not be able to
+    suppress (the gap that let COIN bleed -19% un-cut while ranked #1,
+    L4549a). Backtester-tuned within a protective band thereafter; the band's
+    loose end is the real safeguard.
+    """
+    if not strategy_config.get("position_loss_floor_enabled", True):
+        return None
+    # Inline default mirrors strategies.config.POSITION_LOSS_FLOOR_PCT so the
+    # floor is active even on a partial config (active on merge with no
+    # risk.yaml edit). An explicit ``None`` still disables it.
+    floor = strategy_config.get("position_loss_floor_pct", -0.15)
+    if (
+        floor is None
+        or avg_cost is None
+        or current_price is None
+        or float(avg_cost) <= 0
+    ):
+        return None
+    loss = float(current_price) / float(avg_cost) - 1.0
+    if loss <= float(floor):
+        logger.info(
+            f"POSITION LOSS FLOOR EXIT {ticker}: loss={loss * 100:.1f}% "
+            f"<= floor={float(floor) * 100:.1f}% "
+            f"(avg_cost={float(avg_cost):.2f}, px={float(current_price):.2f})"
+        )
+        return {
+            "ticker": ticker,
+            "action": "EXIT",
+            "reason": "position_loss_floor",
+            "detail": (
+                f"MAE floor breached: {loss * 100:.1f}% from avg cost "
+                f"(floor {float(floor) * 100:.1f}%)"
+            ),
+        }
+    return None
+
+
 def _evaluate_single_position(
     *,
     ticker: str,
@@ -574,7 +627,22 @@ def _evaluate_single_position(
     sector-relative veto suppressed it (load-bearing for grading the
     sector-veto decision separately from the ATR-fire decision).
     """
-    # 0. Catalyst hard exit — runs FIRST so the deadline supersedes
+    # 0. Position loss floor (MAE) — hard-risk, stance-agnostic, runs
+    # FIRST. A position down past the floor is cut regardless of stance,
+    # catalyst, or price-based checks (the falling-knife backstop, L4549a).
+    # ``position_loss_floor_pct`` is intentionally NOT in STANCE_EXIT_OVERRIDES,
+    # so ``stance_config`` carries its base value here — the value stance's
+    # loosened ATR/time-decay cannot subordinate this floor.
+    loss_floor_exit = check_position_loss_floor(
+        ticker=ticker,
+        current_price=current_price,
+        avg_cost=pos.get("avg_cost"),
+        strategy_config=stance_config,
+    )
+    if loss_floor_exit:
+        return loss_floor_exit, "position_loss_floor"
+
+    # 0b. Catalyst hard exit — runs next so the deadline supersedes
     # price-based checks (the thesis is mechanically expired).
     catalyst_exit = check_catalyst_hard_exit(
         ticker=ticker,

--- a/tests/test_exit_manager.py
+++ b/tests/test_exit_manager.py
@@ -368,3 +368,87 @@ class TestSectorRelativeVeto:
             strategy_config=_strategy_config(sector_relative_veto_enabled=False),
         )
         assert vetoed is False
+
+
+# ── Position loss floor (MAE stop) — L4549a ──────────────────────────────────
+
+from executor.strategies.exit_manager import (  # noqa: E402
+    check_position_loss_floor,
+    _evaluate_single_position,
+)
+from executor.strategies.exit_manager import STANCE_EXIT_OVERRIDES  # noqa: E402
+
+
+class TestPositionLossFloor:
+    """MAE / position loss floor — hard-risk stance-agnostic exit (L4549a)."""
+
+    _CFG = {"position_loss_floor_enabled": True, "position_loss_floor_pct": -0.15}
+
+    def test_trips_when_loss_breaches_floor(self):
+        # COIN-shape: avg 187, px 152 → -18.7% <= -15% → EXIT
+        sig = check_position_loss_floor("COIN", 152.0, 187.0, self._CFG)
+        assert sig is not None
+        assert sig["action"] == "EXIT"
+        assert sig["reason"] == "position_loss_floor"
+        assert "COIN" == sig["ticker"]
+
+    def test_trips_exactly_at_floor(self):
+        sig = check_position_loss_floor("X", 85.0, 100.0, self._CFG)  # -15.0%
+        assert sig is not None and sig["action"] == "EXIT"
+
+    def test_no_trip_above_floor(self):
+        # -5% loss, inside the floor → hold
+        assert check_position_loss_floor("AMD", 95.0, 100.0, self._CFG) is None
+
+    def test_no_trip_when_in_profit(self):
+        assert check_position_loss_floor("BRO", 110.0, 100.0, self._CFG) is None
+
+    def test_disabled_returns_none(self):
+        cfg = {"position_loss_floor_enabled": False, "position_loss_floor_pct": -0.15}
+        assert check_position_loss_floor("COIN", 152.0, 187.0, cfg) is None
+
+    def test_missing_inputs_return_none(self):
+        assert check_position_loss_floor("X", None, 100.0, self._CFG) is None
+        assert check_position_loss_floor("X", 50.0, None, self._CFG) is None
+        assert check_position_loss_floor("X", 50.0, 0.0, self._CFG) is None
+
+    def test_floor_pct_absent_defaults_active(self):
+        # No key in config → default -0.15 applies (active on merge w/o risk.yaml edit)
+        sig = check_position_loss_floor("COIN", 152.0, 187.0, {})
+        assert sig is not None and sig["action"] == "EXIT"
+
+    def test_floor_pct_none_in_config_returns_none(self):
+        cfg = {"position_loss_floor_enabled": True, "position_loss_floor_pct": None}
+        assert check_position_loss_floor("COIN", 152.0, 187.0, cfg) is None
+
+    def test_floor_is_not_a_stance_override(self):
+        # INVARIANT: the floor must never be loosened per-stance — a hard-risk
+        # backstop the value stance's loosened ATR/time-decay cannot subordinate.
+        for stance, overrides in STANCE_EXIT_OVERRIDES.items():
+            assert "position_loss_floor_pct" not in overrides, stance
+            assert "position_loss_floor_enabled" not in overrides, stance
+
+    def test_floor_supersedes_value_stance_in_single_position_eval(self):
+        # A value-stance position down past the floor exits via the loss floor
+        # FIRST, even though value loosens ATR (4.5x) / time-decay (30d).
+        cfg = {
+            "position_loss_floor_enabled": True,
+            "position_loss_floor_pct": -0.15,
+            "atr_trailing_enabled": True,
+            "fallback_stop_enabled": False,
+        }
+        sig, rule = _evaluate_single_position(
+            ticker="COIN",
+            pos={"avg_cost": 187.0, "stance": "value", "shares": 100},
+            research_action="HOLD",
+            current_price=152.0,
+            history=None,
+            sector_etf_histories=None,
+            stance_config=cfg,
+            catalyst_date=None,
+            entry_date="2026-05-26",
+            run_date="2026-06-08",
+            feature_lookup=None,
+        )
+        assert rule == "position_loss_floor"
+        assert sig is not None and sig["action"] == "EXIT"


### PR DESCRIPTION
## What

Adds a **stance-agnostic maximum-adverse-excursion (MAE) floor**: any held position whose loss from average cost breaches `position_loss_floor_pct` (cold-start **−0.15**) is fully **EXITed** regardless of stance / catalyst / Research signal. The cumulative-drawdown sibling of the single-move catastrophic gap stop.

## Why (L4549a — the COIN falling-knife trap)

Diagnosed 2026-06-07: the book's bleed (cum alpha ≈ −4.3% / 20d) was concentrated in **COIN**, which the predictor ranked **#1 every day** (`predicted_alpha +0.30`, conf 0.98, `stance:value`) while it cratered 187→152 (−19% from cost, held since 5/26, never cut). Every layer let it bleed:

- **Entry gate** (`deciders.py:550`): the `value` stance requires a name be *down* to qualify and **skips the momentum veto** — the further it falls, the more it qualifies.
- **Exit overrides** (`exit_manager.py:57`): `value` loosens ATR to **4.5×** and time-decay to **30d**.
- **Only hard floor** (`catastrophic_gap`, single-move −15%) is evaded by a gradual −3..−7%/day bleed.

There was **no absolute downside floor anywhere**. This adds one.

## How

- `check_position_loss_floor` rule in `strategies/exit_manager.py`, wired as the **highest-priority check (step 0)** in `_evaluate_single_position` (backtest / dry-run path → backtester-tunable).
- **Unconditional hard-risk block in `main.py` (§2f')** mirroring the §2g drawdown-forced-exit — **survives `optimizer_owns_exits`** (which suppresses *alpha* strategy exits, NOT risk floors). Includes a `market_value/shares` price fallback so the floor fires even if live pricing is unavailable pre-open.
- Defaults in `strategies/config.py` (**active on merge — no `risk.yaml` edit needed**) + documented keys in `risk.yaml.example`.
- **Invariant:** `position_loss_floor_pct` is never a per-stance override (enforced by test) — the value loosening cannot subordinate it.

## Validation

- Full suite **1086 passed** (+10 new floor tests).
- Replayed against the live **2026-06-05** book: cuts **only COIN (−18.7%)**, holds all others (next-worst AMD −4.7%).

## Deploy / activation

Cold-start **−0.15** is a deliberate immediate default that cuts the current COIN-class knife; **the backtester tunes the floor within a protective band thereafter** (L4549a follow-up). On merge, the trading EC2 boot-pull picks it up before Monday's `RunMorningPlanner` → the floor emits an urgent EXIT for COIN at Monday open. **No live `risk.yaml` edit required.**

Design doc: `alpha-engine-config/private-docs/value-stance-falling-knife-guard-260607.md`. Follow-ups (own PRs): Guard A entry-floor (L4549a), backtester tuning, predictor value-stance calibration (L4549b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)