### PR TITLE
feat: wire stance_size_* overlay application (L4598, config#697)

### DIFF
--- a/executor/main.py
+++ b/executor/main.py
@@ -104,6 +104,14 @@ _PARAM_MAP = {
     # itself is a bool, handled with the other non-numeric special keys below.
     "barrier_win_prob_sizing_min": ("barrier_win_prob_sizing_min",),
     "barrier_win_prob_sizing_range": ("barrier_win_prob_sizing_range",),
+    # L4598 (config#697): stance-conditional sizing multipliers tuned by the
+    # backtester's stance_sizing_optimizer (field_overlay via the assembler).
+    # Consumed by position_sizer's stance_adj; gated upstream by the optimizer's
+    # rank-IC promotion gate — no key reaches the live artifact until it clears.
+    "stance_size_momentum": ("stance_size_momentum",),
+    "stance_size_value": ("stance_size_value",),
+    "stance_size_quality": ("stance_size_quality",),
+    "stance_size_catalyst": ("stance_size_catalyst",),
 }
 
 
@@ -127,6 +135,12 @@ _PARAM_VALIDATORS = {
     "momentum_exit_threshold":     (float, -50,  0),
     "barrier_win_prob_sizing_min":   (float, 0.3, 1.0),
     "barrier_win_prob_sizing_range": (float, 0.1, 1.0),
+    # Bounds mirror stance_sizing_optimizer._SIZE_FLOOR/_SIZE_CAP — a producer
+    # emission widened past these is rejected loudly here (WARN + skip).
+    "stance_size_momentum":          (float, 0.4, 1.1),
+    "stance_size_value":             (float, 0.4, 1.1),
+    "stance_size_quality":           (float, 0.4, 1.1),
+    "stance_size_catalyst":          (float, 0.4, 1.1),
 }
 
 _EXECUTOR_PARAMS_CACHE_PATH = Path(__file__).resolve().parent.parent / "config" / ".executor_params_cache.json"
@@ -143,10 +157,6 @@ _EXECUTOR_PARAMS_SPECIAL_KEYS = (
 # Producer provenance/metadata keys — KNOWN (no unknown-key WARN) but never
 # applied. Keeping this list complete keeps the WARN signal: an unknown key
 # always means genuine producer/consumer contract drift, not noise.
-# NOTE deliberately ABSENT: stance_size_* (the stance overlay is emitted by
-# the backtester's stance_sizing_optimizer but its application is NOT wired
-# here — its first live arrival must WARN; see the named gap in
-# PIPELINE_CONTRACT.yaml + the ROADMAP follow-up).
 _EXECUTOR_PARAMS_KNOWN_METADATA_KEYS = (
     "updated_at", "assembled_by", "fit_target",
     "best_sharpe", "best_alpha", "best_sortino",

--- a/tests/test_executor_params_consumer_contract.py
+++ b/tests/test_executor_params_consumer_contract.py
@@ -18,8 +18,7 @@ from executor import main
 
 
 # Params the producer (backtester optimizer assembler) can emit for the
-# executor to APPLY — PIPELINE_CONTRACT.yaml "applied" sections, minus the
-# stance_size_* overlay (deliberately NOT consumer-accepted yet — see below).
+# executor to APPLY — PIPELINE_CONTRACT.yaml "applied" sections.
 PRODUCER_APPLIED_PARAMS = {
     "atr_multiplier", "time_decay_reduce_days", "time_decay_exit_days",
     "min_score", "max_position_pct", "reduce_fraction",
@@ -29,6 +28,11 @@ PRODUCER_APPLIED_PARAMS = {
     "momentum_gate_threshold", "correlation_block_threshold",
     "profit_take_pct", "momentum_exit_threshold",
     "barrier_win_prob_sizing_min", "barrier_win_prob_sizing_range",
+    # L4598 (config#697): stance overlay application wired 2026-06-12 —
+    # the silent-drop gap is closed; keys remain triple-gated upstream
+    # (rank-IC promotion gate → assembler cutover → soak).
+    "stance_size_momentum", "stance_size_value", "stance_size_quality",
+    "stance_size_catalyst",
 }
 PRODUCER_SPECIAL_KEYS = {
     "disabled_triggers", "use_p_up_sizing", "p_up_sizing_blend",
@@ -43,12 +47,7 @@ PRODUCER_METADATA_KEYS = {
     "barrier_win_prob_sizing_ic", "p_up_sizing_updated_at", "p_up_sizing_ic",
     "stance_sizing_updated_at", "stance_sizing_alpha_spread",
 }
-# Emitted by stance_sizing_optimizer but NOT applied by the executor — the
-# named gap in PIPELINE_CONTRACT.yaml. These must stay OUT of both the applied
-# map and the advisory known-keys list so their first live arrival logs an
-# unknown-key WARN (the only signal until application is wired or the overlay
-# is retired — ROADMAP follow-up filed with the boundary).
-STANCE_OVERLAY_NOT_APPLIED = {
+STANCE_OVERLAY_KEYS = {
     "stance_size_momentum", "stance_size_value", "stance_size_quality",
     "stance_size_catalyst",
 }
@@ -89,11 +88,20 @@ def test_special_keys_accepted():
     assert PRODUCER_SPECIAL_KEYS == set(main._EXECUTOR_PARAMS_SPECIAL_KEYS)
 
 
-def test_stance_overlay_deliberately_unknown():
-    # Inverse pin: the stance overlay must NOT be silently known/applied until
-    # its application is actually wired (or the overlay retired).
-    assert not STANCE_OVERLAY_NOT_APPLIED & set(main._PARAM_MAP)
-    assert not STANCE_OVERLAY_NOT_APPLIED & set(main._EXECUTOR_PARAMS_SPECIAL_KEYS)
-    assert not STANCE_OVERLAY_NOT_APPLIED & set(
-        main._EXECUTOR_PARAMS_KNOWN_METADATA_KEYS
-    )
+def test_stance_overlay_wired_and_bounded():
+    # L4598 (config#697): the stance overlay is APPLIED — every key maps to the
+    # flat top-level config path position_sizer reads, and the validator bounds
+    # mirror the producer's emit bounds (stance_sizing_optimizer
+    # _SIZE_FLOOR=0.4 / _SIZE_CAP=1.1) so a widened producer emission is
+    # rejected loudly (WARN + skip), never applied unchecked.
+    for key in STANCE_OVERLAY_KEYS:
+        assert main._PARAM_MAP.get(key) == (key,), (
+            f"{key} must map to the flat top-level config key position_sizer "
+            f"reads (config.get('{key}'))"
+        )
+        assert main._PARAM_VALIDATORS.get(key) == (float, 0.4, 1.1), (
+            f"{key} validator must mirror the producer emit bounds [0.4, 1.1]"
+        )
+    # Applied params are not metadata — keys must not be double-declared.
+    assert not STANCE_OVERLAY_KEYS & set(main._EXECUTOR_PARAMS_KNOWN_METADATA_KEYS)
+    assert not STANCE_OVERLAY_KEYS & set(main._EXECUTOR_PARAMS_SPECIAL_KEYS)


### PR DESCRIPTION
Closes the silent-drop half of config#697: `stance_sizing_optimizer` emits `stance_size_{momentum,value,quality,catalyst}` as a field_overlay, but the executor loader applied only `_PARAM_MAP` + specials — a promoted stance overlay would have tuned NOTHING.

**Decision: wire, not retire.** #965's P3 leg (reconcile IC-gated stance sizing, pending skilled-risk validation) is the appointed decision point for stance sizing's fate — wiring keeps that decision open while making the producer/consumer halves agree; retiring the emission would have pre-decided it. The issue's build text also leads with wire.

**Changes:**
- `_PARAM_MAP`: 4 stance keys → flat top-level config paths (exactly what `position_sizer` reads via `config.get('stance_size_*')`).
- `_PARAM_VALIDATORS`: `(float, 0.4, 1.1)` mirroring the producer's `_SIZE_FLOOR`/`_SIZE_CAP` — a widened producer emission is rejected loudly (WARN + skip).
- Consumer contract test: inverse pin `test_stance_overlay_deliberately_unknown` → positive pin `test_stance_overlay_wired_and_bounded` (mapping + bounds + no double-declaration).

**Zero live behavior change today:** the live `config/executor_params.json` carries no stance keys — the overlay has never produced `promotion_intent=apply` (rank-IC gate unmet). Keys remain triple-gated upstream: rank-IC promotion gate → assembler cutover → soak.

**Companions:** backtester producer-test comment update + PIPELINE_CONTRACT.yaml gap-entry flip ride separate PRs (cross-repo).

Full suite: 1152 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)