### PR TITLE
Codify cyphering-signal-ssm-read inline policy (fix IAM drift)

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/cyphering-signal-ssm-read.json
+++ b/infrastructure/iam/alpha-engine-executor-role/cyphering-signal-ssm-read.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "CypheringSignalParamRead",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:GetParameter",
+                "ssm:GetParameters"
+            ],
+            "Resource": "arn:aws:ssm:us-east-1:711398986525:parameter/cyphering/signal/*"
+        },
+        {
+            "Sid": "CypheringSignalParamDecrypt",
+            "Effect": "Allow",
+            "Action": "kms:Decrypt",
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "kms:ViaService": "ssm.us-east-1.amazonaws.com"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## What

Adds `infrastructure/iam/alpha-engine-executor-role/cyphering-signal-ssm-read.json`, codifying an inline policy that already exists live on the executor role.

## Why

The scheduled **IAM Drift Check** on `main` has failed every day since **2026-06-06** (last green 2026-06-05):

```
IAM drift detected (1 finding(s)):
  - alpha-engine-executor-role/cyphering-signal-ssm-read: present on AWS role but not codified (add JSON file or delete from AWS)
```

The grant was added **live to AWS on 2026-06-05** for the the-cyphering-ops signal dashboard — a scoped read of `/cyphering/signal/*` (the fine-grained GitHub PAT lives at `/cyphering/signal/github_token`) plus `kms:Decrypt` via `ssm`. It is intentional; it just was never codified, so the daily drift sweep flagged the source/live mismatch.

## Fix

Codify the live `PolicyDocument` verbatim. Source now matches AWS.

- **No AWS change** — the grant already exists live, so `apply.sh` is not needed. This is a source-only reconciliation.
- `check-drift.py --role alpha-engine-executor-role` → `OK: no IAM drift` locally.

This is the "codify source to match an intentional live grant" branch of the drift finding (vs. deleting from AWS) — the grant is in active use by the cyphering signal funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)