### PR TITLE
feat(executor): L4515 turnover tripwire + L4520 executor_params consumer contract

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -396,6 +396,20 @@ portfolio_optimizer:
   # emits a WARN + SNS/Telegram alert for operator approval to accelerate —
   # the move is still executed gradually under the cap regardless.
   large_move_turnover_flag: 0.35
+  # ── Turnover tripwire (L4515) — SAFETY alarm, not backtester-tuned ──────
+  # Band-checks EXECUTED one-way turnover daily in the planner and pages on
+  # breach (verdict persisted in predictor/optimizer_shadow/{date}.json):
+  #   daily   — executed > max_daily_turnover × daily_multiple → ERROR page
+  #             (the governor should make this impossible; a breach means the
+  #             cap was bypassed/disabled).
+  #   rolling — sum of executed turnover over the last rolling_days sessions
+  #             > rolling_sum_band → WARN page (churn-by-a-thousand-cuts:
+  #             each day under the cap, week abnormal — the 5/29 / 6/01 /
+  #             6/04 incident signature).
+  turnover_tripwire_enabled: true
+  turnover_tripwire_daily_multiple: 1.25
+  turnover_tripwire_rolling_days: 5
+  turnover_tripwire_rolling_sum_band: 0.60
   # Σ horizon in trading days. 1 (default) = legacy daily Σ, bit-identical to
   # pre-260526 behavior. Set to 21 to align Σ with the canonical 21d log-domain
   # α̂; under i.i.d. log-returns Σ_H = H · Σ_daily, with vol-target SOC and

--- a/executor/main.py
+++ b/executor/main.py
@@ -131,6 +131,32 @@ _PARAM_VALIDATORS = {
 
 _EXECUTOR_PARAMS_CACHE_PATH = Path(__file__).resolve().parent.parent / "config" / ".executor_params_cache.json"
 
+# Non-numeric S3-delivered params the loader passes through to the applied
+# set (master switches / lists — not range-validated like _PARAM_MAP values).
+# Contract: PIPELINE_CONTRACT.yaml executor_params "applied special" section +
+# tests/test_executor_params_consumer_contract.py (L4520).
+_EXECUTOR_PARAMS_SPECIAL_KEYS = (
+    "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
+    "barrier_win_prob_sizing_enabled",
+)
+
+# Producer provenance/metadata keys — KNOWN (no unknown-key WARN) but never
+# applied. Keeping this list complete keeps the WARN signal: an unknown key
+# always means genuine producer/consumer contract drift, not noise.
+# NOTE deliberately ABSENT: stance_size_* (the stance overlay is emitted by
+# the backtester's stance_sizing_optimizer but its application is NOT wired
+# here — its first live arrival must WARN; see the named gap in
+# PIPELINE_CONTRACT.yaml + the ROADMAP follow-up).
+_EXECUTOR_PARAMS_KNOWN_METADATA_KEYS = (
+    "updated_at", "assembled_by", "fit_target",
+    "best_sharpe", "best_alpha", "best_sortino",
+    "improvement_pct", "n_combos_tested", "manual_override",
+    "disabled_triggers_updated_at",
+    "barrier_win_prob_sizing_updated_at", "barrier_win_prob_sizing_ic",
+    "p_up_sizing_updated_at", "p_up_sizing_ic",
+    "stance_sizing_updated_at", "stance_sizing_alpha_spread",
+)
+
 
 def _load_executor_params_from_s3(bucket: str) -> dict | None:
     """Read config/executor_params.json from S3. Cache per cold-start.
@@ -151,12 +177,12 @@ def _load_executor_params_from_s3(bucket: str) -> dict | None:
         obj = s3.get_object(Bucket=bucket, Key="config/executor_params.json")
         data = json.loads(obj["Body"].read())
         # Advisory schema validation (log warnings, never block)
-        _unknown_keys = [k for k in data if k not in _PARAM_MAP and k not in (
-            "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
-            "barrier_win_prob_sizing_enabled",
-            "updated_at", "best_sharpe", "best_alpha", "improvement_pct",
-            "n_combos_tested", "manual_override",
-        )]
+        _unknown_keys = [
+            k for k in data
+            if k not in _PARAM_MAP
+            and k not in _EXECUTOR_PARAMS_SPECIAL_KEYS
+            and k not in _EXECUTOR_PARAMS_KNOWN_METADATA_KEYS
+        ]
         if _unknown_keys:
             logger.warning("executor_params.json contains unknown keys: %s", _unknown_keys)
         # Only keep safe-to-override params (numeric) + special non-numeric params
@@ -164,10 +190,7 @@ def _load_executor_params_from_s3(bucket: str) -> dict | None:
         # Phase 4 non-numeric params: disabled_triggers (list), p_up sizing (bool).
         # Task B2: barrier_win_prob_sizing_enabled (bool) — the dormant sizing
         # consumer's master switch, flipped via S3 after soak + backtester sweep.
-        for special_key in (
-            "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
-            "barrier_win_prob_sizing_enabled",
-        ):
+        for special_key in _EXECUTOR_PARAMS_SPECIAL_KEYS:
             if special_key in data:
                 safe[special_key] = data[special_key]
         if safe:

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -78,6 +78,17 @@ def run_shadow_optimizer(
             run_date=run_date,
             legacy_orders=legacy_orders or [],
         )
+        # L4515 turnover tripwire: band-check the executed turnover (daily +
+        # rolling) BEFORE the artifact write so the verdict rides the daily
+        # shadow log. check_turnover_tripwire never raises (sentinel on error).
+        from executor.turnover_tripwire import check_turnover_tripwire
+        log["turnover_tripwire"] = check_turnover_tripwire(
+            log.get("diagnostics") or {},
+            log.get("optimizer_cfg") or {},
+            signals_bucket,
+            run_date,
+            s3_client,
+        )
         _write_shadow_log_to_s3(log, signals_bucket, run_date, s3_client)
         logger.info(
             f"Shadow optimizer OK: status={log['diagnostics']['status']} "

--- a/executor/portfolio_optimizer.py
+++ b/executor/portfolio_optimizer.py
@@ -269,6 +269,18 @@ OPTIMIZER_CONFIG_DEFAULTS: dict = {
     #     the flag.
     "max_daily_turnover": 0.20,
     "large_move_turnover_flag": 0.35,
+    # ── Turnover tripwire (L4515) ─────────────────────────────────────────
+    # SAFETY alarm — NOT an alpha knob, NOT backtester-tuned. Band-checks the
+    # EXECUTED one-way turnover daily in the planner and pages on breach
+    # (executor/turnover_tripwire.py): daily = cap × multiple at ERROR (the
+    # governor should make a breach impossible, so one means the cap was
+    # bypassed/disabled); rolling = sum over the last N sessions at WARN
+    # (churn-by-a-thousand-cuts — each day under the cap, week abnormal; the
+    # signature of the 5/29, 6/01, 6/04 incidents this generalizes).
+    "turnover_tripwire_enabled": True,
+    "turnover_tripwire_daily_multiple": 1.25,
+    "turnover_tripwire_rolling_days": 5,
+    "turnover_tripwire_rolling_sum_band": 0.60,
 }
 
 

--- a/executor/turnover_tripwire.py
+++ b/executor/turnover_tripwire.py
@@ -1,0 +1,224 @@
+"""Turnover tripwire — ROADMAP L4515 (fast standalone live-system ops fix).
+
+``turnover_one_way`` has been computed in ``portfolio_optimizer`` since the
+governor shipped, but never ALARMED. Three extreme-decision incidents (idle
+cash after a hard-risk exit 2026-05-29 #229; a ~90%-DOWN-skew prediction day
+2026-06-01 #230; an optimizer target silently dropped on a missing price
+2026-06-04 #234/#235) were each caught by a point fix after the fact. This is
+the GENERAL surface: a band check on the existing executed-turnover metric
+that pages when the book churns abnormally, whatever the upstream cause.
+
+Two independent bands, checked daily in the morning planner (via
+``run_shadow_optimizer``) and persisted into the shadow artifact:
+
+- **daily** — executed ``turnover_one_way`` above the governor cap × a
+  multiple. The governor is supposed to make this impossible; a breach means
+  the cap was bypassed/disabled and pages at ERROR.
+- **rolling** — the sum of executed turnover over the last N sessions (read
+  from the prior ``predictor/optimizer_shadow/{date}.json`` artifacts) above a
+  band. Catches churn-by-a-thousand-cuts: every day under the cap but the
+  week's cumulative rebalance abnormal — the actual signature of the three
+  incidents above. Pages at WARN.
+
+Posture (per [[feedback_no_silent_fails]]): the tripwire itself RAISES on a
+breach via ``alerts.publish`` (SNS + Telegram, deduped per run_date). It is
+secondary observability hung off the planner's primary path, so an internal
+failure must never block order planning — but the failure is RECORDED, not
+swallowed: WARN log + a status/sentinel block written into the daily shadow
+artifact (``turnover_tripwire`` key), so a dead tripwire is itself visible.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+_SHADOW_PREFIX = "predictor/optimizer_shadow/"
+_DATED_KEY_RE = re.compile(r"optimizer_shadow/(\d{4}-\d{2}-\d{2})\.json$")
+
+# Absolute daily band when the governor is OFF (max_daily_turnover: None) —
+# with no cap to multiply, a full-book one-way move above this is the same
+# "should have been operator-reviewed" event the governor would have capped.
+_DAILY_BAND_GOVERNOR_OFF = 0.25
+
+
+def check_turnover_tripwire(
+    diagnostics: dict,
+    optimizer_cfg: dict,
+    signals_bucket: str,
+    run_date: str,
+    s3_client=None,
+) -> dict:
+    """Run both bands and alert on breach. Returns the block persisted into
+    the shadow artifact. Never raises (see module docstring posture)."""
+    try:
+        if not optimizer_cfg.get("turnover_tripwire_enabled", True):
+            return {"status": "disabled"}
+        today = (diagnostics or {}).get("turnover_one_way")
+        if today is None or not math.isfinite(float(today)):
+            # Upstream contract violation — the optimizer always writes this
+            # field on a solved run. Surface it, don't quietly skip (the
+            # silent-skip is how the 6/04 dropped-target class hid).
+            logger.warning(
+                "turnover tripwire: diagnostics carry no finite "
+                "turnover_one_way (run_date=%s) — tripwire DID NOT RUN",
+                run_date,
+            )
+            return {"status": "no_turnover_metric"}
+        today = float(today)
+
+        cap = optimizer_cfg.get("max_daily_turnover")
+        multiple = float(optimizer_cfg.get("turnover_tripwire_daily_multiple", 1.25))
+        daily_band = float(cap) * multiple if cap else _DAILY_BAND_GOVERNOR_OFF
+        rolling_days = int(optimizer_cfg.get("turnover_tripwire_rolling_days", 5))
+        rolling_band = float(
+            optimizer_cfg.get("turnover_tripwire_rolling_sum_band", 0.60)
+        )
+
+        prior = _read_prior_turnovers(
+            signals_bucket, run_date, rolling_days - 1, s3_client
+        )
+        window = [today] + prior
+        rolling_sum = float(sum(window))
+
+        daily_breach = today > daily_band
+        rolling_breach = rolling_sum > rolling_band
+        out = {
+            "status": "ok",
+            "turnover_one_way": round(today, 6),
+            "daily_band": round(daily_band, 6),
+            "daily_breach": daily_breach,
+            "rolling_days": rolling_days,
+            "n_days_used": len(window),
+            "rolling_sum": round(rolling_sum, 6),
+            "rolling_band": round(rolling_band, 6),
+            "rolling_breach": rolling_breach,
+        }
+        if daily_breach:
+            _publish(
+                out,
+                severity="ERROR",
+                dedup_key=f"turnover_tripwire_daily_{run_date}",
+                message=(
+                    f"[executor] TURNOVER TRIPWIRE (daily): executed one-way "
+                    f"turnover {today:.1%} exceeds the {daily_band:.1%} band "
+                    f"(governor cap {cap if cap is None else format(cap, '.0%')}, "
+                    f"run_date={run_date}). The governor should make this "
+                    f"impossible — investigate before the next session."
+                ),
+            )
+            logger.warning(
+                "TURNOVER TRIPWIRE daily breach: %.1f%% > %.1f%% (run_date=%s)",
+                today * 100, daily_band * 100, run_date,
+            )
+        if rolling_breach:
+            _publish(
+                out,
+                severity="WARN",
+                dedup_key=f"turnover_tripwire_rolling_{run_date}",
+                message=(
+                    f"[executor] TURNOVER TRIPWIRE (rolling): one-way turnover "
+                    f"summed {rolling_sum:.1%} over the last {len(window)} "
+                    f"session(s) — above the {rolling_band:.0%}/{rolling_days}d "
+                    f"band (run_date={run_date}). The book is churning "
+                    f"abnormally even though each day is under the cap; review "
+                    f"the optimizer shadow logs for the driver."
+                ),
+            )
+            logger.warning(
+                "TURNOVER TRIPWIRE rolling breach: sum %.1f%% over %d sessions "
+                "> %.1f%% (run_date=%s)",
+                rolling_sum * 100, len(window), rolling_band * 100, run_date,
+            )
+        if not (daily_breach or rolling_breach):
+            logger.info(
+                "turnover tripwire OK: today=%.1f%% (band %.1f%%), "
+                "rolling %.1f%%/%dd (band %.1f%%)",
+                today * 100, daily_band * 100, rolling_sum * 100,
+                len(window), rolling_band * 100,
+            )
+        return out
+    except Exception as e:  # noqa: BLE001 — secondary observability: must not
+        # block the planner; failure recorded in the shadow artifact + WARN.
+        logger.warning("turnover tripwire failed (non-blocking): %s", e, exc_info=True)
+        return {"status": "error", "error": repr(e)}
+
+
+def _read_prior_turnovers(
+    bucket: str, run_date: str, n: int, s3_client=None,
+) -> list[float]:
+    """Executed ``turnover_one_way`` from the most recent ``n`` dated shadow
+    artifacts strictly before ``run_date``. Artifacts that are missing the
+    metric (failed/sentinel days) are skipped with a log line — a short window
+    still alerts when its partial sum already breaches (sum is monotonic)."""
+    if n <= 0:
+        return []
+    s3 = s3_client or boto3.client("s3")
+    dates: list[str] = []
+    token = None
+    # Hard page cap: the prefix accrues ~1 dated key per session (~250/yr) at
+    # 1000 keys/page, so >10 pages is structurally impossible — the cap is a
+    # guard against a pathological/non-conforming client looping forever on a
+    # truthy IsTruncated (exactly how a MagicMock behaves in tests).
+    for _page in range(10):
+        kwargs = {"Bucket": bucket, "Prefix": _SHADOW_PREFIX}
+        if token:
+            kwargs["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kwargs)
+        for obj in resp.get("Contents", []):
+            m = _DATED_KEY_RE.search(obj.get("Key", ""))
+            if m and m.group(1) < run_date:
+                dates.append(m.group(1))
+        if not resp.get("IsTruncated"):
+            break
+        token = resp.get("NextContinuationToken")
+    else:
+        logger.warning(
+            "turnover tripwire: shadow-prefix listing exceeded the 10-page "
+            "cap — rolling window computed from the first %d keys only",
+            len(dates),
+        )
+    out: list[float] = []
+    for d in sorted(dates, reverse=True)[:n]:
+        try:
+            body = s3.get_object(Bucket=bucket, Key=f"{_SHADOW_PREFIX}{d}.json")
+            log_d = json.loads(body["Body"].read())
+            v = (log_d.get("diagnostics") or {}).get("turnover_one_way")
+            if v is not None and math.isfinite(float(v)):
+                out.append(float(v))
+            else:
+                logger.info(
+                    "turnover tripwire: %s shadow log has no turnover "
+                    "(sentinel/failed day) — excluded from rolling window", d,
+                )
+        except Exception as e:  # noqa: BLE001 — one unreadable day must not
+            # kill the window; the exclusion is logged and n_days_used shows it.
+            logger.warning(
+                "turnover tripwire: could not read shadow log for %s: %s", d, e,
+            )
+    return out
+
+
+def _publish(out: dict, *, severity: str, dedup_key: str, message: str) -> None:
+    """Best-effort alert publish — mirrors the large-move flag posture: the
+    band verdict is already recorded (shadow artifact + WARN log), so a
+    publish failure must never block the planner; it is recorded in the
+    artifact's ``publish_error`` field."""
+    try:
+        from alpha_engine_lib import alerts as _alerts
+        _alerts.publish(
+            message=message,
+            severity=severity,
+            source="alpha-engine/executor/turnover_tripwire.py",
+            sns=True,
+            telegram=True,
+            dedup_key=dedup_key,
+        )
+    except Exception as e:  # noqa: BLE001 — secondary observability
+        logger.warning("turnover tripwire alert publish failed (non-fatal): %s", e)
+        out["publish_error"] = repr(e)

--- a/tests/test_executor_params_consumer_contract.py
+++ b/tests/test_executor_params_consumer_contract.py
@@ -1,0 +1,99 @@
+"""L4520 — consumer contract for config/executor_params.json (cross-repo).
+
+Pins the executor side of the boundary declared in alpha-engine-config/
+private-docs/PIPELINE_CONTRACT.yaml (boundary_id: executor_params), mirroring
+the backtester's tests/test_executor_params_producer_contract.py. The loader
+(main._load_executor_params_from_s3) APPLIES only _PARAM_MAP + the special
+non-numeric keys and silently excludes everything else, so this test is the
+chokepoint that catches a producer/consumer key-set drift at PR time instead
+of as a tuned-param-that-never-applied in live trading.
+
+The declared sets are hard-coded here (per-repo CI can't import the config
+repo's YAML — the test_scanner_consumer_contract.py precedent); the YAML is
+the human SoT.
+"""
+from __future__ import annotations
+
+from executor import main
+
+
+# Params the producer (backtester optimizer assembler) can emit for the
+# executor to APPLY — PIPELINE_CONTRACT.yaml "applied" sections, minus the
+# stance_size_* overlay (deliberately NOT consumer-accepted yet — see below).
+PRODUCER_APPLIED_PARAMS = {
+    "atr_multiplier", "time_decay_reduce_days", "time_decay_exit_days",
+    "min_score", "max_position_pct", "reduce_fraction",
+    "atr_sizing_target_risk", "confidence_sizing_min",
+    "confidence_sizing_range", "staleness_decay_per_day",
+    "earnings_sizing_reduction", "earnings_proximity_days",
+    "momentum_gate_threshold", "correlation_block_threshold",
+    "profit_take_pct", "momentum_exit_threshold",
+    "barrier_win_prob_sizing_min", "barrier_win_prob_sizing_range",
+}
+PRODUCER_SPECIAL_KEYS = {
+    "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
+    "barrier_win_prob_sizing_enabled",
+}
+# Provenance / metadata the producer rides along — the loader must KNOW them
+# (no unknown-key WARN) but never apply them.
+PRODUCER_METADATA_KEYS = {
+    "updated_at", "assembled_by", "fit_target", "best_sharpe", "best_alpha",
+    "best_sortino", "improvement_pct", "n_combos_tested", "manual_override",
+    "disabled_triggers_updated_at", "barrier_win_prob_sizing_updated_at",
+    "barrier_win_prob_sizing_ic", "p_up_sizing_updated_at", "p_up_sizing_ic",
+    "stance_sizing_updated_at", "stance_sizing_alpha_spread",
+}
+# Emitted by stance_sizing_optimizer but NOT applied by the executor — the
+# named gap in PIPELINE_CONTRACT.yaml. These must stay OUT of both the applied
+# map and the advisory known-keys list so their first live arrival logs an
+# unknown-key WARN (the only signal until application is wired or the overlay
+# is retired — ROADMAP follow-up filed with the boundary).
+STANCE_OVERLAY_NOT_APPLIED = {
+    "stance_size_momentum", "stance_size_value", "stance_size_quality",
+    "stance_size_catalyst",
+}
+
+
+def test_param_map_covers_every_applied_producer_param():
+    missing = PRODUCER_APPLIED_PARAMS - set(main._PARAM_MAP)
+    assert not missing, (
+        f"executor _PARAM_MAP is missing producer-emitted param(s) "
+        f"{sorted(missing)} — they would be silently dropped from the applied "
+        f"set. Add the mapping + _PARAM_VALIDATORS entry, or remove them from "
+        f"the contract (PIPELINE_CONTRACT.yaml executor_params) + producer."
+    )
+
+
+def test_every_applied_param_has_a_validator():
+    missing = PRODUCER_APPLIED_PARAMS - set(main._PARAM_VALIDATORS)
+    assert not missing, (
+        f"S3-delivered param(s) {sorted(missing)} have no _PARAM_VALIDATORS "
+        f"range — an out-of-range tuned value would apply unchecked."
+    )
+
+
+def test_advisory_known_keys_cover_producer_metadata():
+    # The loader's unknown-key WARN must stay SIGNAL: every declared metadata
+    # key is known, so a WARN always means genuine contract drift.
+    known = main._EXECUTOR_PARAMS_KNOWN_METADATA_KEYS
+    missing = PRODUCER_METADATA_KEYS - set(known) - PRODUCER_SPECIAL_KEYS
+    assert not missing, (
+        f"producer metadata key(s) {sorted(missing)} missing from the "
+        f"loader's advisory known-keys list — every live read would log a "
+        f"spurious unknown-key WARN, training operators to ignore the warn."
+    )
+
+
+def test_special_keys_accepted():
+    # The loader's special-key passthrough must accept every declared special.
+    assert PRODUCER_SPECIAL_KEYS == set(main._EXECUTOR_PARAMS_SPECIAL_KEYS)
+
+
+def test_stance_overlay_deliberately_unknown():
+    # Inverse pin: the stance overlay must NOT be silently known/applied until
+    # its application is actually wired (or the overlay retired).
+    assert not STANCE_OVERLAY_NOT_APPLIED & set(main._PARAM_MAP)
+    assert not STANCE_OVERLAY_NOT_APPLIED & set(main._EXECUTOR_PARAMS_SPECIAL_KEYS)
+    assert not STANCE_OVERLAY_NOT_APPLIED & set(
+        main._EXECUTOR_PARAMS_KNOWN_METADATA_KEYS
+    )

--- a/tests/test_turnover_tripwire.py
+++ b/tests/test_turnover_tripwire.py
@@ -1,0 +1,162 @@
+"""L4515 — turnover tripwire (daily + rolling band on executed turnover).
+
+Pins: no-breach quiet path; daily breach pages at ERROR with the run-date
+dedup key; rolling breach sums the prior shadow artifacts and pages at WARN;
+sentinel/unreadable prior days are excluded (not fabricated); a partial
+window still alerts when its sum already breaches; the disabled flag and the
+missing-metric upstream-contract case; publish failure is recorded in the
+artifact block, never raised into the planner.
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from executor import turnover_tripwire as tw
+
+
+class _FakeS3:
+    """list_objects_v2 + get_object over a dict of {key: dict-payload}."""
+
+    def __init__(self, objects=None):
+        self.objects = dict(objects or {})
+
+    def list_objects_v2(self, Bucket, Prefix, **kwargs):  # noqa: N803
+        return {
+            "Contents": [{"Key": k} for k in self.objects if k.startswith(Prefix)],
+            "IsTruncated": False,
+        }
+
+    def get_object(self, Bucket, Key):  # noqa: N803
+        return {"Body": io.BytesIO(json.dumps(self.objects[Key]).encode())}
+
+
+def _shadow(date, turnover):
+    diag = {} if turnover is None else {"turnover_one_way": turnover}
+    return {"run_date": date, "diagnostics": diag}
+
+
+_CFG = {
+    "max_daily_turnover": 0.20,
+    "turnover_tripwire_enabled": True,
+    "turnover_tripwire_daily_multiple": 1.25,
+    "turnover_tripwire_rolling_days": 5,
+    "turnover_tripwire_rolling_sum_band": 0.60,
+}
+
+
+@pytest.fixture
+def published(monkeypatch):
+    calls = []
+    from alpha_engine_lib import alerts
+
+    monkeypatch.setattr(alerts, "publish", lambda **kw: calls.append(kw))
+    return calls
+
+
+def test_quiet_day_no_alert(published):
+    s3 = _FakeS3({
+        f"{tw._SHADOW_PREFIX}2026-06-09.json": _shadow("2026-06-09", 0.05),
+    })
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.05}, _CFG, "bkt", "2026-06-10", s3)
+    assert out["status"] == "ok"
+    assert out["daily_breach"] is False and out["rolling_breach"] is False
+    assert out["rolling_sum"] == pytest.approx(0.10)
+    assert out["n_days_used"] == 2
+    assert published == []
+
+
+def test_daily_breach_pages_error(published):
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.30}, _CFG, "bkt", "2026-06-10", _FakeS3())
+    assert out["daily_breach"] is True            # 0.30 > 0.20 × 1.25
+    severities = [c["severity"] for c in published]
+    assert "ERROR" in severities
+    daily = next(c for c in published if c["severity"] == "ERROR")
+    assert daily["dedup_key"] == "turnover_tripwire_daily_2026-06-10"
+    assert daily["sns"] is True and daily["telegram"] is True
+
+
+def test_rolling_breach_sums_prior_days_and_pages_warn(published):
+    s3 = _FakeS3({
+        f"{tw._SHADOW_PREFIX}2026-06-{d:02d}.json": _shadow(f"2026-06-{d:02d}", t)
+        for d, t in [(4, 0.15), (5, 0.15), (8, 0.15), (9, 0.15)]
+    })
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.10}, _CFG, "bkt", "2026-06-10", s3)
+    assert out["daily_breach"] is False           # every day under the cap…
+    assert out["rolling_breach"] is True          # …but the week churned 70%
+    assert out["rolling_sum"] == pytest.approx(0.70)
+    assert [c["severity"] for c in published] == ["WARN"]
+    assert published[0]["dedup_key"] == "turnover_tripwire_rolling_2026-06-10"
+
+
+def test_window_takes_newest_n_and_ignores_future_and_latest(published):
+    objs = {
+        f"{tw._SHADOW_PREFIX}latest.json": _shadow("x", 9.9),       # not dated
+        f"{tw._SHADOW_PREFIX}2026-06-11.json": _shadow("f", 9.9),   # future
+    }
+    for d in range(2, 10):  # 06-02..06-09 all small
+        objs[f"{tw._SHADOW_PREFIX}2026-06-{d:02d}.json"] = _shadow(f"2026-06-{d:02d}", 0.01)
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.01}, _CFG, "bkt", "2026-06-10", _FakeS3(objs))
+    assert out["n_days_used"] == 5                # today + newest 4 dated
+    assert out["rolling_breach"] is False
+    assert published == []
+
+
+def test_sentinel_prior_day_excluded_partial_window_still_alerts(published):
+    s3 = _FakeS3({
+        f"{tw._SHADOW_PREFIX}2026-06-08.json": _shadow("2026-06-08", None),  # sentinel
+        f"{tw._SHADOW_PREFIX}2026-06-09.json": _shadow("2026-06-09", 0.45),
+    })
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.20}, _CFG, "bkt", "2026-06-10", s3)
+    assert out["n_days_used"] == 2                # sentinel day excluded
+    assert out["rolling_breach"] is True          # 0.65 > 0.60 on a partial window
+    assert [c["severity"] for c in published] == ["WARN"]
+
+
+def test_disabled_and_missing_metric(published):
+    off = tw.check_turnover_tripwire(
+        {"turnover_one_way": 9.9}, {**_CFG, "turnover_tripwire_enabled": False},
+        "bkt", "2026-06-10", _FakeS3())
+    assert off == {"status": "disabled"}
+    missing = tw.check_turnover_tripwire({}, _CFG, "bkt", "2026-06-10", _FakeS3())
+    assert missing == {"status": "no_turnover_metric"}
+    assert published == []
+
+
+def test_governor_off_uses_absolute_band(published):
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.26}, {**_CFG, "max_daily_turnover": None},
+        "bkt", "2026-06-10", _FakeS3())
+    assert out["daily_band"] == pytest.approx(tw._DAILY_BAND_GOVERNOR_OFF)
+    assert out["daily_breach"] is True
+
+
+def test_publish_failure_recorded_not_raised(monkeypatch):
+    from alpha_engine_lib import alerts
+
+    def _boom(**kw):
+        raise RuntimeError("sns down")
+
+    monkeypatch.setattr(alerts, "publish", _boom)
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.30}, _CFG, "bkt", "2026-06-10", _FakeS3())
+    assert out["daily_breach"] is True            # verdict still recorded
+    assert "publish_error" in out                 # failure recorded in artifact
+
+
+def test_internal_error_returns_sentinel(monkeypatch):
+    class _ExplodingS3:
+        def list_objects_v2(self, **kw):
+            raise RuntimeError("s3 down")
+
+    out = tw.check_turnover_tripwire(
+        {"turnover_one_way": 0.05}, _CFG, "bkt", "2026-06-10", _ExplodingS3())
+    assert out["status"] == "error"               # recorded in the artifact
+    assert "s3 down" in out["error"]


### PR DESCRIPTION
## Two commits, two ROADMAP items

### 1. L4515 (P1) — turnover tripwire (fast standalone live-system ops fix)
`turnover_one_way` has been computed since the governor shipped but never alarmed; the 5/29 (idle cash), 6/01 (DOWN-skew day), and 6/04 (dropped target) incidents were each caught by a point fix after the fact. This is the general surface:

- **daily band** — executed turnover > governor cap × `turnover_tripwire_daily_multiple` (1.25) → **ERROR** page. The governor should make this impossible; a breach means the cap was bypassed/disabled.
- **rolling band** — Σ executed turnover over the last `turnover_tripwire_rolling_days` (5) sessions > `turnover_tripwire_rolling_sum_band` (0.60) → **WARN** page. Catches churn-by-a-thousand-cuts (every day under the cap, week abnormal — the actual incident signature).
- Runs in the morning planner via `run_shadow_optimizer`; the verdict block is persisted into `predictor/optimizer_shadow/{date}.json` **before** the write so a dead tripwire is itself visible. Alerts via `alerts.publish` (SNS+Telegram, deduped per run_date); publish failure recorded in the artifact, never blocks the planner. Sentinel/unreadable prior days excluded by name. Knobs in `risk.yaml portfolio_optimizer.*` — safety alarm, **not** backtester-tuned.

### 2. L4520 slice 3 — executor_params consumer contract (companion to backtester #314 + the config-PR boundary)
- `test_executor_params_consumer_contract.py` pins: every producer-applied param ∈ `_PARAM_MAP` **and** `_PARAM_VALIDATORS`; producer metadata ∈ the advisory known-keys list; the four special keys exact.
- Loader refactor: inline tuples → named constants; advisory list completed (`fit_target`, `best_sortino`, `assembled_by`, `*_updated_at`, `*_ic`) so an unknown-key WARN always means real contract drift.
- **`stance_size_*` pinned deliberately UNKNOWN** — the stance overlay is emitted by the backtester but its application is unwired here (silent-drop, found building this boundary; filed as **ROADMAP L4598** with blocker + trigger). Its first live arrival must WARN, not vanish.

**Tests:** +14; full suite **1112 passed in 3s**. (The session's earlier 33-min "hang" was an infinite-pagination bug in the new tripwire's S3 listing against a MagicMock S3 — fixed with a hard 10-page cap; the suite is actually fast.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)