### PR TITLE
chore: drop single-developer/solo framing from public surfaces

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Nous Ergon / Alpha Engine is a single-developer portfolio project running paper-account trading. No customer funds, no production user data.
+Nous Ergon / Alpha Engine runs paper-account trading. No customer funds, no production user data.
 
 ## Reporting a vulnerability
 

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -46,7 +46,7 @@ absent ⇒ that axis is skipped for that role).
   **robodashboard** (`portfolio.nousergon.ai`). robodashboard is an
   **intentional co-tenant** — it stays a separate repo (per the 2026-06-03
   keep-separate-product decision) but is treated as part of the nous-ergon
-  single-operator trust domain, so it shares this role rather than getting its
+  shared nous-ergon trust domain, so it shares this role rather than getting its
   own. ⚠️ **Commercialization gate:** the moment robodashboard serves its first
   *external* customer (multi-tenant, others' brokerage data) it becomes a
   separate trust domain and MUST move to dedicated compute + its own role +


### PR DESCRIPTION
Brian directive 2026-06-11: stop referring to Nous Ergon as a sole/solo-dev project on public surfaces. SECURITY.md reworded fleet-wide (keeps the defensible facts: paper trading, no customer funds, no production user data — drops the positioning). Additional surfaces for this repo, if any, in the diff. These surfaces still say Nous Ergon / Alpha Engine — the Crucible rename rides config#904 separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)