### PR TITLE
ci: alert on main-branch CI failure via reusable Telegram workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,13 @@ jobs:
         run: |
           pip install pip-audit
           pip-audit || true
+
+  # Alert (Telegram) ONLY on genuine post-merge breakage of the default
+  # branch. PR-branch reds (mid-fix commits, cross-repo lib-tag merge-order
+  # races) stay silent. Reusable workflow + transport in nousergon-lib.
+  # See alpha-engine-config#1128.
+  notify-main-failure:
+    needs: [test]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    uses: nousergon/nousergon-lib/.github/workflows/notify-ci-failure.yml@main
+    secrets: inherit


### PR DESCRIPTION
## What
Adds a `notify-main-failure` job that fires a **Telegram alert only on genuine post-merge breakage of `main`**, via the shared `nousergon-lib` reusable workflow (`secrets: inherit`).

## Why
GitHubs built-in Actions failure email fires on every red run and cant distinguish transient from real. PR-branch reds (mid-fix commits, cross-repo lib-tag merge-order races) stay silent; only `failure() && github.ref == refs/heads/main` alerts. Fleet rollout following the crucible-backtester pilot (#347, merged). Transport verified end-to-end. Tracked: alpha-engine-config#1128.

## Note
notify job is dormant on this PR (gated to push:main + failure), so PR CI only runs the normal test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)