### PR TITLE
chore: repoint remaining GitHub refs after rename (tail)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Append to system-wide deploy changelog
-        uses: cipher813/alpha-engine-docs/.github/actions/append-changelog@main
+        uses: nousergon/nousergon-docs/.github/actions/append-changelog@main
         with:
           deploy_status: merged
           deploy_workflow: changelog.yml

--- a/.github/workflows/iam-drift-check.yml
+++ b/.github/workflows/iam-drift-check.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Checkout sibling repos
         run: |
           set -e
-          for repo in alpha-engine-data alpha-engine-research alpha-engine-predictor \
-                      alpha-engine-backtester alpha-engine-dashboard alpha-engine-lib; do
-            git clone --depth=1 https://github.com/cipher813/${repo}.git ${repo} || \
+          for repo in nousergon-data crucible-research crucible-predictor \
+                      crucible-backtester crucible-dashboard nousergon-lib; do
+            git clone --depth=1 https://github.com/nousergon/${repo}.git ${repo} || \
               echo "WARN: ${repo} not cloneable (private/archived?) — skipping"
           done
 
@@ -68,4 +68,4 @@ jobs:
         run: |
           cd alpha-engine
           python3 infrastructure/iam/check-no-foreign-writers.py \
-            $(for d in ../alpha-engine*; do [ -d "$d" ] && echo --repo "$d"; done)
+            $(for d in ../crucible-* ../nousergon-*; do [ -d "$d" ] && echo --repo "$d"; done)

--- a/DOCS.md
+++ b/DOCS.md
@@ -35,7 +35,7 @@ AWS SES → your inbox
 - IB Gateway credentials (username + password)
 - A verified email address in AWS SES
 - SSH key pair created in EC2
-- A signals pipeline that writes `signals/{date}/signals.json` to S3 — see [alpha-engine-research](https://github.com/cipher813/alpha-engine-research) for the reference implementation
+- A signals pipeline that writes `signals/{date}/signals.json` to S3 — see [alpha-engine-research](https://github.com/nousergon/crucible-research) for the reference implementation
 
 ---
 
@@ -382,7 +382,7 @@ sudo chown ec2-user:ec2-user /var/log/executor.log /var/log/eod.log
 
 The executor reads `signals/{YYYY-MM-DD}/signals.json` from the research S3 bucket each morning. If today's file is missing it falls back up to 5 calendar days (skipping weekends) with a warning log.
 
-[alpha-engine-research](https://github.com/cipher813/alpha-engine-research) is the reference implementation — a LangGraph pipeline that runs on AWS Lambda each trading day and writes a compliant signals file to S3. You can use it directly or build your own source that conforms to the schema below.
+[alpha-engine-research](https://github.com/nousergon/crucible-research) is the reference implementation — a LangGraph pipeline that runs on AWS Lambda each trading day and writes a compliant signals file to S3. You can use it directly or build your own source that conforms to the schema below.
 
 The file must conform to this schema:
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,6 +1,6 @@
 # alpha-engine (executor) — Code Index
 
-> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs).
+> Index of entry points, key files, and data contracts. Companion to [README.md](README.md). System overview lives in [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs).
 
 ## Module purpose
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Interactive Brokers](https://img.shields.io/badge/IBKR-1a73e8?style=flat-square)](https://www.interactivebrokers.com/)
 [![ArcticDB](https://img.shields.io/badge/ArcticDB-0e1117?style=flat-square)](https://docs.arcticdb.io/)
 [![License: AGPL-3.0-only](https://img.shields.io/badge/License-AGPL--3.0--only-yellow?style=flat-square)](LICENSE)
-[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/cipher813/alpha-engine-docs#phase-trajectory)
+[![Phase 2 · Reliability](https://img.shields.io/badge/Phase_2-Reliability-e9c46a?style=flat-square)](https://github.com/nousergon/nousergon-docs#phase-trajectory)
 
 Risk-gated trade executor. Reads research signals + predictor verdicts from S3, applies hard risk rules, sizes positions, and routes orders through IB Gateway. The morning planner writes the order book; an intraday daemon is the sole order executor.
 
-> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
+> System overview, Step Function orchestration, and module relationships live in [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs). Code index lives in [`OVERVIEW.md`](OVERVIEW.md).
 
 ## What this does
 
@@ -41,19 +41,19 @@ The daemon is the sole order executor — main.py never places orders, only writ
 
 ## Configuration
 
-This repo is **public**. `config/risk.yaml` is gitignored locally; real risk thresholds, sizing parameters, and IB credentials live in the private [`alpha-engine-config`](https://github.com/cipher813/alpha-engine-config) repo. Tunable safe-to-tune params auto-applied weekly by the Backtester via `s3://alpha-engine-research/config/executor_params.json`. Architecture and approach are public; specific values are private.
+This repo is **public**. `config/risk.yaml` is gitignored locally; real risk thresholds, sizing parameters, and IB credentials live in the private [`alpha-engine-config`](https://github.com/nousergon/alpha-engine-config) repo. Tunable safe-to-tune params auto-applied weekly by the Backtester via `s3://alpha-engine-research/config/executor_params.json`. Architecture and approach are public; specific values are private.
 
 ## Sister repos
 
 | Module | Repo |
 |---|---|
-| Data | [`alpha-engine-data`](https://github.com/cipher813/alpha-engine-data) |
-| Research | [`alpha-engine-research`](https://github.com/cipher813/alpha-engine-research) |
-| Predictor | [`alpha-engine-predictor`](https://github.com/cipher813/alpha-engine-predictor) |
-| Backtester | [`alpha-engine-backtester`](https://github.com/cipher813/alpha-engine-backtester) |
-| Dashboard | [`alpha-engine-dashboard`](https://github.com/cipher813/alpha-engine-dashboard) |
-| Library | [`alpha-engine-lib`](https://github.com/cipher813/alpha-engine-lib) |
-| Docs | [`alpha-engine-docs`](https://github.com/cipher813/alpha-engine-docs) |
+| Data | [`alpha-engine-data`](https://github.com/nousergon/nousergon-data) |
+| Research | [`alpha-engine-research`](https://github.com/nousergon/crucible-research) |
+| Predictor | [`alpha-engine-predictor`](https://github.com/nousergon/crucible-predictor) |
+| Backtester | [`alpha-engine-backtester`](https://github.com/nousergon/crucible-backtester) |
+| Dashboard | [`alpha-engine-dashboard`](https://github.com/nousergon/crucible-dashboard) |
+| Library | [`alpha-engine-lib`](https://github.com/nousergon/nousergon-lib) |
+| Docs | [`alpha-engine-docs`](https://github.com/nousergon/nousergon-docs) |
 
 ## License
 

--- a/flow-doctor.yaml
+++ b/flow-doctor.yaml
@@ -1,5 +1,5 @@
 flow_name: executor
-repo: cipher813/alpha-engine
+repo: nousergon/crucible-executor
 owner: "@brianmcmahon"
 notify:
   - type: email
@@ -9,7 +9,7 @@ notify:
     smtp_port: 587
     smtp_password: ${GMAIL_APP_PASSWORD}
   - type: github
-    repo: cipher813/alpha-engine
+    repo: nousergon/crucible-executor
     token: ${FLOW_DOCTOR_GITHUB_TOKEN}
   # Telegram fires on the same error report as the GitHub issue (the issue
   # and the alert land together). Creds resolve from the ae-trading box's

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,7 +1,7 @@
 ## Relocated to nous-ergon-ops (private)
 
 The following operational files were relocated to the private
-`cipher813/nous-ergon-ops` repo (mirrored layout) in the Phase-2 scoped
+`nousergon/nous-ergon-ops` repo (mirrored layout) in the Phase-2 scoped
 ops migration (alpha-engine-config#636, 2026-06-11). Each was verified
 consumer-free (no workflow/test/SF-literal/box-runtime path) before
 removal. Operators: find them at `nous-ergon-ops/<this-repo>/<same-path>`.

--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -259,7 +259,7 @@ fi
 # infrastructure/) — closes ROADMAP L4490, the asymmetry where a private-repo
 # fetch failure on THIS box was WARN-only-in-the-log (invisible) while the
 # dashboard box raised a flow-doctor badge + email. flow-doctor.yaml here is
-# flow_name=executor → reports to cipher813/alpha-engine + emails the owner.
+# flow_name=executor → reports to nousergon/crucible-executor + emails the owner.
 # Fire-and-forget (`|| true`): if flow-doctor itself is broken, the FAIL lines
 # in /var/log/boot-pull.log are the fallback signal, and we still exit 1.
 if [ "$PULL_FAILURES" -gt 0 ]; then

--- a/infrastructure/iam/README.md
+++ b/infrastructure/iam/README.md
@@ -63,7 +63,7 @@ absent ⇒ that axis is skipped for that role).
   `iam:ListAttachedRolePolicies` (the last two added 2026-06-09 for the
   trust/managed coverage axes) scoped to every codified role across
   alpha-engine + alpha-engine-data + alpha-engine-predictor.
-  Trust policy: `repo:cipher813/alpha-engine` + `repo:cipher813/alpha-engine-data`
+  Trust policy: `repo:nousergon/crucible-executor` + `repo:nousergon/nousergon-data`
   (main + pull_request); widened 2026-05-06 to support alpha-engine-data's
   drift-check workflow when the cross-cutting orchestration roles moved
   to that repo.


### PR DESCRIPTION
Tail sweep of remaining stale GitHub `<owner>/repo` references after the org + repo rename (cipher813/alpha-engine* -> nousergon/crucible-* and nousergon/nousergon-*). GitHub repo refs only; local dir paths, S3 bucket `alpha-engine-research`, IAM role names, and the `alpha_engine_lib` package are untouched.

config#1095

🤖 Generated with [Claude Code](https://claude.com/claude-code)