### PR TITLE
feat: flow-doctor default-on roll (lib v0.58.0) + telegram-on-issue

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -66,7 +66,7 @@ from executor.price_monitor import PriceMonitor
 from executor.strategies.config import load_strategy_config
 from executor.trade_logger import init_db, log_trade, get_unmatched_entry
 
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 # See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
@@ -1773,4 +1773,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Alpha Engine Intraday Daemon")
     parser.add_argument("--dry-run", action="store_true", help="Log triggers without placing orders")
     args = parser.parse_args()
-    run_daemon(dry_run=args.dry_run)
+    # Capture an uncaught daemon crash via flow-doctor before re-raising
+    # (no-ops when flow-doctor is inactive).
+    with guard_entrypoint():
+        run_daemon(dry_run=args.dry_run)

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -26,7 +26,7 @@ from executor.trade_logger import (
 )
 
 from alpha_engine_lib.dates import now_dual
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 # See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
@@ -1003,4 +1003,7 @@ if __name__ == "__main__":
         help="YYYY-MM-DD; must equal today's trading_day or the run aborts.",
     )
     args = parser.parse_args()
-    run(run_date=args.date)
+    # Capture an uncaught crash via flow-doctor before re-raising
+    # (no-ops when flow-doctor is inactive).
+    with guard_entrypoint():
+        run(run_date=args.date)

--- a/executor/main.py
+++ b/executor/main.py
@@ -60,7 +60,7 @@ from executor.trade_logger import (
     log_trade,
 )
 
-from alpha_engine_lib.logging import setup_logging
+from alpha_engine_lib.logging import setup_logging, guard_entrypoint
 # Suppress benign IB Error codes that don't represent real failures:
 #   10197 — "No market data during competing live session". The daemon
 #     keeps receiving delayed ticks via the delayedLast fallback in
@@ -1941,4 +1941,9 @@ if __name__ == "__main__":
         else:
             logger.info("No simulated orders generated")
     else:
-        run(dry_run=args.dry_run)
+        # guard_entrypoint captures an uncaught crash (bare raise) and reports
+        # it to flow-doctor before re-raising — the log handler only sees
+        # logger.error/exception, not a propagating exception. No-ops when
+        # flow-doctor is inactive (e.g. local dev).
+        with guard_entrypoint():
+            run(dry_run=args.dry_run)

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -11,6 +11,12 @@ notify:
   - type: github
     repo: cipher813/alpha-engine
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
+  # Telegram fires on the same error report as the GitHub issue (the issue
+  # and the alert land together). Creds resolve from the ae-trading box's
+  # ~/.alpha-engine.env (TELEGRAM_BOT_TOKEN / TELEGRAM_CHAT_ID).
+  - type: telegram
+    bot_token: ${TELEGRAM_BOT_TOKEN}
+    chat_id: ${TELEGRAM_CHAT_ID}
   - type: s3
     bucket: alpha-engine-research
     subsystem: executor

--- a/infrastructure/systemd/alpha-engine-daemon.service
+++ b/infrastructure/systemd/alpha-engine-daemon.service
@@ -20,6 +20,7 @@ Environment=PYTHONPATH=/home/ec2-user/alpha-engine
 Environment=AWS_REGION=us-east-1
 Environment=ALPHA_ENGINE_JSON_LOGS=1
 Environment=FLOW_DOCTOR_ENABLED=1
+Environment=ALPHA_ENGINE_DEPLOYED=1
 # Secrets (EMAIL_SENDER, GMAIL_APP_PASSWORD, ANTHROPIC_API_KEY, ...) — the
 # RunDaemon SSM step launches this unit via systemd, which (unlike the SF's
 # RunMorningPlanner command) does not `source` the env file. PR 9g (#182)

--- a/infrastructure/systemd/alpha-engine-morning.service
+++ b/infrastructure/systemd/alpha-engine-morning.service
@@ -17,6 +17,7 @@ Environment=PYTHONPATH=/home/ec2-user/alpha-engine
 Environment=AWS_REGION=us-east-1
 Environment=ALPHA_ENGINE_JSON_LOGS=1
 Environment=FLOW_DOCTOR_ENABLED=1
+Environment=ALPHA_ENGINE_DEPLOYED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ requests~=2.32
 # are NOT consumed here (executor has no LLM exposure per
 # [[preference_llm_calls_confined_to_research_module]]) but the
 # transitive lib pin stays current.
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.42.0
+alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
## Why
Work stream 3 (executor) of the "make flow-doctor actually kick in" arc. Brings the executor onto **lib v0.58.0** (default-on flow-doctor + flow-doctor `0.6.0rc3`: decision-trace, heartbeat, telegram-on-fix-PR), adds crash-capture, and wires **telegram-on-issue**.

## What
- **Pin** `alpha-engine-lib@v0.42.0 → v0.58.0`.
- **Crash capture:** wrap `main.py` `run()`, `daemon.py` `run_daemon()`, `eod_reconcile.py` `run()` in `guard_entrypoint()` — an uncaught `raise` now reaches flow-doctor (the log handler only sees `logger.error/exception`). No-ops when inactive; existing `fd.report()` sites unchanged (60-min dedup absorbs any same-signature overlap).
- **Telegram-on-issue:** add a `telegram` notifier to `flow-doctor.yaml` — fires on the same report as the GitHub issue. Creds resolve from the ae-trading box's `~/.alpha-engine.env` (`TELEGRAM_BOT_TOKEN`/`TELEGRAM_CHAT_ID`).
- **`ALPHA_ENGINE_DEPLOYED=1`** on the morning + daemon systemd units (fail-loud marker; `FLOW_DOCTOR_ENABLED=1` already implied strict — belt-and-suspenders / future-proof).

## Validation
**1093 tests pass**; `python executor/main.py --simulate --dry-run` runs clean through the new guard. flow-doctor stays inactive under pytest (lib's `PYTEST_CURRENT_TEST` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)