### PR TITLE
feat(contract): consumer fixtures validate against lib slot schemas (M0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ requests~=2.32
 # are NOT consumed here (executor has no LLM exposure per
 # [[preference_llm_calls_confined_to_research_module]]) but the
 # transitive lib pin stays current.
-alpha-engine-lib[flow_doctor] @ git+https://github.com/cipher813/alpha-engine-lib@v0.58.0
+alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.1
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/tests/test_signal_reader_consumer_contract.py
+++ b/tests/test_signal_reader_consumer_contract.py
@@ -51,15 +51,15 @@ def _complete_signals() -> dict:
         "signals": {},
         "population": ["AAA", "BBB", "CCC"],
         "universe": [
-            {"ticker": "AAA", "signal": "ENTER", "score": 80, "conviction": "rising",
+            {"ticker": "AAA", "signal": "ENTER", "score": 80, "rating": "BUY", "conviction": "rising",
              "sector": "Technology", "sector_rating": "overweight", "price_target_upside": 0.2},
-            {"ticker": "BBB", "signal": "HOLD", "score": 60, "conviction": "stable",
+            {"ticker": "BBB", "signal": "HOLD", "score": 60, "rating": "HOLD", "conviction": "stable",
              "sector": "Technology", "sector_rating": "market_weight", "price_target_upside": 0.0},
-            {"ticker": "CCC", "signal": "EXIT", "score": 30, "conviction": "declining",
+            {"ticker": "CCC", "signal": "EXIT", "score": 30, "rating": "SELL", "conviction": "declining",
              "sector": "Technology", "sector_rating": "underweight", "price_target_upside": 0.0},
         ],
         "buy_candidates": [
-            {"ticker": "AAA", "signal": "ENTER", "score": 80, "conviction": "rising",
+            {"ticker": "AAA", "signal": "ENTER", "score": 80, "rating": "BUY", "conviction": "rising",
              "sector": "Technology", "sector_rating": "overweight", "price_target_upside": 0.2},
         ],
     }

--- a/tests/test_slot_contract_fixture_conformance.py
+++ b/tests/test_slot_contract_fixture_conformance.py
@@ -1,0 +1,89 @@
+"""Consumer-side conformance: the executor's contract-test fixtures must be
+valid Slot R / Slot M artifacts (M0, config#989).
+
+The executor is the canonical consumer of both slot contracts. Its consumer
+contract tests (``test_signal_reader_consumer_contract.py``) exercise
+``signal_reader`` against fixtures — if those fixtures drift from the real
+producer shape, the consumer tests prove nothing about the actual boundary.
+This pins fixture <-> contract agreement via ``alpha_engine_lib.contracts``
+(lib >= 0.59.1), the same versioned schemas the producers validate against
+(research / predictor CI).
+
+Fail-soft tolerance is NOT weakened: signal_reader may still degrade gracefully
+on partial payloads at runtime; this only asserts that the *reference fixtures*
+used to certify the consumer are contract-complete.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+contracts = pytest.importorskip(
+    "alpha_engine_lib.contracts",
+    reason="needs alpha-engine-lib[contracts] >= 0.59.1",
+)
+
+from tests.test_signal_reader_consumer_contract import _complete_signals
+
+
+def _complete_predictions() -> dict:
+    """Reference Slot M payload mirroring read_predictions' expectations."""
+    return {
+        "date": "2026-06-15",
+        "model_version": "v3.0-test",
+        "n_predictions": 2,
+        "predictions": [
+            {
+                "ticker": "AAA",
+                "predicted_direction": "UP",
+                "prediction_confidence": 0.7,
+                "predicted_alpha": 0.04,
+                "combined_rank": 1,
+                "gbm_veto": False,
+                "momentum_veto": False,
+                "barrier_win_prob": 0.6,
+                "predicted_alpha_std": 0.01,
+            },
+            {
+                "ticker": "BBB",
+                "predicted_direction": "DOWN",
+                "prediction_confidence": 0.8,
+                "predicted_alpha": -0.05,
+                "combined_rank": 2,
+                "gbm_veto": True,
+                "momentum_veto": True,
+            },
+        ],
+    }
+
+
+class TestConsumerFixturesConformToSlotContracts:
+    def test_signals_fixture_is_a_valid_slot_r_artifact(self):
+        contracts.validate("signals", _complete_signals())
+
+    def test_predictions_fixture_is_a_valid_slot_m_artifact(self):
+        contracts.validate("predictions", _complete_predictions())
+
+    def test_red_fixture_fails_loud(self):
+        """config#989 closes-when demo on the consumer side."""
+        broken = _complete_signals()
+        del broken["universe"][0]["sector_rating"]
+        errors = contracts.conformance_errors("signals", broken)
+        assert errors and "sector_rating" in " ".join(errors)
+
+
+class TestReaderAcceptsContractShapedPayloads:
+    """The reader must consume a fully contract-conform payload end-to-end —
+    guards against the reader growing an undocumented reliance the contract
+    doesn't promise."""
+
+    def test_get_actionable_signals_on_conform_payload(self):
+        from executor.signal_reader import get_actionable_signals
+
+        payload = _complete_signals()
+        contracts.validate("signals", payload)
+        result = get_actionable_signals(payload)
+        tickers = {
+            e["ticker"] for k in ("enter", "exit", "reduce", "hold") for e in result[k]
+        }
+        assert "AAA" in tickers


### PR DESCRIPTION
M0 slice 2, repo 3 of 4 (config#989; lib substrate #111/#112).

- **Pin:** `alpha-engine-lib[flow_doctor,contracts]@v0.59.1`. **MERGE ORDER: needs lib PR #112 merged+tagged first.**
- **New `test_slot_contract_fixture_conformance.py`:** the consumer-side half of the contract — `signal_reader`'s reference fixtures must be valid Slot R + Slot M artifacts (otherwise the consumer contract tests certify against a shape no producer emits), plus an end-to-end read of a fully conform payload. `_complete_signals` upgraded to carry `rating` (producer-always-emitted; executor doesn't read it — exactly the kind of fixture drift this test now prevents).
- Runtime risk: none — tests-only; runtime never imports `alpha_engine_lib.contracts`; additive lib delta. Executor fail-soft posture unchanged (graceful degradation on partial payloads remains tested in the consumer contract test).

Full suite **1116 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)