### PR TITLE
feat(strategies): Slot S contract — ExitRule plugin interface + conformance kit (config#990)

### DIFF
--- a/executor/strategies/conformance/README.md
+++ b/executor/strategies/conformance/README.md
@@ -1,0 +1,57 @@
+# Slot S conformance kit
+
+**Slot S** is the strategy slot of the Nous Ergon harness: backtestable
+exit rules behind a typed Python plugin interface
+(`executor/strategies/contract.py`). Slots R and M exchange JSON
+artifacts validated by `alpha_engine_lib.contracts`; Slot S's contract is
+this interface, and this kit is its conformance check — same role, one
+vocabulary (the future `ne validate` verb fronts both).
+
+## Validate your strategy rule
+
+```bash
+pytest executor/strategies/conformance --exit-rule "your_pkg.your_mod:YourRule"
+```
+
+Repeat `--exit-rule` for multiple rules. Run with no flag to certify the
+stock rules (CI does this on every push).
+
+## What you implement
+
+Any object satisfying the `ExitRule` protocol:
+
+```python
+from executor.strategies.contract import ExitContext, ExitDecision, RuleOutcome
+
+class MyDrawupRule:
+    key = "my_drawup_exit"                # snake_case; becomes the exit reason
+
+    def check(self, ctx: ExitContext) -> RuleOutcome:
+        if ctx.current_price is None or not ctx.position.get("avg_cost"):
+            return RuleOutcome.none()     # degenerate inputs: decline, never raise
+        gain = ctx.current_price / ctx.position["avg_cost"] - 1
+        if gain > ctx.config.get("my_drawup_pct", 0.25):
+            return RuleOutcome(decision=ExitDecision(
+                ticker=ctx.ticker, action="REDUCE", reason=self.key,
+                detail=f"gain {gain:.1%} > threshold", extras={"gain_pct": gain}))
+        return RuleOutcome.none()
+```
+
+## What conformance asserts
+
+| check | meaning |
+|---|---|
+| C1 interface | `key` is snake_case; object satisfies the protocol |
+| C2 shape | decisions are valid: action ∈ {EXIT, REDUCE}, `reason == key`, ticker echoes the context, non-empty detail |
+| C3 no-crash | survives every golden scenario, including data-gap shapes (no price, no history, one bar, no avg_cost) |
+| C4 purity | deterministic; never mutates the context |
+| C5 flags | raised flags are snake_case identifiers |
+
+Golden scenarios live in `scenarios.py` (deterministic, offline). The
+chain semantics (ordering, short-circuit, `skip_if_flags`) live in
+`ExitRuleRegistry` — your rule doesn't reimplement them.
+
+> Production wiring of external rules (entry-point group
+> `alpha_engine.exit_rules`) is deliberately not active until the
+> registry cutover lands (config#990, post-2026-06-13). Conformance is
+> the prerequisite, not the activation.

--- a/executor/strategies/conformance/__init__.py
+++ b/executor/strategies/conformance/__init__.py
@@ -1,0 +1,9 @@
+"""Slot S conformance kit (M0 / config#990) — see README.md in this directory.
+
+Validate any ExitRule implementation with one command:
+
+    pytest executor/strategies/conformance --exit-rule "your_pkg.your_mod:YourRule"
+
+Run without ``--exit-rule`` to certify the stock rules (the reference
+implementations) — CI does this on every push.
+"""

--- a/executor/strategies/conformance/conftest.py
+++ b/executor/strategies/conformance/conftest.py
@@ -1,0 +1,42 @@
+"""Pytest plumbing for the Slot S conformance kit.
+
+``--exit-rule "pkg.mod:ClassName"`` points the kit at an external
+implementation; omitted, the kit certifies the stock rules.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--exit-rule",
+        action="append",
+        default=[],
+        help='ExitRule under test, as "pkg.mod:ClassName" (repeatable). '
+             "Omit to certify the stock rules.",
+    )
+
+
+def _load(spec: str):
+    mod_name, _, attr = spec.partition(":")
+    if not attr:
+        raise pytest.UsageError(f'--exit-rule must be "pkg.mod:ClassName", got {spec!r}')
+    obj = getattr(importlib.import_module(mod_name), attr)
+    return obj() if isinstance(obj, type) else obj
+
+
+def pytest_generate_tests(metafunc):
+    if "rule_under_test" not in metafunc.fixturenames:
+        return
+    specs = metafunc.config.getoption("--exit-rule")
+    if specs:
+        rules = [_load(s) for s in specs]
+    else:
+        from executor.strategies.contract import stock_registry
+        reg = stock_registry()
+        rules = list(reg._rules)  # noqa: SLF001 — kit is first-party to the registry
+    metafunc.parametrize("rule_under_test", rules, ids=lambda r: getattr(r, "key", repr(r)))

--- a/executor/strategies/conformance/kit.py
+++ b/executor/strategies/conformance/kit.py
@@ -1,0 +1,107 @@
+"""Slot S conformance checks — the validation battery behind the kit.
+
+``conformance_errors(rule)`` returns a flat list of human-readable
+violations (empty = conformant), mirroring
+``alpha_engine_lib.contracts.conformance_errors`` for slots R/M so the
+future ``ne validate`` CLI can front both with one vocabulary.
+
+What conformance asserts (the Slot S contract, executor/strategies/contract.py):
+
+  C1  interface  — ``key`` is a valid snake_case identifier; ``check`` is
+      callable; the object satisfies the ExitRule protocol.
+  C2  shape      — on every golden scenario, ``check`` returns a
+      RuleOutcome whose decision (when present) is a valid ExitDecision:
+      action in {EXIT, REDUCE}, reason == rule.key, ticker == ctx.ticker,
+      non-empty detail.
+  C3  no-crash   — no exception on any golden scenario, including the
+      degenerate data-gap shapes the live executor produces.
+  C4  purity     — two evaluations of the same scenario return equal
+      outcomes (determinism), and the context's position dict / config
+      dict / price index are not mutated.
+  C5  flag use   — flags (when raised) are snake_case identifiers.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from executor.strategies.contract import (
+    ALLOWED_ACTIONS,
+    ExitRule,
+    RuleOutcome,
+)
+from executor.strategies.conformance.scenarios import golden_scenarios
+
+
+def _outcome_repr(outcome: RuleOutcome) -> tuple:
+    d = outcome.decision
+    return (
+        None if d is None else (d.ticker, d.action, d.reason, d.detail, sorted(d.extras.items())),
+        outcome.flag,
+    )
+
+
+def conformance_errors(rule: object) -> list[str]:
+    """Run the full battery against ``rule``; return violations (empty = pass)."""
+    errors: list[str] = []
+
+    # C1 — interface
+    if not isinstance(rule, ExitRule):
+        errors.append("C1: object does not satisfy the ExitRule protocol (needs .key and .check(ctx))")
+        return errors  # nothing else is checkable
+    key = getattr(rule, "key", None)
+    if not isinstance(key, str) or not key.isidentifier() or key != key.lower():
+        errors.append(f"C1: key must be a snake_case identifier string, got {key!r}")
+
+    for name, ctx in golden_scenarios().items():
+        pos_before = copy.deepcopy(ctx.position)
+        cfg_before = copy.deepcopy(ctx.config)
+        hist_len_before = None if ctx.price_history is None else len(ctx.price_history)
+
+        # C3 — no-crash
+        try:
+            outcome = rule.check(ctx)
+        except Exception as e:  # noqa: BLE001 — the kit's whole job is to catch these
+            errors.append(f"C3[{name}]: check() raised {type(e).__name__}: {e}")
+            continue
+
+        # C2 — shape
+        if not isinstance(outcome, RuleOutcome):
+            errors.append(f"C2[{name}]: check() must return RuleOutcome, got {type(outcome).__name__}")
+            continue
+        d = outcome.decision
+        if d is not None:
+            if d.action not in ALLOWED_ACTIONS:
+                errors.append(f"C2[{name}]: action {d.action!r} not in {ALLOWED_ACTIONS}")
+            declared = getattr(rule, "reasons", None) or {rule.key}
+            if d.reason not in declared:
+                errors.append(
+                    f"C2[{name}]: reason {d.reason!r} not in declared vocabulary {sorted(declared)}"
+                )
+            if d.ticker != ctx.ticker:
+                errors.append(f"C2[{name}]: ticker {d.ticker!r} != ctx.ticker {ctx.ticker!r}")
+            if not d.detail:
+                errors.append(f"C2[{name}]: decision detail must be non-empty")
+
+        # C5 — flag vocabulary
+        if outcome.flag is not None and (
+            not isinstance(outcome.flag, str) or not outcome.flag.isidentifier()
+        ):
+            errors.append(f"C5[{name}]: flag must be a snake_case identifier, got {outcome.flag!r}")
+
+        # C4 — purity: determinism + no input mutation
+        try:
+            second = rule.check(ctx)
+        except Exception as e:  # noqa: BLE001
+            errors.append(f"C4[{name}]: second evaluation raised {type(e).__name__}: {e}")
+            continue
+        if _outcome_repr(outcome) != _outcome_repr(second):
+            errors.append(f"C4[{name}]: non-deterministic — two evaluations of the same context differ")
+        if ctx.position != pos_before:
+            errors.append(f"C4[{name}]: check() mutated ctx.position")
+        if ctx.config != cfg_before:
+            errors.append(f"C4[{name}]: check() mutated ctx.config")
+        if hist_len_before is not None and len(ctx.price_history) != hist_len_before:
+            errors.append(f"C4[{name}]: check() mutated ctx.price_history")
+
+    return errors

--- a/executor/strategies/conformance/scenarios.py
+++ b/executor/strategies/conformance/scenarios.py
@@ -1,0 +1,83 @@
+"""Golden scenario fixtures for the Slot S conformance kit.
+
+A small battery of ExitContext scenarios every conforming rule must
+survive WITHOUT RAISING — rich paths (trending/crashing/split-shaped
+histories) and the degenerate-but-valid inputs the live executor
+produces on bad data days (no price, no history, no avg_cost, one bar).
+Mirrors the spirit of the L4593 golden battery (backtester #318): known
+inputs, mechanically reproducible, no network.
+
+Scenario prices are deterministic (no randomness — conformance must be
+bit-stable run to run).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from executor.strategies.config import load_strategy_config
+from executor.strategies.contract import ExitContext
+
+RUN_DATE = "2026-06-05"
+ENTRY_DATE = "2026-05-01"
+
+
+def _ohlc(closes: list[float], start: str = "2026-04-01") -> pd.DataFrame:
+    idx = pd.bdate_range(start=start, periods=len(closes))
+    df = pd.DataFrame(index=idx)
+    df["close"] = closes
+    df["open"] = [c * 0.995 for c in closes]
+    df["high"] = [c * 1.01 for c in closes]
+    df["low"] = [c * 0.99 for c in closes]
+    return df
+
+
+def _ctx(**overrides) -> ExitContext:
+    base = dict(
+        ticker="TEST",
+        position={"avg_cost": 100.0, "sector": "Technology", "shares": 10},
+        research_action="HOLD",
+        current_price=105.0,
+        price_history=_ohlc([100 + 0.2 * i for i in range(45)]),
+        sector_etf_histories={"XLK": _ohlc([200 + 0.1 * i for i in range(45)]),
+                              "SPY": _ohlc([400 + 0.1 * i for i in range(45)])},
+        config=load_strategy_config({}),  # stock defaults, no risk.yaml needed
+        catalyst_date=None,
+        entry_date=ENTRY_DATE,
+        run_date=RUN_DATE,
+        feature_lookup=None,
+    )
+    base.update(overrides)
+    return ExitContext(**base)
+
+
+def golden_scenarios() -> dict[str, ExitContext]:
+    """name -> ExitContext. Every conforming rule must return a valid
+    RuleOutcome (decision or none) on each, never raise."""
+    steady = [100 + 0.2 * i for i in range(45)]
+    crash = steady[:40] + [95.0, 88.0, 80.0, 72.0, 65.0]
+    melt_up = steady[:40] + [115.0, 122.0, 130.0, 138.0, 146.0]
+    split_shaped = steady[:42] + [25.4, 25.5, 25.6]  # 4:1-split-like cliff, unadjusted
+
+    return {
+        # rich paths
+        "steady_uptrend": _ctx(),
+        "crash_into_run_date": _ctx(price_history=_ohlc(crash), current_price=63.0),
+        "melt_up_profit_zone": _ctx(price_history=_ohlc(melt_up), current_price=148.0),
+        "split_shaped_history": _ctx(price_history=_ohlc(split_shaped), current_price=25.5),
+        "deep_loss_vs_cost": _ctx(current_price=70.0),
+        "catalyst_expired": _ctx(catalyst_date="2026-05-20",
+                                 position={"avg_cost": 100.0, "sector": "Healthcare",
+                                           "shares": 10, "stance": "catalyst"}),
+        "research_reaffirms": _ctx(research_action="ENTER"),
+        "stale_position_hold": _ctx(entry_date="2026-01-05"),
+        "unknown_sector": _ctx(position={"avg_cost": 100.0, "sector": "Cryptids", "shares": 10}),
+        # degenerate-but-valid (live data-gap shapes — decline, don't crash)
+        "no_current_price": _ctx(current_price=None),
+        "no_price_history": _ctx(price_history=None),
+        "one_bar_history": _ctx(price_history=_ohlc([100.0])),
+        "no_avg_cost": _ctx(position={"avg_cost": None, "sector": "Technology", "shares": 10}),
+        "no_entry_date": _ctx(entry_date=None),
+        "no_etf_histories": _ctx(sector_etf_histories=None),
+        "empty_config_uses_rule_defaults": _ctx(config={}),
+    }

--- a/executor/strategies/conformance/test_conformance.py
+++ b/executor/strategies/conformance/test_conformance.py
@@ -1,0 +1,17 @@
+"""Slot S conformance kit — THE documented validation command (config#990).
+
+    pytest executor/strategies/conformance --exit-rule "your_pkg.your_mod:YourRule"
+
+Without ``--exit-rule`` this certifies the seven stock rules (the
+reference implementations) — which is what repo CI runs.
+"""
+
+from executor.strategies.conformance.kit import conformance_errors
+
+
+def test_rule_conforms_to_slot_s_contract(rule_under_test):
+    errors = conformance_errors(rule_under_test)
+    assert not errors, (
+        f"{getattr(rule_under_test, 'key', rule_under_test)!r} fails Slot S conformance:\n  "
+        + "\n  ".join(errors)
+    )

--- a/executor/strategies/contract.py
+++ b/executor/strategies/contract.py
@@ -1,0 +1,374 @@
+"""Slot S contract — the strategy (exit-rule) plugin interface (M0 / config#990).
+
+The harness's three experiment slots exchange PRODUCT CONTRACTS (M0
+discipline, ratified 2026-06-11 — config#638). Slots R and M are JSON
+artifacts with versioned schemas in ``alpha_engine_lib.contracts``; Slot S
+is different in kind: a **Python plugin interface** for backtestable exit
+strategy rules. This module is that contract's single source of truth:
+
+- :class:`ExitContext`   — everything a rule may read (frozen; one per
+  held position per evaluation).
+- :class:`ExitDecision`  — the decision payload a rule returns (the
+  formalization of the ad-hoc dicts the stock checks have always built).
+- :class:`RuleOutcome`   — decision | flag wrapper (a rule can fire,
+  decline, or decline-with-flag, e.g. ``sector_veto_blocked``).
+- :class:`ExitRule`      — the runtime-checkable Protocol an
+  implementation satisfies.
+- :class:`ExitRuleRegistry` — ordered rule chain with the canonical
+  short-circuit semantics (first decision wins; later rules can be
+  skipped by earlier flags via ``skip_if_flags``).
+- :func:`stock_registry` — the seven stock rules (adapters over
+  ``exit_manager``'s functions, behavior-identical) registered in
+  canonical order: the reference Slot S implementation.
+
+External implementations ("bring your own strategy") subclass nothing —
+they provide any object satisfying :class:`ExitRule` and validate it with
+the conformance kit (``executor/strategies/conformance/`` — one pytest
+command, see its README). Discovery for production use is via the
+``alpha_engine.exit_rules`` entry-point group (:func:`load_entry_point_rules`),
+mirroring the ``metron.plugins`` precedent.
+
+CONTRACT EVOLUTION is additive-only (mirrors the S3 contract rule):
+``ExitContext`` may gain fields; existing fields are never renamed or
+removed without a major version bump of ``CONTRACT_VERSION`` and a
+deprecation window. Rules MUST tolerate unknown extra context fields.
+
+NOTE (sequencing, config#990): the live ``evaluate_exits`` path still
+calls ``_evaluate_single_position`` directly — the registry is wired in
+parallel and proven equivalent by ``tests/test_slot_s_contract.py``'s
+equivalence battery. The one-line cutover is deliberately deferred
+post-2026-06-13 per the issue's runtime-refactor gate.
+"""
+
+from __future__ import annotations
+
+import keyword
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol, runtime_checkable
+
+CONTRACT_VERSION = 1
+
+#: The only actions a Slot S rule may emit. HOLD is expressed by returning
+#: no decision; ENTER is not a Slot S concern (entries belong to the
+#: planner/trigger layers).
+ALLOWED_ACTIONS = ("EXIT", "REDUCE")
+
+
+@dataclass(frozen=True)
+class ExitContext:
+    """Read-only evaluation context for one held position on one run.
+
+    Field semantics (all prices in dollars, dates as ISO ``YYYY-MM-DD``):
+
+    - ``ticker``: position symbol.
+    - ``position``: the holder's position dict — at minimum ``avg_cost``
+      (float | None) and ``sector`` (str); additive extra keys allowed.
+    - ``research_action``: today's research signal for the ticker
+      (``ENTER``/``HOLD``/``EXIT``/``REDUCE``) — ``HOLD`` when absent.
+    - ``current_price``: latest price (may be None on data gaps — rules
+      must tolerate).
+    - ``price_history``: OHLC DataFrame (columns open/high/low/close,
+      ascending DatetimeIndex) or None.
+    - ``sector_etf_histories``: {etf_ticker: OHLC DataFrame} or None.
+    - ``config``: the stance-resolved strategy config dict (see
+      ``strategies.config.load_strategy_config`` +
+      ``_resolve_strategy_config_for_stance``). Rules read their knobs
+      here; unknown keys must be ignored.
+    - ``catalyst_date`` / ``entry_date``: ISO dates or None.
+    - ``run_date``: the trading run date.
+    - ``feature_lookup``: optional precomputed-feature accelerator
+      (``executor.feature_lookup.FeatureLookup``); rules MUST function
+      identically (modulo speed) when it is None.
+    """
+
+    ticker: str
+    position: dict[str, Any]
+    research_action: str
+    current_price: float | None
+    price_history: Any  # pd.DataFrame | None (kept untyped: no hard pandas dep in the contract)
+    sector_etf_histories: dict[str, Any] | None
+    config: dict[str, Any]
+    catalyst_date: str | None
+    entry_date: str | None
+    run_date: str
+    feature_lookup: Any | None = None
+
+
+@dataclass(frozen=True)
+class ExitDecision:
+    """A fired exit decision.
+
+    ``reason`` MUST equal the emitting rule's ``key`` (it becomes the
+    order-book exit reason, the trades.db ``trigger_type``, and the
+    decision-artifact ``fired_rule`` — one canonical vocabulary).
+    ``extras`` carries rule-specific diagnostics (stop levels, ATR values,
+    reduce fractions…) — additive, never load-bearing for the executor.
+    """
+
+    ticker: str
+    action: str
+    reason: str
+    detail: str
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.action not in ALLOWED_ACTIONS:
+            raise ValueError(
+                f"ExitDecision.action must be one of {ALLOWED_ACTIONS}, got {self.action!r}"
+            )
+
+    def to_signal_dict(self) -> dict[str, Any]:
+        """The legacy signal-dict shape ``evaluate_exits`` consumers expect."""
+        return {
+            "ticker": self.ticker,
+            "action": self.action,
+            "reason": self.reason,
+            "detail": self.detail,
+            **self.extras,
+        }
+
+
+@dataclass(frozen=True)
+class RuleOutcome:
+    """What a rule evaluation produced.
+
+    Exactly the (signal, fired_rule_key) duality the stock chain has
+    always had: a rule may fire a decision, decline silently, or decline
+    while raising a ``flag`` that downstream rules / capture can see
+    (today's only stock flag: ``sector_veto_blocked``).
+    """
+
+    decision: ExitDecision | None = None
+    flag: str | None = None
+
+    @classmethod
+    def none(cls) -> "RuleOutcome":
+        return cls()
+
+
+@runtime_checkable
+class ExitRule(Protocol):
+    """The Slot S plugin interface.
+
+    Implementations provide:
+
+    - ``key`` — canonical snake_case identifier; the chain/grading
+      identity (``fired_rule_key``, capture vocabulary).
+    - ``check(ctx)`` — pure decision function: same ``ExitContext`` in,
+      same :class:`RuleOutcome` out; MUST NOT mutate ``ctx`` or its
+      members, perform I/O, or raise on degenerate-but-valid inputs
+      (missing prices/history/avg_cost → decline, don't crash).
+    - ``reasons`` (optional) — the set of decision ``reason`` strings the
+      rule may emit; defaults to ``{key}``. Declare variants explicitly
+      (stock example: ``time_decay`` emits ``time_decay_exit`` /
+      ``time_decay_reduce`` — vocabulary predating this contract, baked
+      into trades.db ``trigger_type``).
+    - ``skip_if_flags`` (optional) — set of flags raised earlier in the
+      chain that suppress this rule for the position (stock example:
+      ``fallback_stop`` is skipped after ``sector_veto_blocked``).
+    """
+
+    key: str
+
+    def check(self, ctx: ExitContext) -> RuleOutcome: ...
+
+
+def _validate_key(rule_key: str) -> None:
+    if not rule_key or not rule_key.isidentifier() or keyword.iskeyword(rule_key):
+        raise ValueError(f"ExitRule.key must be a valid snake_case identifier, got {rule_key!r}")
+
+
+class ExitRuleRegistry:
+    """Ordered Slot S rule chain with the canonical evaluation semantics.
+
+    Order is significance: rules are evaluated in registration order, the
+    first decision wins (short-circuit), and a rule whose
+    ``skip_if_flags`` intersects already-raised flags is skipped. On
+    no-fire the LAST raised flag is reported (mirrors the stock chain's
+    ``sector_veto_blocked`` reporting).
+    """
+
+    def __init__(self) -> None:
+        self._rules: list[ExitRule] = []
+
+    def register(self, rule: ExitRule, *, before: str | None = None) -> None:
+        """Append ``rule`` (or insert before the rule keyed ``before``)."""
+        if not isinstance(rule, ExitRule):
+            raise TypeError(f"{rule!r} does not satisfy the ExitRule protocol")
+        _validate_key(rule.key)
+        if any(r.key == rule.key for r in self._rules):
+            raise ValueError(f"duplicate ExitRule key {rule.key!r}")
+        if before is None:
+            self._rules.append(rule)
+            return
+        for i, existing in enumerate(self._rules):
+            if existing.key == before:
+                self._rules.insert(i, rule)
+                return
+        raise ValueError(f"no registered rule keyed {before!r} to insert before")
+
+    @property
+    def keys(self) -> list[str]:
+        return [r.key for r in self._rules]
+
+    def evaluate(self, ctx: ExitContext) -> tuple[dict[str, Any] | None, str | None]:
+        """Run the chain. Returns the legacy ``(signal_dict, fired_rule_key)``.
+
+        ``fired_rule_key`` is the firing rule's key, or the last raised
+        flag on no-fire, or None — bit-identical to
+        ``exit_manager._evaluate_single_position``'s return contract.
+        """
+        flags: set[str] = set()
+        last_flag: str | None = None
+        for rule in self._rules:
+            skip = getattr(rule, "skip_if_flags", None) or set()
+            if flags & set(skip):
+                continue
+            outcome = rule.check(ctx)
+            if outcome.decision is not None:
+                return outcome.decision.to_signal_dict(), rule.key
+            if outcome.flag:
+                flags.add(outcome.flag)
+                last_flag = outcome.flag
+        return None, last_flag
+
+
+# ── Stock rules: adapters over the existing exit_manager functions ──────────
+#
+# Thin, behavior-identical wrappers — the 1000-line battle-tested check
+# functions stay the implementation; the adapters only translate
+# ExitContext into each function's historical signature. This is the
+# reference Slot S implementation the conformance kit certifies.
+
+
+@dataclass(frozen=True)
+class _FunctionRule:
+    """Adapter base: wraps a legacy ``check_*`` function as an ExitRule."""
+
+    key: str = ""
+    skip_if_flags: frozenset[str] = frozenset()
+    reasons: frozenset[str] | None = None  # None -> {key}
+    _call: Callable[[ExitContext], dict | None] = lambda ctx: None  # noqa: E731
+
+    def check(self, ctx: ExitContext) -> RuleOutcome:
+        raw = self._call(ctx)
+        if raw is None:
+            return RuleOutcome.none()
+        extras = {k: v for k, v in raw.items()
+                  if k not in ("ticker", "action", "reason", "detail")}
+        return RuleOutcome(decision=ExitDecision(
+            ticker=raw["ticker"], action=raw["action"],
+            reason=raw["reason"], detail=raw.get("detail", ""), extras=extras,
+        ))
+
+
+class _AtrWithSectorVetoRule:
+    """ATR trailing stop + the sector-relative veto, as one composite rule.
+
+    The veto is intrinsically coupled to the ATR fire (it suppresses
+    exactly that decision), so Slot S models the pair as a single rule
+    that either fires ``atr_trailing_stop`` or raises the
+    ``sector_veto_blocked`` flag — preserving the stock chain's exact
+    semantics, including ``fallback_stop`` being skipped after a veto.
+    """
+
+    key = "atr_trailing_stop"
+
+    def check(self, ctx: ExitContext) -> RuleOutcome:
+        from executor.strategies import exit_manager as em
+
+        raw = em.check_atr_trailing_stop(
+            ticker=ctx.ticker, current_price=ctx.current_price,
+            entry_date=ctx.entry_date, price_history=ctx.price_history,
+            strategy_config=ctx.config, feature_lookup=ctx.feature_lookup,
+            run_date=ctx.run_date,
+        )
+        if raw is None:
+            return RuleOutcome.none()
+        sector = ctx.position.get("sector", "")
+        etf_ticker = em.SECTOR_ETF_MAP.get(sector, "SPY")
+        etf_history = (ctx.sector_etf_histories or {}).get(etf_ticker)
+        if em.check_sector_relative_veto(
+            ctx.ticker, sector, ctx.price_history, etf_history, ctx.config,
+        ):
+            return RuleOutcome(flag="sector_veto_blocked")
+        extras = {k: v for k, v in raw.items()
+                  if k not in ("ticker", "action", "reason", "detail")}
+        return RuleOutcome(decision=ExitDecision(
+            ticker=raw["ticker"], action=raw["action"],
+            reason=raw["reason"], detail=raw.get("detail", ""), extras=extras,
+        ))
+
+
+def stock_registry() -> ExitRuleRegistry:
+    """The seven stock rules in canonical chain order — Slot S's reference
+    implementation (loss floor first, decay last; matches
+    ``_evaluate_single_position`` exactly, proven by the equivalence
+    battery in ``tests/test_slot_s_contract.py``)."""
+    from executor.strategies import exit_manager as em
+
+    reg = ExitRuleRegistry()
+    reg.register(_FunctionRule(
+        key="position_loss_floor",
+        _call=lambda ctx: em.check_position_loss_floor(
+            ticker=ctx.ticker, current_price=ctx.current_price,
+            avg_cost=ctx.position.get("avg_cost"), strategy_config=ctx.config),
+    ))
+    reg.register(_FunctionRule(
+        key="catalyst_hard_exit",
+        _call=lambda ctx: em.check_catalyst_hard_exit(
+            ticker=ctx.ticker, catalyst_date=ctx.catalyst_date,
+            run_date=ctx.run_date, strategy_config=ctx.config),
+    ))
+    reg.register(_AtrWithSectorVetoRule())
+    reg.register(_FunctionRule(
+        key="fallback_stop",
+        skip_if_flags=frozenset({"sector_veto_blocked"}),
+        _call=lambda ctx: em.check_fallback_stop(
+            ticker=ctx.ticker, current_price=ctx.current_price,
+            entry_price=ctx.position.get("avg_cost"), strategy_config=ctx.config),
+    ))
+    reg.register(_FunctionRule(
+        key="profit_take",
+        _call=lambda ctx: em.check_profit_take(
+            ticker=ctx.ticker, current_price=ctx.current_price,
+            avg_cost=ctx.position.get("avg_cost"), strategy_config=ctx.config),
+    ))
+    reg.register(_FunctionRule(
+        key="momentum_exit",
+        _call=lambda ctx: em.check_momentum_exit(
+            ticker=ctx.ticker, price_history=ctx.price_history,
+            strategy_config=ctx.config, feature_lookup=ctx.feature_lookup,
+            run_date=ctx.run_date),
+    ))
+    reg.register(_FunctionRule(
+        key="time_decay",
+        # Pre-contract vocabulary baked into trades.db trigger_type — declared,
+        # not renamed (renaming = breaking change to downstream consumers).
+        reasons=frozenset({"time_decay_exit", "time_decay_reduce"}),
+        _call=lambda ctx: em.check_time_decay(
+            ticker=ctx.ticker, entry_date=ctx.entry_date, run_date=ctx.run_date,
+            signal_action=ctx.research_action, strategy_config=ctx.config),
+    ))
+    return reg
+
+
+def load_entry_point_rules(
+    registry: ExitRuleRegistry, group: str = "alpha_engine.exit_rules",
+) -> list[str]:
+    """Discover and register external ExitRules from entry points.
+
+    Each entry point must resolve to an ExitRule class or factory; loading
+    is fail-loud (a broken plugin raises at load time, before any trading
+    decision). Returns the registered keys. NOT yet called from the live
+    path — production wiring rides the post-6/13 cutover (config#990).
+    """
+    from importlib.metadata import entry_points
+
+    registered = []
+    for ep in entry_points(group=group):
+        obj = ep.load()
+        rule = obj() if isinstance(obj, type) else obj
+        registry.register(rule)
+        registered.append(rule.key)
+    return registered

--- a/executor/strategies/exit_manager.py
+++ b/executor/strategies/exit_manager.py
@@ -263,6 +263,13 @@ def check_time_decay(
     if signal_action in ("ENTER", "EXIT", "REDUCE"):
         return None
 
+    # entry_date guard: the planner skips entry-date-less positions upstream,
+    # but the Slot S contract (strategies/contract.py, config#990) requires
+    # every rule to decline — not raise — on data-gap inputs, since external
+    # orchestrators don't carry the caller-side guard.
+    if not entry_date:
+        return None
+
     reduce_days = strategy_config.get("time_decay_reduce_days", 5)
     exit_days = strategy_config.get("time_decay_exit_days", 10)
 
@@ -391,7 +398,11 @@ def check_profit_take(
     if not strategy_config.get("profit_take_enabled", True):
         return None
 
-    if avg_cost is None or avg_cost <= 0:
+    # current_price guard: the planner skips price-less positions upstream,
+    # but the Slot S contract (strategies/contract.py, config#990) requires
+    # every rule to decline — not raise — on data-gap inputs, since external
+    # orchestrators don't carry the caller-side guard.
+    if avg_cost is None or avg_cost <= 0 or current_price is None:
         return None
 
     unrealized_gain = (current_price - avg_cost) / avg_cost

--- a/tests/test_conformance_stock_rules.py
+++ b/tests/test_conformance_stock_rules.py
@@ -1,0 +1,20 @@
+"""CI certification: every stock exit rule passes the Slot S conformance kit.
+
+The kit's user-facing entry is ``pytest executor/strategies/conformance
+--exit-rule ...`` (its own conftest); this bridge puts the stock-rule
+certification inside the default-collected suite so a regression in any
+stock rule (or in the kit itself) fails repo CI.
+"""
+
+import pytest
+
+from executor.strategies.conformance.kit import conformance_errors
+from executor.strategies.contract import stock_registry
+
+_RULES = list(stock_registry()._rules)  # noqa: SLF001 — first-party certification
+
+
+@pytest.mark.parametrize("rule", _RULES, ids=[r.key for r in _RULES])
+def test_stock_rule_passes_slot_s_conformance(rule):
+    errors = conformance_errors(rule)
+    assert not errors, f"{rule.key} fails Slot S conformance:\n  " + "\n  ".join(errors)

--- a/tests/test_slot_s_contract.py
+++ b/tests/test_slot_s_contract.py
@@ -1,0 +1,165 @@
+"""Slot S contract tests (config#990) — registry mechanics + the
+EQUIVALENCE BATTERY proving ``ExitRuleRegistry(stock_registry()).evaluate``
+is behavior-identical to the live ``_evaluate_single_position`` chain.
+
+The equivalence battery is the load-bearing piece: the post-6/13 cutover
+(one line — the orchestrator delegating to the registry) is only safe
+because every scenario here returns bit-identical (signal, fired_rule_key)
+through both paths.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from executor.strategies.conformance.scenarios import golden_scenarios, _ctx, _ohlc
+from executor.strategies.contract import (
+    ExitContext,
+    ExitDecision,
+    ExitRuleRegistry,
+    RuleOutcome,
+    stock_registry,
+)
+from executor.strategies.exit_manager import _evaluate_single_position
+
+
+# ── ExitDecision validation ─────────────────────────────────────────────────
+
+
+def test_decision_rejects_unknown_action():
+    with pytest.raises(ValueError):
+        ExitDecision(ticker="X", action="ENTER", reason="r", detail="d")
+
+
+def test_decision_signal_dict_roundtrip():
+    d = ExitDecision(ticker="X", action="EXIT", reason="my_rule",
+                     detail="why", extras={"stop_level": 9.5})
+    assert d.to_signal_dict() == {"ticker": "X", "action": "EXIT", "reason": "my_rule",
+                                  "detail": "why", "stop_level": 9.5}
+
+
+# ── registry mechanics ──────────────────────────────────────────────────────
+
+
+class _StubRule:
+    def __init__(self, key, outcome=None, skip_if_flags=frozenset()):
+        self.key = key
+        self.skip_if_flags = skip_if_flags
+        self._outcome = outcome or RuleOutcome.none()
+        self.calls = 0
+
+    def check(self, ctx):
+        self.calls += 1
+        return self._outcome
+
+
+def _fire(key):
+    return RuleOutcome(decision=ExitDecision(
+        ticker="TEST", action="EXIT", reason=key, detail="fired"))
+
+
+def test_registry_short_circuits_on_first_decision():
+    a, b = _StubRule("a", _fire("a")), _StubRule("b", _fire("b"))
+    reg = ExitRuleRegistry()
+    reg.register(a)
+    reg.register(b)
+    signal, fired = reg.evaluate(golden_scenarios()["steady_uptrend"])
+    assert fired == "a" and signal["reason"] == "a"
+    assert b.calls == 0
+
+
+def test_registry_skip_if_flags_and_flag_reporting():
+    flagger = _StubRule("flagger", RuleOutcome(flag="sector_veto_blocked"))
+    skipped = _StubRule("skipped", _fire("skipped"),
+                        skip_if_flags=frozenset({"sector_veto_blocked"}))
+    runs = _StubRule("runs")
+    reg = ExitRuleRegistry()
+    for r in (flagger, skipped, runs):
+        reg.register(r)
+    signal, fired = reg.evaluate(golden_scenarios()["steady_uptrend"])
+    assert signal is None and fired == "sector_veto_blocked"
+    assert skipped.calls == 0 and runs.calls == 1
+
+
+def test_registry_rejects_duplicates_bad_keys_and_non_rules():
+    reg = ExitRuleRegistry()
+    reg.register(_StubRule("a"))
+    with pytest.raises(ValueError):
+        reg.register(_StubRule("a"))
+    with pytest.raises(ValueError):
+        reg.register(_StubRule("not-an-identifier"))
+    with pytest.raises(TypeError):
+        reg.register(object())
+
+
+def test_registry_insert_before():
+    reg = ExitRuleRegistry()
+    reg.register(_StubRule("a"))
+    reg.register(_StubRule("c"))
+    reg.register(_StubRule("b"), before="c")
+    assert reg.keys == ["a", "b", "c"]
+    with pytest.raises(ValueError):
+        reg.register(_StubRule("d"), before="zzz")
+
+
+def test_stock_registry_canonical_order():
+    assert stock_registry().keys == [
+        "position_loss_floor", "catalyst_hard_exit", "atr_trailing_stop",
+        "fallback_stop", "profit_take", "momentum_exit", "time_decay",
+    ]
+
+
+# ── equivalence battery: registry vs _evaluate_single_position ─────────────
+
+
+def _legacy(ctx: ExitContext):
+    return _evaluate_single_position(
+        ticker=ctx.ticker, pos=ctx.position, research_action=ctx.research_action,
+        current_price=ctx.current_price, history=ctx.price_history,
+        sector_etf_histories=ctx.sector_etf_histories, stance_config=ctx.config,
+        catalyst_date=ctx.catalyst_date, entry_date=ctx.entry_date,
+        run_date=ctx.run_date, feature_lookup=ctx.feature_lookup,
+    )
+
+
+def _equivalence_cases() -> dict[str, ExitContext]:
+    cases = dict(golden_scenarios())
+    # Targeted path-forcing additions beyond the golden battery:
+    steady = [100 + 0.2 * i for i in range(45)]
+    # ATR fire with an UNDERPERFORMING sector ETF (veto must NOT suppress)
+    cases["atr_fire_no_veto"] = _ctx(
+        price_history=_ohlc(steady[:40] + [108, 96, 90, 84, 78]), current_price=77.0,
+        sector_etf_histories={"XLK": _ohlc([200 - 0.8 * i for i in range(45)]),
+                              "SPY": _ohlc([400 - 0.5 * i for i in range(45)])},
+    )
+    # ATR fire with an OUTPERFORMING ticker vs collapsing ETF (veto path)
+    cases["atr_fire_veto_candidate"] = _ctx(
+        price_history=_ohlc(steady[:40] + [108, 99, 95, 92, 89]), current_price=88.0,
+        sector_etf_histories={"XLK": _ohlc([200 - 2.5 * i for i in range(45)]),
+                              "SPY": _ohlc([400 - 2.0 * i for i in range(45)])},
+    )
+    # Profit-take zone without momentum breakdown
+    cases["profit_take_zone"] = _ctx(
+        price_history=_ohlc([100 + 0.9 * i for i in range(45)]), current_price=141.0)
+    # Old position + HOLD signal → time decay territory
+    cases["time_decay_zone"] = _ctx(entry_date="2025-12-01", research_action="HOLD")
+    # Old position + ENTER reaffirmation → decay reset
+    cases["time_decay_reset"] = _ctx(entry_date="2025-12-01", research_action="ENTER")
+    return cases
+
+
+@pytest.mark.parametrize("name", sorted(_equivalence_cases().keys()))
+def test_registry_equivalent_to_legacy_chain(name):
+    ctx = _equivalence_cases()[name]
+    legacy_signal, legacy_key = _legacy(ctx)
+    reg_signal, reg_key = stock_registry().evaluate(ctx)
+    assert reg_key == legacy_key, f"{name}: fired_rule_key diverged"
+    assert reg_signal == legacy_signal, f"{name}: signal dict diverged"
+
+
+def test_equivalence_battery_exercises_multiple_rules():
+    """Guard against a vacuous battery: the cases must collectively fire
+    several distinct rules (not all no-fire)."""
+    fired = {stock_registry().evaluate(ctx)[1] for ctx in _equivalence_cases().values()}
+    fired.discard(None)
+    assert len(fired) >= 3, f"battery too weak — only fired {fired}"


### PR DESCRIPTION
Step 0 of config#990 — the Slot S contract + conformance kit, **mergeable now**.

**What the 6/13 gate actually covers (scoping corrected per Brian 2026-06-11):** the post-6/13 hold applies to the future CUTOVER commit (rewiring `evaluate_exits` to the registry + entry-point loading) — which is NOT in this PR. This PR's live-path delta is exactly two defensive guards in `exit_manager.py` on inputs that are caller-guarded (unreachable) today; everything else is new files imported by nothing in the live path. Behavior for all reachable inputs is bit-identical; suite 1152 green.

**The design** (`executor/strategies/contract.py`):
- `ExitContext` (frozen, additive-evolution) → `ExitRule.check(ctx)` → `RuleOutcome` (decision | flag)
- `ExitRuleRegistry`: ordered chain, first-decision-wins, `skip_if_flags` (models today's ATR→sector-veto→fallback gating declaratively)
- `stock_registry()`: the 7 stock rules as thin adapters over the existing battle-tested functions — zero behavioral rewrite
- External rules: any protocol-satisfying object; production discovery via `alpha_engine.exit_rules` entry points (wired only at the post-6/13 cutover)

**The conformance kit** (`executor/strategies/conformance/`) — the issue's closes-when:
```
pytest executor/strategies/conformance --exit-rule "your_pkg.your_mod:YourRule"
```
C1 interface / C2 decision shape + declared reason vocabulary / C3 no-crash on 16 golden scenarios (incl. data-gap shapes) / C4 purity + determinism / C5 flag vocabulary. Stock rules certified in repo CI via a bridge test.

**Equivalence battery:** 21 scenarios through both the registry and `_evaluate_single_position` — bit-identical `(signal, fired_rule_key)`, including the veto and fallback-gating paths. This is the proof the eventual one-line cutover is safe.

**The kit found two latent bugs** (caller-guarded today, real for any external orchestrator): `check_profit_take` raised on `current_price=None`, `check_time_decay` on `entry_date=None` — hardened to decline per the contract. Also surfaced: `time_decay` emits `time_decay_exit`/`time_decay_reduce` (pre-contract vocabulary baked into trades.db `trigger_type`) — the contract has rules DECLARE their reason vocabulary instead of forcing a breaking rename.

**Design notes for review** (merging implies accepting these; all evolvable additively): (1) composite ATR+veto as one rule; (2) entry points for external discovery; (3) kit lives in this repo until a second consumer justifies lifting to lib.

**After this merges:** one small post-6/13 PR = the one-line cutover + entry-point wiring → config#990 closes.

Suite: **1152 passed** (29 contract/equivalence + 7 CI certifications new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)