### PR TITLE
feat(optimizer): executor consumes auto-tuned MVO params, clamped + gated (config#1057 inc 2, executor)

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -346,7 +346,14 @@ shadow_portfolio_optimizer: false
 use_portfolio_optimizer: false
 
 portfolio_optimizer:
+  # config#1057 inc 2: consume the backtester's auto-tuned risk_aversion ×
+  # tcost_bps from config/portfolio_optimizer.json (S3). The executor allowlists
+  # ONLY those two knobs and re-clamps them (defense in depth), and falls back to
+  # the YAML values below on absence/error. Set false = executor's independent
+  # kill-switch (ignore the auto-tuned file, use the YAML values here).
+  consume_auto_tuned: true
   # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty.
+  # (Static fallback / starting point — auto-tuned value wins when present.)
   risk_aversion: 5.0
   # Transaction cost penalty (bps per dollar traded) used in the L1 turnover
   # term. 5 bps is conservative for liquid US large-caps; backtester tunes.

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -47,6 +47,64 @@ _CASH_ALPHA_HINT = -1e-6
 _RETURNS_LOOKBACK_DAYS = 252
 _MIN_RETURNS_FOR_COV = 60
 
+# config#1057 inc 2: the backtester auto-tunes the MVO optimizer's OWN params
+# and writes them to config/portfolio_optimizer.json. Mirror the WRITER's
+# writable-set + bounds here as DEFENSE IN DEPTH — the executor never trusts the
+# written value: it consumes ONLY these two knobs and re-clamps them, so even a
+# corrupt/out-of-band file can't move the live solver outside a sane band.
+_AUTO_TUNED_WRITABLE = ("risk_aversion", "tcost_bps")
+_AUTO_TUNED_BOUNDS = {
+    "risk_aversion": (3.0, 10.0),
+    "tcost_bps": (1.0, 20.0),
+}
+
+
+def _load_auto_tuned_optimizer_cfg(config: dict, s3_client=None) -> dict:
+    """Read the backtester's auto-tuned MVO params (risk_aversion × tcost_bps)
+    from ``config/portfolio_optimizer.json`` and return them ALLOWLISTED +
+    CLAMPED (config#1057 inc 2).
+
+    Fail-safe: any absence / read error / parse error returns ``{}`` so the
+    solver falls back to the YAML/defaults — the auto-tuner is never a hard
+    dependency. Gated by ``portfolio_optimizer.consume_auto_tuned`` (default
+    True), the executor's independent kill-switch (separate from the
+    backtester's apply flag)."""
+    po_cfg = config.get("portfolio_optimizer", {}) or {}
+    if not po_cfg.get("consume_auto_tuned", True):
+        return {}
+    bucket = config.get("signals_bucket")
+    if not bucket:
+        return {}
+    try:
+        import json
+
+        s3 = s3_client or boto3.client("s3")
+        obj = s3.get_object(Bucket=bucket, Key="config/portfolio_optimizer.json")
+        data = json.loads(obj["Body"].read())
+    except Exception as e:  # noqa: BLE001 — absence/error → fall back to defaults
+        logger.debug("no auto-tuned optimizer params (%s) — using YAML/defaults", e)
+        return {}
+
+    out: dict = {}
+    for k in _AUTO_TUNED_WRITABLE:
+        if k not in data:
+            continue
+        try:
+            v = float(data[k])
+        except (TypeError, ValueError):
+            logger.warning("auto-tuned %s=%r non-numeric — ignored", k, data.get(k))
+            continue
+        lo, hi = _AUTO_TUNED_BOUNDS[k]
+        cv = min(max(v, lo), hi)
+        if cv != v:
+            logger.warning(
+                "auto-tuned %s=%s clamped to %s (band [%s, %s])", k, v, cv, lo, hi,
+            )
+        out[k] = cv
+    if out:
+        logger.info("Consuming auto-tuned optimizer params from S3: %s", out)
+    return out
+
 
 def run_shadow_optimizer(
     signals_raw: dict,
@@ -125,6 +183,10 @@ def _build_and_solve(
     optimizer_cfg = {
         **OPTIMIZER_CONFIG_DEFAULTS,
         **config.get("portfolio_optimizer", {}),
+        # config#1057 inc 2: the backtester's auto-tuned risk_aversion × tcost_bps
+        # win over the static YAML (allowlisted + re-clamped; empty on absence so
+        # the solver is unchanged until a tuned config exists).
+        **_load_auto_tuned_optimizer_cfg(config),
     }
     tickers = _build_universe(
         signals_raw, predictions_by_ticker, current_positions, price_histories,

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -473,3 +473,55 @@ class TestShadowWiringAndAblation:
                 assert abs(entry["delta"]) >= 1e-4
             # n_names_moved must equal length of the list
             assert ab["n_names_moved"] == len(ab["per_ticker_delta"])
+
+
+# ── _load_auto_tuned_optimizer_cfg (config#1057 inc 2) ───────────────────────
+
+
+def _s3_returning(payload):
+    s3 = MagicMock()
+    s3.get_object.return_value = {"Body": MagicMock(read=lambda: json.dumps(payload).encode())}
+    return s3
+
+
+class TestLoadAutoTunedOptimizerCfg:
+    def _cfg(self, **po):
+        return {"signals_bucket": "bkt", "portfolio_optimizer": po}
+
+    def test_loads_allowlisted_and_clamps(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        s3 = _s3_returning({"risk_aversion": 4.0, "tcost_bps": 3.0,
+                            "max_sector_pct": 0.99, "updated_at": "2026-06-14"})
+        out = _load_auto_tuned_optimizer_cfg(self._cfg(), s3_client=s3)
+        # only the two writable knobs survive
+        assert out == {"risk_aversion": 4.0, "tcost_bps": 3.0}
+
+    def test_out_of_band_value_is_reclamped(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg, _AUTO_TUNED_BOUNDS
+        s3 = _s3_returning({"risk_aversion": 999.0, "tcost_bps": -5.0})
+        out = _load_auto_tuned_optimizer_cfg(self._cfg(), s3_client=s3)
+        assert out["risk_aversion"] == _AUTO_TUNED_BOUNDS["risk_aversion"][1]  # hi
+        assert out["tcost_bps"] == _AUTO_TUNED_BOUNDS["tcost_bps"][0]          # lo
+
+    def test_kill_switch_disables_consumption(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        s3 = _s3_returning({"risk_aversion": 4.0})
+        out = _load_auto_tuned_optimizer_cfg(self._cfg(consume_auto_tuned=False), s3_client=s3)
+        assert out == {}
+        s3.get_object.assert_not_called()
+
+    def test_failsafe_on_s3_error_returns_empty(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        s3 = MagicMock()
+        s3.get_object.side_effect = RuntimeError("NoSuchKey")
+        assert _load_auto_tuned_optimizer_cfg(self._cfg(), s3_client=s3) == {}
+
+    def test_no_bucket_returns_empty(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        assert _load_auto_tuned_optimizer_cfg({"portfolio_optimizer": {}}, s3_client=MagicMock()) == {}
+
+    def test_non_numeric_value_ignored(self):
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        s3 = _s3_returning({"risk_aversion": "oops", "tcost_bps": 3.0})
+        out = _load_auto_tuned_optimizer_cfg(self._cfg(), s3_client=s3)
+        assert out == {"tcost_bps": 3.0}


### PR DESCRIPTION
## config#1057 — increment 2 (executor side): consume the auto-tuned params

The half that makes the backtester's auto-tuned optimizer params (PR alpha-engine-backtester#339) actually **drive live trades**. `optimizer_shadow._build_and_solve` now merges `config/portfolio_optimizer.json` into `optimizer_cfg`, so the auto-tuned `risk_aversion × tcost_bps` win over the static `risk.yaml` values.

### Defense in depth — the executor never trusts the written value
- **Allowlist** — consumes ONLY `risk_aversion` + `tcost_bps`; every other key is ignored, so the auto-tuner can't reach a safety knob (caps, turnover governor, drawdown circuit breaker) even if the file contained one.
- **Re-clamp** — each value is clamped to the same band the writer uses (`risk_aversion [3,10]`, `tcost_bps [1,20]`); out-of-band/non-numeric is clamped/ignored and logged loudly.
- **Fail-safe** — any absence/read/parse error returns `{}` → the solver falls back to YAML/defaults. The auto-tuner is never a hard dependency.
- **Kill-switch** — `portfolio_optimizer.consume_auto_tuned` (default `true`), the executor's independent off-switch (separate from the backtester's apply flag).

`risk.yaml.example` documents the flag. Tests: allowlist + clamp + kill-switch + fail-safe-on-error + no-bucket + non-numeric-ignored. **Full executor suite green (1158 passed).**

### Pairs with [backtester #339](https://github.com/cipher813/alpha-engine-backtester/pull/339)
Until both merge, the auto-tuned config is **inert**. After both, the optimizer-param tuner is live behind the full safeguard stack: promote gate (≥15% Sortino margin) + writable allowlist + clamps (both sides) + rollback + regression auto-revert + the independent live nets (turnover governor / drawdown breaker / caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)