### PR TITLE
feat(executor): de-stance the entry/exit gates — uniform momentum veto + reversal-confirmation gate (L4565 P1)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -53,9 +53,19 @@ min_conviction_to_enter:         # only these conviction levels allow new entrie
   - rising
   - stable
 
-# Momentum confirmation gate — skip entries with weak momentum
+# Momentum confirmation gate — skip entries with weak momentum.
+# DE-STANCED 2026-06-07 (L4565): this veto now applies UNIFORMLY to every
+# stance (the value-invert / quality-relax bypasses are retired). catalyst
+# stays exempt (event-driven). "Don't treat value differently."
 momentum_gate_enabled: true
 momentum_gate_threshold: -5.0   # min 20d momentum % (backtester-tunable: [-10.0, -5.0, -2.0])
+
+# Reversal-confirmation gate (L4565) — "don't buy a cheap name until momentum
+# stops deteriorating." Blocks entry while the predictor's momentum_confirmation
+# (the momentum L1 score) is below the threshold. Uniform across stances;
+# catalyst exempt. DEFAULT-ON in code (active on merge); backtester-tunable.
+reversal_confirmation_enabled: true
+reversal_confirmation_threshold: 0.0   # require momentum_confirmation >= this (backtester-tunable: [-0.05, 0.0, 0.05])
 
 # Cross-ticker correlation blocking — prevent correlated entries
 correlation_block_enabled: true

--- a/executor/deciders.py
+++ b/executor/deciders.py
@@ -532,76 +532,25 @@ def decide_entries(
             predictor_momentum_veto = pred_data_for_veto.get("momentum_veto")
             predictor_momentum_20d = pred_data_for_veto.get("momentum_20d")
             stance = pred_data_for_veto.get("stance")  # may be None (legacy)
-            value_drawdown_min = config.get("value_stance_drawdown_min", -0.05)
-            quality_threshold_pct = config.get(
-                "quality_stance_momentum_threshold", -15.0
-            )
-            quality_threshold_decimal = float(quality_threshold_pct) / 100.0
+            # NOTE (L4565): value_stance_drawdown_min / quality_stance_momentum_threshold
+            # are retired — the momentum veto is now uniform across stances.
 
             momentum_20d_decimal: float | None = None
             if isinstance(predictor_momentum_20d, (int, float)):
                 momentum_20d_decimal = float(predictor_momentum_20d)
 
-            # ── Value stance: require drawdown to qualify ───────────────
-            # A value pick must actually be oversold — that's the entry
-            # premise. If the ticker isn't down, the stance label is
-            # mis-applied (or the underlying feature has noise) and the
-            # pick doesn't fit its declared strategy. Block.
-            if stance == "value":
-                if (
-                    momentum_20d_decimal is not None
-                    and momentum_20d_decimal > value_drawdown_min
-                ):
-                    reason = (
-                        f"value stance gate: 20d="
-                        f"{momentum_20d_decimal * 100:.1f}% > drawdown min "
-                        f"{value_drawdown_min * 100:.1f}% "
-                        "(value picks require actual drawdown)"
-                    )
-                    logger.info(f"SKIP ENTER {ticker} — {reason}")
-                    plan.blocked.append({**_shadow_base, "block_reason": reason})
-                    plan.risk_events.append({**_event_base,
-                        "event_type": "veto",
-                        "rule": "stance_gate",
-                        "stance": "value",
-                        "reason": reason,
-                        "value": momentum_20d_decimal,
-                        "threshold": value_drawdown_min,
-                    })
-                    continue
-                # Else: drawdown qualifies. Skip the standard momentum
-                # gate (the predictor's veto is for trend-following,
-                # inappropriate for value picks).
-                logger.debug(
-                    f"PASS value gate {ticker} — 20d="
-                    f"{momentum_20d_decimal * 100 if momentum_20d_decimal is not None else '?':.1f}%"
-                )
-
-            # ── Quality stance: relaxed threshold ───────────────────────
-            # Defensive names (low vol, low debt) can absorb deeper
-            # drawdowns before we abandon them. Default -15% vs the
-            # standard -5%. Backtester-tunable.
-            elif stance == "quality":
-                if (
-                    momentum_20d_decimal is not None
-                    and momentum_20d_decimal < quality_threshold_decimal
-                ):
-                    reason = (
-                        f"quality stance gate (relaxed): 20d="
-                        f"{momentum_20d_decimal * 100:.1f}% < "
-                        f"{quality_threshold_pct}%"
-                    )
-                    logger.info(f"SKIP ENTER {ticker} — {reason}")
-                    plan.blocked.append({**_shadow_base, "block_reason": reason})
-                    plan.risk_events.append({**_event_base,
-                        "event_type": "veto",
-                        "rule": "stance_gate",
-                        "stance": "quality",
-                        "reason": reason,
-                        "value": momentum_20d_decimal,
-                        "threshold": quality_threshold_decimal,
-                    })
-                    continue
+            # ── Uniform momentum gating (de-stanced — L4565) ─────────────
+            # SOTA combine-not-route (Asness-Moskowitz-Pedersen 2013;
+            # Barra/Axioma z-score+sum): value & momentum combine at the
+            # signal level, so we do NOT treat "value" specially (Brian
+            # 2026-06-07: "I don't like falling knives, I don't think we
+            # should treat value differently"). The predictor's momentum_veto
+            # now applies UNIFORMLY to every stance — the prior value-invert
+            # (skip-veto, the gap that let COIN re-qualify as it fell) and
+            # quality-relax branches are RETIRED. ``catalyst`` stays the one
+            # exception: an event-driven thesis with a catalyst_date exit
+            # boundary may legitimately trade against trend (flagged for
+            # review in the de-stance arc).
 
             # ── Catalyst stance: skip momentum, require catalyst_date ──
             # Event-driven thesis trumps momentum considerations.
@@ -609,7 +558,7 @@ def decide_entries(
             # the executor's catalyst gate (future PR) hard-exits at
             # catalyst_date + 3 trading days — that contract requires
             # the date.
-            elif stance == "catalyst":
+            if stance == "catalyst":
                 catalyst_date = pred_data_for_veto.get("catalyst_date")
                 if not catalyst_date:
                     reason = (
@@ -632,7 +581,7 @@ def decide_entries(
                     f"PASS catalyst gate {ticker} — catalyst_date={catalyst_date}"
                 )
 
-            # ── Default (momentum / None): existing momentum_veto ────────
+            # ── Uniform momentum veto (all non-catalyst stances) ─────────
             elif predictor_momentum_veto is not None:
                 # Predictor-side veto is authoritative. ``momentum_20d``
                 # in the prediction is a decimal (matches feature
@@ -687,6 +636,42 @@ def decide_entries(
                             "veto_source": "executor_fallback",
                         })
                         continue
+
+            # ── Reversal-confirmation gate (uniform — L4565) ─────────────
+            # "Don't buy a cheap name until momentum stops deteriorating."
+            # Keys off the predictor's ``momentum_confirmation`` (the momentum
+            # L1 score): block entry while momentum is still bearish — catches
+            # a falling knife the 20d veto alone may miss. Uniform across
+            # stances; ``catalyst`` is exempt (event-driven). Default-on per
+            # the de-stance decision (Brian 2026-06-07); flip
+            # ``reversal_confirmation_enabled: false`` to disable.
+            if (
+                stance != "catalyst"
+                and config.get("reversal_confirmation_enabled", True)
+            ):
+                momentum_confirmation = pred_data_for_veto.get(
+                    "momentum_confirmation"
+                )
+                rc_threshold = config.get("reversal_confirmation_threshold", 0.0)
+                if (
+                    isinstance(momentum_confirmation, (int, float))
+                    and float(momentum_confirmation) < rc_threshold
+                ):
+                    reason = (
+                        f"reversal-confirmation gate: momentum_confirmation="
+                        f"{float(momentum_confirmation):.3f} < {rc_threshold} "
+                        f"(momentum still deteriorating — wait for reversal)"
+                    )
+                    logger.info(f"SKIP ENTER {ticker} — {reason}")
+                    plan.blocked.append({**_shadow_base, "block_reason": reason})
+                    plan.risk_events.append({**_event_base,
+                        "event_type": "veto",
+                        "rule": "reversal_confirmation",
+                        "reason": reason,
+                        "value": float(momentum_confirmation),
+                        "threshold": rc_threshold,
+                    })
+                    continue
 
         # Earnings proximity warning (logs only)
         earnings_warning_days = config.get("earnings_proximity_warning_days", 2)

--- a/executor/strategies/exit_manager.py
+++ b/executor/strategies/exit_manager.py
@@ -46,26 +46,20 @@ SECTOR_ETF_MAP = {
 # disable the corresponding rule outright. Falls through to baseline
 # config when stance is None / unknown (legacy entries, ML drift, etc.).
 #
-# Defaults below are the cold-start values; backtester adds them to the
-# parameter search space in a follow-up PR.
+# DE-STANCED 2026-06-07 (L4565): the value (4.5× ATR / 30-day) and quality
+# (time-decay disabled) LOOSENINGS are RETIRED — risk is now UNIFORM across
+# stances (Brian: "I don't like falling knives, I don't think we should treat
+# value differently"). The value loosening was the exit-side half of the
+# COIN falling-knife trap; it was an unvalidated cold-start ("backtester adds
+# in a follow-up PR" that never shipped), so removal reverts to the baseline.
+# ``catalyst`` keeps its time-decay disable: that's tied to the catalyst_date
+# hard-exit being the canonical event boundary (a different exit MECHANISM,
+# not a "give it more rope" risk loosening), and catalyst is the documented
+# exception in the entry gate too.
 STANCE_EXIT_OVERRIDES: dict[str, dict] = {
-    "momentum": {
-        # Baseline — no overrides. Pinned explicitly so future readers see
-        # the contrast with the other stances; the dict is otherwise
-        # empty for performance + clarity.
-    },
-    "value": {
-        # Contrarian thesis needs room to play out. Wider stop +
-        # extended hold:
-        "atr_multiplier": 4.5,           # vs default 3.0 — give bounce more room
-        "time_decay_reduce_days": 20,    # vs default 5
-        "time_decay_exit_days": 30,      # vs default 10 — full 30d window for mean reversion
-    },
-    "quality": {
-        # Defensive: long hold, time decay disabled. ATR untouched
-        # (rare exit on the trailing stop is still appropriate).
-        "time_decay_enabled": False,
-    },
+    "momentum": {},   # baseline
+    "value": {},      # de-stanced (L4565) — uniform stops
+    "quality": {},    # de-stanced (L4565) — uniform stops
     "catalyst": {
         # Event-driven: standard checks PLUS the hard catalyst-date
         # exit (see check_catalyst_hard_exit). Time decay disabled

--- a/tests/test_deciders_risk_events.py
+++ b/tests/test_deciders_risk_events.py
@@ -342,125 +342,103 @@ def _pred_with_stance(
     return base
 
 
-# ── Value stance: invert momentum gate ──
+# ── Uniform momentum gating (de-stanced — L4565) ──
+# value & quality are NO LONGER special-cased: the predictor's momentum_veto
+# applies uniformly, and a reversal-confirmation gate blocks names whose
+# momentum is still deteriorating. "Don't treat value differently."
 
 
-def test_value_stance_blocks_when_drawdown_insufficient():
-    """value stance picks must actually be oversold — that's the entry
-    premise. If 20d ret is flat or up, the stance label is misapplied
-    and the pick doesn't fit its declared strategy. Block.
-
-    This is the institutional value-sleeve check: a "value" pick must
-    look like value (downward price action), not just be labeled
-    value via factor model noise.
-    """
-    enter = [{"ticker": "AAPL", "signal": "ENTER", "score": 85,
-              "conviction": "rising", "sector": "Technology",
+def test_value_stance_blocked_uniformly_when_momentum_veto():
+    """DE-STANCED (L4565): a value pick the predictor flags
+    momentum_veto=True (a falling knife, e.g. COIN) is now BLOCKED by the
+    uniform momentum gate. The prior value bypass is retired — there is no
+    longer a stance_gate rule."""
+    enter = [{"ticker": "COIN", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Financials",
               "rating": "BUY", "price_target_upside": 0.20}]
-    predictions = {"AAPL": _pred_with_stance("value", momentum_20d=0.02)}  # +2% — not value
+    predictions = {"COIN": _pred_with_stance(
+        "value", momentum_20d=-0.15, momentum_veto=True)}
     inputs = _make_inputs(
         signals_date="2026-05-08", run_date="2026-05-11",
         enter_signals=enter,
         predictions_by_ticker=predictions,
-        config_overrides={"momentum_gate_enabled": True,
-                          "value_stance_drawdown_min": -0.05},
+        config_overrides={"momentum_gate_enabled": True},
     )
     plan = decide_entries(predictions_date="2026-05-11", **inputs)
-    veto_events = [e for e in plan.risk_events if e["rule"] == "stance_gate"]
-    assert len(veto_events) == 1
-    ev = veto_events[0]
-    assert ev["stance"] == "value"
-    assert ev["value"] == pytest.approx(0.02)
-    assert ev["threshold"] == pytest.approx(-0.05)
+    momentum_vetos = [e for e in plan.risk_events if e["rule"] == "momentum_gate"]
+    assert len(momentum_vetos) == 1
+    assert momentum_vetos[0]["veto_source"] == "predictor"
+    # stance_gate rule is retired
+    assert [e for e in plan.risk_events if e["rule"] == "stance_gate"] == []
     assert plan.n_entered == 0
 
 
-def test_value_stance_allows_drawdown_through_momentum_gate():
-    """When a value pick HAS the drawdown that justifies it, the
-    standard momentum gate (which blocks falling knives) is BYPASSED.
-    This is the executor-side resolution of today's bull-market 0-
-    entries mismatch — research's value picks no longer get killed
-    by the trend-following gate.
-    """
-    enter = [{"ticker": "WING", "signal": "ENTER", "score": 85,
-              "conviction": "rising", "sector": "Consumer Discretionary",
+def test_value_stance_passes_when_no_veto_and_momentum_confirmed():
+    """A value pick the predictor does NOT veto (momentum_veto=False) with
+    non-bearish momentum_confirmation passes uniformly — value isn't
+    penalized, it's just not given a bypass."""
+    enter = [{"ticker": "AAPL", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
               "rating": "BUY", "price_target_upside": 0.20}]
-    # WING dropped 28% — a true value/buy-the-dip candidate
-    predictions = {"WING": _pred_with_stance("value", momentum_20d=-0.28)}
+    predictions = {"AAPL": _pred_with_stance(
+        "value", momentum_20d=0.02, momentum_veto=False,
+        momentum_confirmation=0.10)}
     inputs = _make_inputs(
         signals_date="2026-05-08", run_date="2026-05-11",
         enter_signals=enter,
         predictions_by_ticker=predictions,
-        config_overrides={"momentum_gate_enabled": True,
-                          "momentum_gate_threshold": -5.0,
-                          "value_stance_drawdown_min": -0.05},
+        config_overrides={"momentum_gate_enabled": True},
     )
     plan = decide_entries(predictions_date="2026-05-11", **inputs)
-    # No stance_gate veto fires — the drawdown qualifies
-    stance_vetos = [e for e in plan.risk_events if e["rule"] == "stance_gate"]
-    assert stance_vetos == [], (
-        "value stance with sufficient drawdown must pass — got "
-        f"{stance_vetos}"
-    )
-    # Also confirm: standard momentum_gate did NOT fire either (would
-    # have triggered for -28% drawdown if stance routing failed).
-    momentum_vetos = [e for e in plan.risk_events if e["rule"] == "momentum_gate"]
-    assert momentum_vetos == [], (
-        "value stance must skip the standard momentum_gate — got "
-        f"{momentum_vetos}"
-    )
+    gated = [e for e in plan.risk_events
+             if e["rule"] in ("stance_gate", "momentum_gate", "reversal_confirmation")]
+    assert gated == [], f"value should pass uniformly; got {gated}"
 
 
-# ── Quality stance: relaxed threshold ──
-
-
-def test_quality_stance_uses_relaxed_threshold():
-    """quality stance accepts deeper drawdowns than momentum's default
-    -5% — default -15%. A defensive name with -10% drawdown should
-    pass the quality gate but would fail a standard momentum gate.
-    """
-    enter = [{"ticker": "JNJ", "signal": "ENTER", "score": 85,
-              "conviction": "rising", "sector": "Health Care",
-              "rating": "BUY", "price_target_upside": 0.10}]
-    predictions = {"JNJ": _pred_with_stance("quality", momentum_20d=-0.10)}
-    inputs = _make_inputs(
-        signals_date="2026-05-08", run_date="2026-05-11",
-        enter_signals=enter,
-        predictions_by_ticker=predictions,
-        config_overrides={"momentum_gate_enabled": True,
-                          "momentum_gate_threshold": -5.0,
-                          "quality_stance_momentum_threshold": -15.0},
-    )
-    plan = decide_entries(predictions_date="2026-05-11", **inputs)
-    stance_vetos = [e for e in plan.risk_events if e["rule"] == "stance_gate"]
-    assert stance_vetos == [], (
-        "quality stance at -10% should pass (relaxed -15% threshold); got "
-        f"{stance_vetos}"
-    )
-
-
-def test_quality_stance_blocks_at_relaxed_threshold():
-    """quality stance still blocks when drawdown exceeds the relaxed
-    threshold (default -15%). A defensive name down -20% has lost the
-    defensive thesis."""
+def test_quality_stance_blocked_uniformly_when_momentum_veto():
+    """DE-STANCED (L4565): quality no longer gets a relaxed threshold — a
+    quality name the predictor vetoes is blocked uniformly via the
+    momentum gate, not a stance_gate."""
     enter = [{"ticker": "PG", "signal": "ENTER", "score": 85,
               "conviction": "rising", "sector": "Consumer Staples",
               "rating": "BUY", "price_target_upside": 0.10}]
-    predictions = {"PG": _pred_with_stance("quality", momentum_20d=-0.20)}
+    predictions = {"PG": _pred_with_stance(
+        "quality", momentum_20d=-0.10, momentum_veto=True)}
+    inputs = _make_inputs(
+        signals_date="2026-05-08", run_date="2026-05-11",
+        enter_signals=enter,
+        predictions_by_ticker=predictions,
+        config_overrides={"momentum_gate_enabled": True},
+    )
+    plan = decide_entries(predictions_date="2026-05-11", **inputs)
+    momentum_vetos = [e for e in plan.risk_events if e["rule"] == "momentum_gate"]
+    assert len(momentum_vetos) == 1
+    assert [e for e in plan.risk_events if e["rule"] == "stance_gate"] == []
+
+
+def test_reversal_confirmation_blocks_deteriorating_momentum():
+    """L4565: even when momentum_veto is False, a name whose
+    momentum_confirmation is still bearish (< threshold) is blocked by the
+    uniform reversal-confirmation gate — 'wait for the bounce.'"""
+    enter = [{"ticker": "XYZ", "signal": "ENTER", "score": 85,
+              "conviction": "rising", "sector": "Technology",
+              "rating": "BUY", "price_target_upside": 0.20}]
+    predictions = {"XYZ": _pred_with_stance(
+        "value", momentum_20d=-0.03, momentum_veto=False,
+        momentum_confirmation=-0.12)}
     inputs = _make_inputs(
         signals_date="2026-05-08", run_date="2026-05-11",
         enter_signals=enter,
         predictions_by_ticker=predictions,
         config_overrides={"momentum_gate_enabled": True,
-                          "quality_stance_momentum_threshold": -15.0},
+                          "reversal_confirmation_enabled": True,
+                          "reversal_confirmation_threshold": 0.0},
     )
     plan = decide_entries(predictions_date="2026-05-11", **inputs)
-    stance_vetos = [e for e in plan.risk_events if e["rule"] == "stance_gate"]
-    assert len(stance_vetos) == 1
-    ev = stance_vetos[0]
-    assert ev["stance"] == "quality"
-    assert ev["value"] == pytest.approx(-0.20)
-    assert ev["threshold"] == pytest.approx(-0.15)
+    rc_vetos = [e for e in plan.risk_events if e["rule"] == "reversal_confirmation"]
+    assert len(rc_vetos) == 1
+    assert rc_vetos[0]["value"] == pytest.approx(-0.12)
+    assert plan.n_entered == 0
 
 
 # ── Catalyst stance: skip momentum, require date ──
@@ -505,8 +483,7 @@ def test_catalyst_stance_with_date_skips_momentum_gate():
         enter_signals=enter,
         predictions_by_ticker=predictions,
         config_overrides={"momentum_gate_enabled": True,
-                          "momentum_gate_threshold": -5.0,
-                          "quality_stance_momentum_threshold": -15.0},
+                          "momentum_gate_threshold": -5.0},
     )
     plan = decide_entries(predictions_date="2026-05-11", **inputs)
     stance_vetos = [e for e in plan.risk_events if e["rule"] == "stance_gate"]

--- a/tests/test_exit_manager_stance.py
+++ b/tests/test_exit_manager_stance.py
@@ -62,22 +62,22 @@ class TestResolveStanceConfig:
         # No overrides → identity-return for efficiency
         assert out is base
 
-    def test_value_stance_widens_atr_and_extends_time_decay(self):
+    def test_value_stance_now_uniform_baseline(self):
+        """DE-STANCED (L4565): value no longer widens ATR / extends time
+        decay — uniform risk. Empty overrides → baseline identity."""
         base = self._base()
         out = _resolve_strategy_config_for_stance(base, "value")
-        assert out["atr_multiplier"] == STANCE_EXIT_OVERRIDES["value"]["atr_multiplier"]
-        assert out["time_decay_reduce_days"] == STANCE_EXIT_OVERRIDES["value"]["time_decay_reduce_days"]
-        assert out["time_decay_exit_days"] == STANCE_EXIT_OVERRIDES["value"]["time_decay_exit_days"]
-        # Base config preserved — caller can re-use for other stances
-        assert base["atr_multiplier"] == 3.0
-        assert base["time_decay_exit_days"] == 10
+        assert out is base
+        assert out["atr_multiplier"] == 3.0
+        assert out["time_decay_exit_days"] == 10
 
-    def test_quality_stance_disables_time_decay(self):
+    def test_quality_stance_now_uniform_baseline(self):
+        """DE-STANCED (L4565): quality no longer disables time decay —
+        uniform risk."""
         base = self._base()
         out = _resolve_strategy_config_for_stance(base, "quality")
-        assert out["time_decay_enabled"] is False
-        # ATR multiplier untouched — quality keeps standard trailing stop
-        assert out["atr_multiplier"] == 3.0
+        assert out is base
+        assert out["time_decay_enabled"] is True
 
     def test_catalyst_stance_disables_time_decay(self):
         """catalyst-stance positions exit at catalyst_date+N via
@@ -88,11 +88,15 @@ class TestResolveStanceConfig:
         out = _resolve_strategy_config_for_stance(base, "catalyst")
         assert out["time_decay_enabled"] is False
 
-    def test_thesis_ordering_pinned_on_atr_multiplier(self):
-        """value's wider ATR than momentum baseline is institutional
-        discipline. Pin the direction so a future hand-edit can't
-        accidentally tighten value's stop."""
-        assert STANCE_EXIT_OVERRIDES["value"]["atr_multiplier"] > 3.0
+    def test_value_quality_overrides_retired_uniform_risk(self):
+        """DE-STANCED (L4565): value + quality exit-loosenings are RETIRED —
+        risk is uniform across stances. Pin the invariant so a future
+        hand-edit can't re-introduce a value/quality bypass. catalyst keeps
+        its event-boundary time-decay disable (a mechanism, not a loosening)."""
+        assert STANCE_EXIT_OVERRIDES["value"] == {}
+        assert STANCE_EXIT_OVERRIDES["quality"] == {}
+        assert STANCE_EXIT_OVERRIDES["momentum"] == {}
+        assert STANCE_EXIT_OVERRIDES["catalyst"].get("time_decay_enabled") is False
 
 
 # ── check_catalyst_hard_exit ──────────────────────────────────────────────
@@ -203,46 +207,45 @@ def _ibkr_mock(price: float):
     return m
 
 
-def test_evaluate_exits_value_stance_widens_atr_stop():
-    """A value-stance position with -10% drawdown should NOT trigger
-    ATR exit at the wider multiplier (4.5×) when it WOULD at the
-    baseline (3.0×). The wider stop is the stance's room-to-play-out
-    semantic."""
+def test_evaluate_exits_value_stance_now_uniform():
+    """DE-STANCED (L4565): a value-stance position is treated IDENTICALLY
+    to a baseline/momentum position — no wider ATR, no extended hold.
+    "Don't treat value differently." """
     history = _history_with_drawdown(
         "2026-05-01", "2026-05-20", peak=100.0, trough=88.0,
     )
-    positions = {
-        "WING": {
-            "shares": 100,
-            "avg_cost": 100.0,
-            "entry_date": "2026-05-01",
-            "sector": "Consumer Discretionary",
-            "stance": "value",
-        },
-    }
-    signals = MagicMock()
-    signals_by_ticker = {}
-    cfg = _strategy_cfg()
-    # Run at the trough — 12% drawdown from peak
-    exits = evaluate_exits(
-        current_positions=positions,
-        signals_by_ticker=signals_by_ticker,
-        run_date="2026-05-20",
-        price_histories={"WING": history},
-        ibkr_client=_ibkr_mock(88.0),
-        strategy_config=cfg,
-    )
-    # value's wider 4.5× multiplier should NOT fire on this size of drawdown
-    atr_exits = [e for e in exits if e.get("reason") == "atr_trailing_stop"]
-    assert atr_exits == [], (
-        f"value stance's wider ATR should not exit on -12% drawdown; got "
-        f"{atr_exits}"
+
+    def _exits_for(stance):
+        positions = {
+            "WING": {
+                "shares": 100,
+                "avg_cost": 100.0,
+                "entry_date": "2026-05-01",
+                "sector": "Consumer Discretionary",
+                "stance": stance,
+            },
+        }
+        return evaluate_exits(
+            current_positions=positions,
+            signals_by_ticker={},
+            run_date="2026-05-20",
+            price_histories={"WING": history},
+            ibkr_client=_ibkr_mock(88.0),
+            strategy_config=_strategy_cfg(),
+        )
+
+    value_reasons = sorted(e.get("reason") for e in _exits_for("value"))
+    momentum_reasons = sorted(e.get("reason") for e in _exits_for("momentum"))
+    assert value_reasons == momentum_reasons, (
+        f"value must now exit identically to momentum (uniform risk); "
+        f"value={value_reasons} momentum={momentum_reasons}"
     )
 
 
-def test_evaluate_exits_quality_stance_skips_time_decay():
-    """quality-stance positions held >10 days with HOLD signal should
-    NOT trip time decay (disabled via STANCE_EXIT_OVERRIDES)."""
+def test_evaluate_exits_quality_stance_now_uniform():
+    """DE-STANCED (L4565): quality no longer disables time decay — a
+    quality position held past the exit threshold time-decays like any
+    other stance."""
     history = _history_with_drawdown(
         "2026-04-01", "2026-05-01", peak=100.0, trough=100.0,
     )
@@ -265,8 +268,8 @@ def test_evaluate_exits_quality_stance_skips_time_decay():
         strategy_config=cfg,
     )
     time_decays = [e for e in exits if "time_decay" in e.get("reason", "")]
-    assert time_decays == [], (
-        f"quality stance should disable time decay; got {time_decays}"
+    assert time_decays != [], (
+        "quality stance should now time-decay uniformly (L4565 de-stancing)"
     )
 
 


### PR DESCRIPTION
## What

Retires the `value` (and `quality`) **special-casing** in the executor's entry/exit gates so risk is **uniform across stances** — and adds a **reversal-confirmation gate** ("don't buy a cheap name until momentum stops deteriorating"). Brian, 2026-06-07: *"I don't like falling knives, I don't think we should treat value differently."*

## Why (L4565 — the selection/gating root fix)

#238's MAE floor only **backstops the damage** after a bad pick. This fixes **selection**: the `value` stance was a routing tree that (a) **bypassed the predictor `momentum_veto`** with no downside floor — the further a name fell, the more it "qualified" as value → COIN got `predicted_alpha +0.30`, ranked #1 daily — and (b) **loosened stops** (4.5× ATR / 30-day). Both were **unvalidated cold-start rules** (the exit overrides were explicit "backtester adds in a follow-up PR" that never shipped).

**SOTA basis:** Asness-Moskowitz-Pedersen (2013) *Value and Momentum Everywhere* (combine at the signal level, negatively-correlated → diversify, never let one override on a single name); Barra/Axioma z-score+sum; Daniel-Moskowitz (2016) uniform risk overlay. Full write-up: `alpha-engine-config/private-docs/destance-uniform-risk-arc-260607.md`.

## Changes (executor, uniform-by-default)

- **`deciders.py`** — retire the value-invert (skip-veto) + quality-relax entry branches → predictor `momentum_veto` applies **uniformly**. `catalyst` stays the one exception (event-driven, requires `catalyst_date`).
- **`deciders.py`** — NEW uniform **reversal-confirmation gate**: blocks entry while the predictor's `momentum_confirmation` (momentum L1 score) is `< reversal_confirmation_threshold` (default 0.0). `catalyst` exempt. Default-on; `reversal_confirmation_enabled` kill-switch.
- **`strategies/exit_manager.py`** — empty the value + quality `STANCE_EXIT_OVERRIDES` → uniform stops. `catalyst` keeps its event-boundary time-decay disable (a mechanism, not a loosening).
- **`risk.yaml.example`** — document the de-stancing + reversal flags.
- **tests** — rewrite the stance gate + exit-override tests to assert uniform behavior, incl. the **COIN-shape** (value + `momentum_veto=True` → now BLOCKED) and the reversal gate; pin the "no value/quality override" invariant.

## Rollout (decided)

- **Default-to-uniform on merge** (code defaults; live `risk.yaml` needs no edit), validate on the skilled-risk basket **in parallel**.
- Both new behaviors are **strictly more conservative** (tighter entries) and flag-gated (kill-switch). Note: the reversal gate is default-on and blocks entries where momentum is still bearish — broader-blocking in a selloff is the intended falling-knife aversion, but it is **not yet backtester-validated** (parallel validation per the decision).
- #238 MAE floor stays as defense-in-depth.

## Validation

- Full suite **1076 passed** (the 7 stance tests rewritten to uniform; new COIN-block + reversal-gate + invariant tests added).
- Not dry-run locally (no IB/`config/risk.yaml` here) — the decision logic is covered by the suite; EC2 dry-run is part of the deploy checklist.

## Follow-ups

- **Phase 2** — predictor alpha-layer: stance → combined z-scored feature so the bearish momentum L1 offsets the value path → COIN never gets +0.30 at the source (needs retrain + leak-free OOS; gated on the L4549b decomposition).
- Backtester skilled-risk validation of the uniform form; Phase 3 reconcile the IC-gated stance sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)