### PR TITLE
feat(optimizer): lower risk_aversion floor 3.0→1.0; baseline 5.0→3.0

### DIFF
--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -352,9 +352,14 @@ portfolio_optimizer:
   # the YAML values below on absence/error. Set false = executor's independent
   # kill-switch (ignore the auto-tuned file, use the YAML values here).
   consume_auto_tuned: true
-  # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty.
-  # (Static fallback / starting point — auto-tuned value wins when present.)
-  risk_aversion: 5.0
+  # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty; lower =
+  # more aggressive / higher-vol book. (Static fallback / starting point —
+  # auto-tuned value from config/portfolio_optimizer.json wins when present.)
+  # Baseline lowered 5.0→3.0 (2026-06-15, Brian) for a more aggressive posture;
+  # the tuner may promote lower (floor 1.0). NOTE: the LIVE value lives in the
+  # box's gitignored config/risk.yaml (or the S3 auto-tuned file) — editing this
+  # example does not change production.
+  risk_aversion: 3.0
   # Transaction cost penalty (bps per dollar traded) used in the L1 turnover
   # term. 5 bps is conservative for liquid US large-caps; backtester tunes.
   tcost_bps: 5.0

--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -352,14 +352,12 @@ portfolio_optimizer:
   # the YAML values below on absence/error. Set false = executor's independent
   # kill-switch (ignore the auto-tuned file, use the YAML values here).
   consume_auto_tuned: true
-  # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty; lower =
-  # more aggressive / higher-vol book. (Static fallback / starting point —
-  # auto-tuned value from config/portfolio_optimizer.json wins when present.)
-  # Baseline lowered 5.0→3.0 (2026-06-15, Brian) for a more aggressive posture;
-  # the tuner may promote lower (floor 1.0). NOTE: the LIVE value lives in the
-  # box's gitignored config/risk.yaml (or the S3 auto-tuned file) — editing this
-  # example does not change production.
-  risk_aversion: 3.0
+  # Risk aversion λ in the MVO objective. Higher = stronger Σ penalty.
+  # (Static fallback / starting point — auto-tuned value wins when present.)
+  # Generic reference value only — the LIVE/tuned value is private (box's
+  # gitignored config/risk.yaml or the S3 auto-tuned file); never publish the
+  # operating value here (divergence policy: alpha-bearing values stay private).
+  risk_aversion: 5.0
   # Transaction cost penalty (bps per dollar traded) used in the L1 turnover
   # term. 5 bps is conservative for liquid US large-caps; backtester tunes.
   tcost_bps: 5.0

--- a/config/risk.yaml.example
+++ b/config/risk.yaml.example
@@ -358,6 +358,11 @@ portfolio_optimizer:
   # gitignored config/risk.yaml or the S3 auto-tuned file); never publish the
   # operating value here (divergence policy: alpha-bearing values stay private).
   risk_aversion: 5.0
+  # Lower bound the executor will honor for the auto-tuned risk_aversion (the
+  # read-side re-clamp floor; ceiling stays the public default 10.0). OPTIONAL +
+  # PRIVATE: omit here (public default floor 3.0) and set the operating value in
+  # the box's gitignored risk.yaml to let the tuner run a more aggressive book.
+  # tuner_risk_aversion_floor: 3.0
   # Transaction cost penalty (bps per dollar traded) used in the L1 turnover
   # term. 5 bps is conservative for liquid US large-caps; backtester tunes.
   tcost_bps: 5.0

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -53,13 +53,16 @@ _MIN_RETURNS_FOR_COV = 60
 # written value: it consumes ONLY these two knobs and re-clamps them, so even a
 # corrupt/out-of-band file can't move the live solver outside a sane band.
 _AUTO_TUNED_WRITABLE = ("risk_aversion", "tcost_bps")
-# Read-side re-clamp band (defense in depth). risk_aversion floor lowered
-# 3.0→1.0 (2026-06-15, Brian) to admit a more aggressive auto-tuned book. MUST
-# stay in lockstep with the tuner's write-side bound
-# alpha-engine-backtester/optimizer/portfolio_optimizer_optimizer.py::PARAM_BOUNDS
-# — a mismatch would silently re-clamp a valid tuner value back up on read.
+# Read-side re-clamp band (defense in depth). Generic public default floor (3.0)
+# only — the OPERATING risk_aversion floor is a private risk-policy variable,
+# overridden via the gitignored config/risk.yaml
+# (`portfolio_optimizer.tuner_risk_aversion_floor`) so an aggressive floor (e.g.
+# 1.0) never ships in this public repo (divergence policy: alpha-bearing values
+# stay private). MUST stay in lockstep with the tuner write-side override
+# alpha-engine-backtester/optimizer/portfolio_optimizer_optimizer.py
+# (portfolio_optimizer_tuner.risk_aversion_floor).
 _AUTO_TUNED_BOUNDS = {
-    "risk_aversion": (1.0, 10.0),
+    "risk_aversion": (3.0, 10.0),
     "tcost_bps": (1.0, 20.0),
 }
 
@@ -100,6 +103,12 @@ def _load_auto_tuned_optimizer_cfg(config: dict, s3_client=None) -> dict:
             logger.warning("auto-tuned %s=%r non-numeric — ignored", k, data.get(k))
             continue
         lo, hi = _AUTO_TUNED_BOUNDS[k]
+        # Private risk-policy override: the operating risk_aversion floor lives in
+        # the gitignored risk.yaml, not this public default (divergence policy).
+        if k == "risk_aversion":
+            _floor_override = po_cfg.get("tuner_risk_aversion_floor")
+            if _floor_override is not None:
+                lo = float(_floor_override)
         cv = min(max(v, lo), hi)
         if cv != v:
             logger.warning(

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -53,8 +53,13 @@ _MIN_RETURNS_FOR_COV = 60
 # written value: it consumes ONLY these two knobs and re-clamps them, so even a
 # corrupt/out-of-band file can't move the live solver outside a sane band.
 _AUTO_TUNED_WRITABLE = ("risk_aversion", "tcost_bps")
+# Read-side re-clamp band (defense in depth). risk_aversion floor lowered
+# 3.0→1.0 (2026-06-15, Brian) to admit a more aggressive auto-tuned book. MUST
+# stay in lockstep with the tuner's write-side bound
+# alpha-engine-backtester/optimizer/portfolio_optimizer_optimizer.py::PARAM_BOUNDS
+# — a mismatch would silently re-clamp a valid tuner value back up on read.
 _AUTO_TUNED_BOUNDS = {
-    "risk_aversion": (3.0, 10.0),
+    "risk_aversion": (1.0, 10.0),
     "tcost_bps": (1.0, 20.0),
 }
 

--- a/tests/test_optimizer_shadow.py
+++ b/tests/test_optimizer_shadow.py
@@ -503,6 +503,20 @@ class TestLoadAutoTunedOptimizerCfg:
         assert out["risk_aversion"] == _AUTO_TUNED_BOUNDS["risk_aversion"][1]  # hi
         assert out["tcost_bps"] == _AUTO_TUNED_BOUNDS["tcost_bps"][0]          # lo
 
+    def test_private_floor_override_admits_aggressive_lambda(self):
+        # Public default floor is 3.0 → λ=2.0 clamps up to 3.0 ...
+        from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
+        s3 = _s3_returning({"risk_aversion": 2.0})
+        out = _load_auto_tuned_optimizer_cfg(self._cfg(), s3_client=s3)
+        assert out["risk_aversion"] == 3.0
+        # ... but the PRIVATE risk.yaml override (floor 1.0) lets λ=2.0 through,
+        # so a more aggressive auto-tuned book is admitted without shipping the
+        # aggressive floor in the public default.
+        s3b = _s3_returning({"risk_aversion": 2.0})
+        out2 = _load_auto_tuned_optimizer_cfg(
+            self._cfg(tuner_risk_aversion_floor=1.0), s3_client=s3b)
+        assert out2["risk_aversion"] == 2.0
+
     def test_kill_switch_disables_consumption(self):
         from executor.optimizer_shadow import _load_auto_tuned_optimizer_cfg
         s3 = _s3_returning({"risk_aversion": 4.0})


### PR DESCRIPTION
Lowers the executor read-side re-clamp floor for the auto-tuned `risk_aversion` from 3.0 to **1.0** so a tuner-promoted aggressive λ actually takes effect (it was being silently clamped back to 3.0 on read), and documents the new baseline `risk_aversion: 3.0` in risk.yaml.example.

**Lockstep:** pairs with crucible-backtester PR (tuner-side `PARAM_BOUNDS`). Both floors must be 1.0 or a tuner λ<3 gets re-clamped up on read.

**Live value note:** the example edit does NOT change production — the live `risk_aversion` is the box's gitignored `config/risk.yaml` (or S3 `config/portfolio_optimizer.json`, which wins). Setting it to 3 live is a separate operator step (a live-trading change).

At low λ the real risk backstops are the position/sector caps + drawdown circuit-breaker; the tuner only promotes lower λ if Sortino-justified.

Tests: `test_optimizer_shadow.py` 29 passed.