### PR TITLE
Fix: stamp stop_kind on daemon-entered stops (kill same-day collapse churn)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -61,7 +61,7 @@ from executor.open_orders_artifact import OpenOrdersSnapshotWriter
 from executor.daemon_state_logger import get_logger as _get_decision_logger
 from executor.market_hours import is_market_hours
 from executor.notifier import send_daemon_status, send_trade_alert
-from executor.order_book import OrderBook
+from executor.order_book import OrderBook, build_stop_record
 from executor.price_monitor import PriceMonitor
 from executor.strategies.config import load_strategy_config
 from executor.trade_logger import init_db, log_trade, get_unmatched_entry
@@ -959,14 +959,26 @@ def run_daemon(dry_run: bool = False) -> None:
                 if not price_state:
                     continue
 
-                # Dispatch on the record's stop_kind (written by the morning
-                # planner). ``catastrophic_gap_only`` (optimizer owns the book)
-                # runs ONLY the hard-risk catastrophic gap stop — the alpha
-                # rules (trailing-stop / profit-take / collapse) and the trail
-                # ratchet are suppressed by construction. ``alpha``/absent runs
-                # the full legacy IntradayExitManager. Carrying the authority
-                # in the data (not a daemon flag) is the hard-to-misuse form.
-                if stop.get("stop_kind") == "catastrophic_gap_only":
+                # Dispatch on book authority. Under the optimizer the alpha
+                # rules (trailing-stop / profit-take / 5% collapse) and the
+                # trail ratchet are retired — ONLY the hard-risk catastrophic
+                # gap stop runs. The authority is the RUN-level ``use_optimizer``
+                # flag (belt); ``build_stop_record`` also stamps each record's
+                # ``stop_kind`` (suspenders). Keying the dispatch off the run
+                # config means an un-stamped record from a forgotten/new
+                # producer can NEVER reintroduce same-day churn — it fails SAFE
+                # toward no-churn. (WDAY 2026-06-05: a daemon-entered stop
+                # lacked stop_kind, fell through here, and the collapse rule
+                # force-sold it the same day.)
+                stop_kind = stop.get("stop_kind")
+                if use_optimizer or stop_kind == "catastrophic_gap_only":
+                    if use_optimizer and stop_kind != "catastrophic_gap_only":
+                        logger.warning(
+                            "stop_kind=%r under optimizer authority for %s — "
+                            "forcing catastrophic_gap_only (producer did not "
+                            "stamp the record; failing safe toward no-churn)",
+                            stop_kind, ticker,
+                        )
                     exit_signal = exit_mgr.check_catastrophic_gap(stop, price_state)
                 else:
                     # Check for trail update first
@@ -1164,6 +1176,7 @@ def run_daemon(dry_run: bool = False) -> None:
                             _execute_entry(
                                 ibkr, conn, order_book, entry, price_state, reason,
                                 run_date, strategy_config, dry_run, monitor=monitor,
+                                use_optimizer=use_optimizer,
                             )
                             if not dry_run:
                                 trades_executed += 1
@@ -1493,8 +1506,16 @@ def _execute_entry(
     strategy_config: dict,
     dry_run: bool,
     monitor: "PriceMonitor | None" = None,
+    use_optimizer: bool = False,
 ) -> None:
-    """Execute an intraday entry (BUY) with bracket stop."""
+    """Execute an intraday entry (BUY) with bracket stop.
+
+    ``use_optimizer`` carries the book authority into the stop record so a
+    daemon-entered position gets the SAME ``stop_kind`` the morning planner
+    stamps on held positions. Without it, intraday entries silently defaulted
+    to the alpha exit rules and were churned same-day by the 5% intraday
+    collapse rule (WDAY 2026-06-05) — see order_book.build_stop_record.
+    """
     ticker = entry["ticker"]
     shares = entry.get("shares", 0)
     current_price = price_state.get("last", 0)
@@ -1669,17 +1690,18 @@ def _execute_entry(
     atr_mult = strategy_config.get("intraday_trailing_stop_atr_multiple", 2.0)
     if trail_atr and trail_atr > 0:
         stop_price = round(fill_price - trail_atr * atr_mult, 2)
-        order_book.add_stop({
-            "ticker": ticker,
-            "entry_price": fill_price,
-            "current_stop": stop_price,
-            "trail_atr": trail_atr,
-            "atr_multiple": atr_mult,
-            "high_water": fill_price,
-            "entry_date": run_date,
-            "shares": actual_shares,
-            "entry_trade_id": trade_id,
-        })
+        order_book.add_stop(build_stop_record(
+            ticker=ticker,
+            entry_price=fill_price,
+            current_stop=stop_price,
+            trail_atr=trail_atr,
+            atr_multiple=atr_mult,
+            high_water=fill_price,
+            entry_date=run_date,
+            shares=actual_shares,
+            use_optimizer=use_optimizer,
+            entry_trade_id=trade_id,
+        ))
     else:
         fallback_enabled = strategy_config.get("fallback_stop_enabled", True)
         fallback_pct = strategy_config.get("fallback_stop_pct", 0.10)
@@ -1689,17 +1711,18 @@ def _execute_entry(
                 "No ATR for %s — using %.0f%% fallback stop at $%.2f",
                 ticker, fallback_pct * 100, stop_price,
             )
-            order_book.add_stop({
-                "ticker": ticker,
-                "entry_price": fill_price,
-                "current_stop": stop_price,
-                "trail_atr": 0,
-                "atr_multiple": 0,
-                "high_water": fill_price,
-                "entry_date": run_date,
-                "shares": actual_shares,
-                "entry_trade_id": trade_id,
-            })
+            order_book.add_stop(build_stop_record(
+                ticker=ticker,
+                entry_price=fill_price,
+                current_stop=stop_price,
+                trail_atr=0,
+                atr_multiple=0,
+                high_water=fill_price,
+                entry_date=run_date,
+                shares=actual_shares,
+                use_optimizer=use_optimizer,
+                entry_trade_id=trade_id,
+            ))
         else:
             logger.warning("No ATR for %s — fallback stop disabled, position has no stop", ticker)
     order_book.save()

--- a/executor/main.py
+++ b/executor/main.py
@@ -34,7 +34,7 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from executor.ibkr import IBKRClient, SimulatedIBKRClient
-from executor.order_book import OrderBook
+from executor.order_book import OrderBook, build_stop_record
 from executor.position_sizer import compute_position_size
 from executor.risk_guard import check_order, compute_drawdown_multiplier
 from executor.signal_reader import get_actionable_signals, read_signals_with_fallback
@@ -726,34 +726,32 @@ def _write_stops_and_finalize(
             continue
         atr_val = ticker_atr_pct * entry_price
         stop_price = round(entry_price - atr_val * atr_mult, 2)
-        stop_record = {
-            "ticker": t,
-            "entry_price": entry_price,
-            "current_stop": stop_price,
-            "trail_atr": atr_val or 0,
-            "atr_multiple": atr_mult,
-            "high_water": entry_price,
-            "entry_date": (conn and get_entry_dates(conn, [t]).get(t)) or run_date,
-            "shares": pos_shares,
-        }
-        # ``stop_kind`` lets the daemon dispatch which exit checks run against
-        # this record. Under the optimizer, the only intraday exit allowed is
-        # the catastrophic single-name gap stop; alpha rules are suppressed.
-        # ``gap_reference_price`` anchors the gap check on the most recent
-        # close (gap-down detection), falling back to entry_price.
+        # ``gap_reference_price`` anchors the optimizer-mode gap check on the
+        # most recent close (gap-down detection). For a position held into the
+        # planning run we have its history, so use that; build_stop_record
+        # falls back to entry_price if it's missing.
+        gap_ref = None
         if use_optimizer:
-            stop_record["stop_kind"] = "catastrophic_gap_only"
-            gap_ref = entry_price
             hist = (price_histories or {}).get(t)
             if hist is not None and len(hist):
                 try:
                     gap_ref = float(hist["close"].iloc[-1])
                 except (KeyError, IndexError, ValueError, TypeError):
-                    gap_ref = entry_price
-            stop_record["gap_reference_price"] = gap_ref
-        else:
-            stop_record["stop_kind"] = "alpha"
-        ob.add_stop(stop_record)
+                    gap_ref = None
+        # Single chokepoint stamps stop_kind (+ gap_reference_price) from the
+        # book authority — see order_book.build_stop_record.
+        ob.add_stop(build_stop_record(
+            ticker=t,
+            entry_price=entry_price,
+            current_stop=stop_price,
+            trail_atr=atr_val or 0,
+            atr_multiple=atr_mult,
+            high_water=entry_price,
+            entry_date=(conn and get_entry_dates(conn, [t]).get(t)) or run_date,
+            shares=pos_shares,
+            use_optimizer=use_optimizer,
+            gap_reference_price=gap_ref,
+        ))
 
     # Detect short positions and add urgent cover orders
     for t, pos in current_pos.items():

--- a/executor/order_book.py
+++ b/executor/order_book.py
@@ -29,6 +29,62 @@ def _default_book(run_date: str | None = None) -> dict:
     }
 
 
+def build_stop_record(
+    *,
+    ticker: str,
+    entry_price: float,
+    current_stop: float,
+    trail_atr: float,
+    atr_multiple: float,
+    high_water: float,
+    entry_date: str,
+    shares: int,
+    use_optimizer: bool,
+    gap_reference_price: float | None = None,
+    **extra,
+) -> dict:
+    """Construct an active-stop record with book-authority semantics stamped.
+
+    Single chokepoint for stop creation across BOTH producers — the morning
+    planner (``main.py::_write_stops_and_finalize``) and the intraday daemon
+    (``daemon.py::_execute_entry``). ``use_optimizer`` is a REQUIRED keyword:
+    forgetting it raises ``TypeError`` at construction (fail-loud) rather than
+    silently defaulting to the wrong behavior.
+
+    When the portfolio optimizer owns the book (``use_optimizer=True``) every
+    stop is ``catastrophic_gap_only`` — the daemon runs ONLY the hard-risk
+    per-name catastrophic gap stop and the alpha rules (trailing-stop /
+    profit-take / 5% intraday-collapse) are retired. ``gap_reference_price``
+    anchors that gap check; for a same-day daemon entry there is no overnight
+    gap to catch, so it falls back to ``entry_price`` (a 15% crater from where
+    we actually filled). When the optimizer is off, the record is ``alpha`` and
+    the daemon runs the full legacy ``IntradayExitManager``.
+
+    Centralizing this prevents the producer-divergence bug where daemon-entered
+    positions silently omitted ``stop_kind``, defaulted to the alpha rules, and
+    were churned same-day by the 5%-from-intraday-high collapse rule
+    (WDAY 2026-06-05: bought $146.48, force-sold $143.92 on a 5.0% drop from a
+    pre-entry high of $151.50 — a peak the position never held through).
+    """
+    record = {
+        "ticker": ticker,
+        "entry_price": entry_price,
+        "current_stop": current_stop,
+        "trail_atr": trail_atr,
+        "atr_multiple": atr_multiple,
+        "high_water": high_water,
+        "entry_date": entry_date,
+        "shares": shares,
+    }
+    if use_optimizer:
+        record["stop_kind"] = "catastrophic_gap_only"
+        record["gap_reference_price"] = gap_reference_price or entry_price
+    else:
+        record["stop_kind"] = "alpha"
+    record.update(extra)
+    return record
+
+
 class OrderBook:
     """Manages the intraday order book (JSON on disk)."""
 

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -13,6 +13,7 @@ import pytest
 from executor.entry_triggers import EntryTriggerEngine
 from executor.intraday_exit_manager import IntradayExitManager
 from executor.market_hours import is_market_hours, is_trading_day
+from executor.order_book import build_stop_record
 from executor.notifier import send_daemon_status, send_trade_alert
 from executor.retry import retry
 
@@ -274,6 +275,84 @@ class TestIntradayExitManager:
             {"last": 178.0},  # -11% — fires at 10% threshold
         )
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# build_stop_record — book-authority chokepoint (WDAY 2026-06-05 regression)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildStopRecord:
+    """The single chokepoint that stamps stop_kind from the book authority.
+
+    Both producers (morning planner + intraday daemon) route through this, so
+    a daemon-entered position can no longer silently omit stop_kind and inherit
+    the alpha exit rules (the WDAY 2026-06-05 same-day-churn bug).
+    """
+
+    def _kwargs(self, **overrides):
+        base = dict(
+            ticker="WDAY", entry_price=146.48, current_stop=132.0,
+            trail_atr=4.0, atr_multiple=2.0, high_water=146.48,
+            entry_date="2026-06-05", shares=306,
+        )
+        base.update(overrides)
+        return base
+
+    def test_optimizer_stamps_catastrophic_gap_only(self):
+        rec = build_stop_record(use_optimizer=True, **self._kwargs())
+        assert rec["stop_kind"] == "catastrophic_gap_only"
+        # No explicit reference → anchors on entry_price (no overnight gap for a
+        # same-day entry; the gap stop guards a 15% crater from the fill).
+        assert rec["gap_reference_price"] == 146.48
+
+    def test_optimizer_uses_explicit_gap_reference(self):
+        rec = build_stop_record(
+            use_optimizer=True, gap_reference_price=150.0, **self._kwargs()
+        )
+        assert rec["gap_reference_price"] == 150.0
+
+    def test_non_optimizer_stamps_alpha(self):
+        rec = build_stop_record(use_optimizer=False, **self._kwargs())
+        assert rec["stop_kind"] == "alpha"
+        assert "gap_reference_price" not in rec
+
+    def test_use_optimizer_is_required(self):
+        # Forgetting the authority is a TypeError at construction (fail-loud),
+        # never a silent default to the wrong (alpha) behavior.
+        with pytest.raises(TypeError):
+            build_stop_record(**self._kwargs())
+
+    def test_extra_fields_passthrough(self):
+        rec = build_stop_record(
+            use_optimizer=True, entry_trade_id="abc-123", **self._kwargs()
+        )
+        assert rec["entry_trade_id"] == "abc-123"
+
+    def test_wday_scenario_no_intraday_collapse_under_optimizer(self):
+        """The exact WDAY 2026-06-05 churn must not recur.
+
+        Bought $146.48; the day's HIGH was $151.50 (set before the entry); the
+        price fell to $143.92 — 5.0% below the high but only ~1.7% below entry.
+        Under optimizer authority the daemon runs ONLY the catastrophic gap
+        stop, which must NOT fire (a true risk control sees a 1.7% drift, not a
+        crater). The retired 5% collapse rule WOULD have force-sold it.
+        """
+        mgr = IntradayExitManager({"catastrophic_gap_stop_pct": 0.15})
+        rec = build_stop_record(use_optimizer=True, **self._kwargs())
+        price_state = {"last": 143.92, "high": 151.50}
+
+        # Production path under the optimizer: gap stop only — no exit.
+        assert mgr.check_catastrophic_gap(rec, price_state) is None
+
+        # Document the retired behavior: the alpha collapse rule WOULD fire on
+        # the 5%-from-high drop. This is what the fix suppresses.
+        legacy = mgr.evaluate(rec, price_state)
+        assert legacy is not None and legacy["reason"] == "intraday_collapse"
+
+        # And a genuine 15% crater from the fill still trips the gap stop.
+        crater = mgr.check_catastrophic_gap(rec, {"last": 124.0, "high": 151.50})
+        assert crater is not None and crater["reason"] == "catastrophic_gap_stop"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Under the portfolio optimizer the alpha exit rules (trailing-stop / profit-take / 5% intraday-collapse) are **retired** — only the hard-risk catastrophic gap stop runs intraday. That intent was enforced **only** for positions held at morning-planning time (`main.py` stamps `stop_kind="catastrophic_gap_only"`). Positions **entered intraday by the daemon** (`_execute_entry`) added stop records **without** `stop_kind`, so the daemon dispatch fell through to the full legacy `IntradayExitManager` and the 5%-from-intraday-**high** collapse rule force-sold them the same day.

**Confirmed live (trades_full.csv):** WDAY 2026-06-05 bought \$146.48 (VWAP-discount trigger, `optimizer_target_weight` 0.1), force-sold \$143.92 ~2h later — `exit_reason=intraday_collapse` ("drop 5.0% >= 5.0%, high=\$151.50"). The high was set **before** the entry; the position fell only ~1.7% from the fill but 5.0% from a peak it never held through. IBKR (entered intraday 6/08 via time_expiry) carried the same defaulted record and was exposed to the identical failure mode.

This is the same-day churn the optimizer-owns-the-book design exists to eliminate.

## Fix (SOTA/institutional — chokepoint + fail-safe, not a one-path patch)

- **`order_book.build_stop_record()`** — single constructor both producers (`main.py` planner + daemon `_execute_entry`) route through. `use_optimizer` is a **required keyword**: forgetting it raises `TypeError` at construction (fail-loud) rather than silently defaulting to the wrong behavior. Stamps `stop_kind` (+ `gap_reference_price` under the optimizer, falling back to `entry_price` for same-day entries where there is no overnight gap to catch).
- **Daemon dispatch** now keys "catastrophic-gap-only" off the **run-level `use_optimizer` flag** (belt), with the per-record `stop_kind` as suspenders. An un-stamped record from a future/forgotten producer can no longer reintroduce churn — it fails **safe** toward no-churn and logs a WARN (producer-gap detection).
- **Regression test** reproducing WDAY 6/05: optimizer-mode daemon stop + 5%-from-high drop → no catastrophic-gap exit; documents that the retired collapse rule *would* have fired; a true 15% crater still trips the gap stop.

## Why not the minimal patch

Threading the flag into `_execute_entry` alone fixes the one path that bit us but leaves (a) two divergent stop-record producers free to drift again, and (b) the silent `else`-branch fallback that treats *absent* `stop_kind` as "run all alpha rules" — the most aggressive default. The chokepoint constructor + run-config-keyed fail-safe dispatch close the bug **class**, not the instance.

## Testing

- Full executor suite: **1093 passed**.
- New `TestBuildStopRecord` (6 tests) including the WDAY 6/05 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)