### PR TITLE
chore(iam): drop legacy alpha-engine-executor bucket grant (config#1009)

### DIFF
--- a/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
+++ b/infrastructure/iam/alpha-engine-executor-role/alpha-engine-s3-access.json
@@ -66,19 +66,6 @@
             "Resource": "arn:aws:s3:::alpha-engine-research/config/*"
         },
         {
-            "Sid": "ReadWriteExecutorBucket",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::alpha-engine-executor",
-                "arn:aws:s3:::alpha-engine-executor/*"
-            ]
-        },
-        {
             "Sid": "ReadWriteHealth",
             "Effect": "Allow",
             "Action": [


### PR DESCRIPTION
Removes the `ReadWriteExecutorBucket` statement from `alpha-engine-s3-access` — the legacy bucket's artifacts froze 2026-04-07 when trades/ + health/ migrated to `alpha-engine-research`; executor code has zero references (verified via git grep on main). Last consumer (console dashboard) repointed via config#1008 (closed today).

**Deploy coupling:** live IAM must be updated in sync with merge (`infrastructure/iam/apply.sh` or targeted `aws iam put-role-policy`) or the iam-drift check goes red. I'll apply on merge — ping me, or run apply.sh.

Bucket contents (28 objects, 2.8 MB) archived to `s3://alpha-engine-research/archive/legacy-executor-bucket-260612/` ahead of deletion (byte-verified). Bucket delete itself is held for explicit operator confirm on config#1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)