### PR TITLE
fix(tests): stop the suite from firing real operator alerts (L4566)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ never the real SSM Parameter Store.
 """
 import sys
 import os
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -30,3 +31,29 @@ def _isolate_secrets_from_ssm(monkeypatch):
     clear_cache()
     yield
     clear_cache()
+
+
+@pytest.fixture(autouse=True)
+def _block_real_alert_publish(monkeypatch):
+    """Stub ``alpha_engine_lib.alerts.publish`` so NO test fans out a real
+    SNS / Telegram operator alert.
+
+    Without this, any test exercising a code path that calls
+    ``alerts.publish(..., sns=True, telegram=True)`` pages the operator for
+    real. Concretely: ``test_optimizer_shadow.py``'s baseline fixture (a
+    near-all-cash book) trips the turnover-governor large-move flag added in
+    #237, which fired a live WARN to Telegram + SNS on every suite run
+    (``run_date=2026-05-11``, observed 2026-06-07). Tests assert on the call
+    inputs, not on real delivery. ``optimizer_shadow`` imports the symbol
+    lazily as ``from alpha_engine_lib import alerts as _alerts`` and calls
+    ``_alerts.publish`` at runtime, so patching the module attribute here
+    intercepts it. See ROADMAP L4566; mirrored by a cross-repo guard in
+    ``alpha_engine_lib.alerts.publish`` (PYTEST_CURRENT_TEST).
+    """
+    try:
+        from alpha_engine_lib import alerts
+    except ImportError:
+        yield
+        return
+    monkeypatch.setattr(alerts, "publish", MagicMock(name="alerts.publish"))
+    yield


### PR DESCRIPTION
## What

An autouse `conftest.py` fixture now stubs `alpha_engine_lib.alerts.publish` for the entire test suite, so no test can fan out a real SNS / Telegram operator alert.

## Why

A `[WARN] … Optimizer requested a large rebalance: one-way turnover 92.0% exceeds the 35% flag (run_date=2026-05-11)` alert was delivered to the operator on **2026-06-07 with no executor running**.

Root cause: `tests/test_optimizer_shadow.py`'s `_baseline_inputs()` fixture (a near-all-cash $1M book, `run_date="2026-05-11"`) makes the optimizer request ~**92% one-way turnover**, which trips the `large_move_turnover_flag` (0.35) added by the turnover governor (#237). That path calls `alerts.publish(..., sns=True, telegram=True, dedup_key="optimizer_large_move_2026-05-11")`. The suite only mocked the S3 client (`MagicMock`) — it **never mocked the alert channel** — so every run paged the operator for real. The S3 dedup marker confirms it fired twice that day (`publish_count: 2`).

Verified locally:
- `large_move_flagged=True`, `requested_turnover_one_way=0.92`, `dedup_key=optimizer_large_move_2026-05-11`, `sns=True/telegram=True` — exactly the delivered alert.
- With the fixture in place, the stub intercepts the call (0 real sends); `tests/test_optimizer_shadow.py` → 23 passed.

## Fix tiers

1. **This PR (alpha-engine):** repo-wide autouse stub — sibling to the existing `_isolate_secrets_from_ssm` guard. Immediate fix for the actual leak.
2. **alpha-engine-lib [#100](https://github.com/cipher813/alpha-engine-lib/pull/100):** defense-in-depth chokepoint in `alerts.publish` that short-circuits real sends when `PYTEST_CURRENT_TEST` is set — protects all 8 repos' suites from this class.

ROADMAP: **L4566** (config [#528](https://github.com/cipher813/alpha-engine-config/pull/528)). Per [[feedback_no_silent_fails]].

> Note: branch name says `l4565`; the tracked ROADMAP id is **L4566** (renumbered to avoid collision with the in-flight destance arc). Cosmetic only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)