### PR TITLE
chore(iam): repoint drift-check trust policy cipher813 -> nousergon

### DIFF
--- a/infrastructure/iam/github-actions-iam-drift-check/trust-policy.json
+++ b/infrastructure/iam/github-actions-iam-drift-check/trust-policy.json
@@ -13,8 +13,8 @@
                 },
                 "StringLike": {
                     "token.actions.githubusercontent.com:sub": [
-                        "repo:cipher813/alpha-engine:*",
-                        "repo:cipher813/alpha-engine-data:*"
+                        "repo:nousergon/alpha-engine:*",
+                        "repo:nousergon/alpha-engine-data:*"
                     ]
                 }
             }


### PR DESCRIPTION
Codified source for the `github-actions-iam-drift-check` role trust still referenced `repo:cipher813/alpha-engine*`; live IAM was re-keyed to `nousergon` during the 2026-06-15 org migration. This realigns codified == live so the daily 09:30 UTC drift scan (and Saturday DriftDetection) is GREEN again. No live apply needed — live IAM is already nousergon.

Part of org-migration follow-up (config#882).