### PR TITLE
chore: repoint GitHub refs after nousergon rename

### DIFF
--- a/infrastructure/iam/github-actions-iam-drift-check/trust-policy.json
+++ b/infrastructure/iam/github-actions-iam-drift-check/trust-policy.json
@@ -13,8 +13,8 @@
                 },
                 "StringLike": {
                     "token.actions.githubusercontent.com:sub": [
-                        "repo:nousergon/alpha-engine:*",
-                        "repo:nousergon/alpha-engine-data:*"
+                        "repo:nousergon/crucible-executor:*",
+                        "repo:nousergon/nousergon-data:*"
                     ]
                 }
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ requests~=2.32
 # are NOT consumed here (executor has no LLM exposure per
 # [[preference_llm_calls_confined_to_research_module]]) but the
 # transitive lib pin stays current.
-alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/cipher813/alpha-engine-lib@v0.59.1
+alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.1
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
Repoints lib pin URL to nousergon/nousergon-lib and the committed iam-drift-check trust policy to nousergon/crucible-executor + nousergon/nousergon-data. Part of the alpha-engine->crucible/nousergon repo rename (config#1097).