### PR TITLE
feat(eod): daemon-vs-IB reconciliation-integrity audit producer (config#859)

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -723,6 +723,47 @@ def run(run_date: str | None = None) -> None:
             logger.warning(msg)
             data_warnings.append(msg)
 
+    # ── Daemon-vs-IB reconciliation-integrity audit (config#859) ──
+    # Secondary observability hung off the primary EOD path: a failure here
+    # must NOT abort EOD reconcile (the NAV log + email are the primary
+    # deliverable), and the failure IS recorded — (a) swallowed: audit
+    # build/write error; (c) recording surface: the WARN below + the
+    # report-card reconciliation_integrity component shows N/A when the
+    # artifact is absent. Per the feedback_no_silent_fails secondary-
+    # observability carve-out.
+    try:
+        from executor.reconciliation_audit import (
+            build_reconciliation_audit,
+            write_reconciliation_audit,
+        )
+
+        _recon_audit = build_reconciliation_audit(
+            conn,
+            today_positions=positions,
+            prior_positions=prior_positions,
+            run_date=run_date,
+            ib_nav=nav,
+        )
+        _recon_key = write_reconciliation_audit(
+            _recon_audit,
+            bucket=trades_bucket,
+            run_date=run_date,
+            region=config.get("aws_region", "us-east-1"),
+        )
+        logger.info(
+            "[reconciliation_audit] match_rate=%.3f status=%s positions=%d "
+            "mismatched=%d -> s3://%s/%s",
+            _recon_audit["reconciliation_match_rate"], _recon_audit["status"],
+            _recon_audit["n_positions"], _recon_audit["n_mismatched"],
+            trades_bucket, _recon_key,
+        )
+    except Exception as _recon_err:  # noqa: BLE001 — secondary observability (see comment above)
+        logger.warning(
+            "[reconciliation_audit] FAILED to build/write reconciliation "
+            "audit for run_date=%s: %s (report card reconciliation_integrity "
+            "shows N/A this cycle)", run_date, _recon_err,
+        )
+
     # Persist EOD snapshot AFTER positions are enriched with closing prices,
     # accrued dividends, and per-position returns. Yesterday's reconcile now
     # reads this snapshot via closing_price (same source as today's

--- a/executor/reconciliation_audit.py
+++ b/executor/reconciliation_audit.py
@@ -1,0 +1,252 @@
+"""Daemon-vs-IB reconciliation-integrity audit (config#859).
+
+Produces ``s3://{trades_bucket}/trades/{date}/reconciliation_audit.json`` for
+the evaluator report-card ``reconciliation_integrity`` component (Executor
+tile, criticality=critical).
+
+The audit compares the system's OWN trade ledger (the ``trades`` table — what
+the daemon *recorded* it executed) against IB's actual broker state (the EOD
+snapshot — what the broker really holds). Two independent checks:
+
+  A. **Position parity** — the headline ``reconciliation_match_rate``.
+     Reconstruct net shares per ticker from the ledger (Σ signed
+     ``filled_shares``) and compare to IB's reported positions. Catches the
+     failures worth catching: fills the system never recorded, positions that
+     drifted, the daemon believing it holds X while IB holds Y.
+  B. **Daily-delta integrity** — a supporting per-day signal. Today's IB
+     position changes (today snapshot vs prior snapshot) vs today's recorded
+     ledger fills. Sidesteps the historical-baseline problem in (A).
+
+DELIBERATELY NOT a NAV tautology: computing a "daemon NAV" as
+``Σ(IB position market_value) + IB cash`` and comparing it to IB
+``net_liquidation`` reconciles IB against ITSELF — it is structurally always
+~0 and grades GREEN forever (false confidence, worse than honest N/A). The
+ledger is the only independent source, so the metric is built on it.
+
+Known reconstruction caveats (surfaced in the artifact, not hidden):
+  - Positions predating the trade ledger reconstruct short (baseline gap).
+  - Corporate actions (splits/spinoffs) change IB shares with no ledger
+    trade → an expected mismatch until the ledger is split-adjusted.
+  - These are why (B)'s daily-delta — which needs no historical baseline —
+    is reported alongside (A).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Trade-action sign conventions (see executor/daemon.py action vocabulary).
+_BUY_ACTIONS = frozenset({"ENTER", "COVER", "BUY"})
+_SELL_ACTIONS = frozenset(
+    {"EXIT", "REDUCE", "SELL", "LIQUIDATION_SELL", "EMERGENCY_SELL"}
+)
+# Statuses that mean the order did NOT result in shares changing hands —
+# excluded from ledger reconstruction. Anything else (Filled / ok / legacy
+# NULL) contributes its filled_shares (or intended shares as a fallback).
+_NON_FILL_STATUSES = frozenset(
+    {"Rejected", "rejected", "error", "failed", "cancelled", "Cancelled", "pending"}
+)
+
+_RECON_TOLERANCE_SHARES = 0  # exact share parity; whole-share equities
+
+
+def _shares_contributed(row: dict[str, Any]) -> int:
+    """Signed shares a single trade row contributes to a ticker's net position.
+
+    Uses the ACTUAL ``filled_shares`` when present (the real executed
+    quantity, incl. partial/zero fills); falls back to the intended
+    ``shares`` only for legacy rows that predate the filled_shares column,
+    and only when the status doesn't mark it a non-fill. Unknown actions
+    contribute 0 (logged) rather than silently guessing a sign.
+    """
+    status = row.get("status")
+    if status in _NON_FILL_STATUSES:
+        return 0
+    filled = row.get("filled_shares")
+    qty = filled if filled is not None else row.get("shares")
+    if not qty:
+        return 0
+    action = (row.get("action") or "").upper()
+    if action in _BUY_ACTIONS:
+        return int(qty)
+    if action in _SELL_ACTIONS:
+        return -int(qty)
+    logger.warning(
+        "[reconciliation_audit] unknown trade action %r (ticker=%s) — "
+        "contributing 0 shares; add it to _BUY_ACTIONS/_SELL_ACTIONS",
+        row.get("action"), row.get("ticker"),
+    )
+    return 0
+
+
+def reconstruct_ledger_positions(
+    conn, *, as_of_date: Optional[str] = None, on_date: Optional[str] = None
+) -> dict[str, int]:
+    """Net shares per ticker reconstructed from the ``trades`` ledger.
+
+    ``as_of_date`` (inclusive upper bound) reconstructs the cumulative
+    position through that date — used for the (A) position-parity check.
+    ``on_date`` restricts to trades dated exactly that day — used for the
+    (B) daily-delta check. Pass at most one. Tickers netting to 0 are
+    dropped.
+    """
+    if as_of_date and on_date:
+        raise ValueError("pass at most one of as_of_date / on_date")
+    sql = "SELECT ticker, action, shares, filled_shares, status FROM trades"
+    params: tuple = ()
+    if on_date is not None:
+        sql += " WHERE date = ?"
+        params = (on_date,)
+    elif as_of_date is not None:
+        sql += " WHERE date <= ?"
+        params = (as_of_date,)
+    net: dict[str, int] = {}
+    for ticker, action, shares, filled_shares, status in conn.execute(sql, params):
+        if not ticker:
+            continue
+        delta = _shares_contributed({
+            "ticker": ticker, "action": action, "shares": shares,
+            "filled_shares": filled_shares, "status": status,
+        })
+        if delta:
+            net[ticker] = net.get(ticker, 0) + delta
+    return {t: s for t, s in net.items() if s != 0}
+
+
+def _ib_shares(positions: dict[str, Any]) -> dict[str, int]:
+    """Extract {ticker: int shares} from an IB positions snapshot, dropping
+    zero/closed positions."""
+    out: dict[str, int] = {}
+    for ticker, pos in (positions or {}).items():
+        shares = pos.get("shares") if isinstance(pos, dict) else None
+        if shares:
+            out[ticker] = int(round(float(shares)))
+    return out
+
+
+def build_reconciliation_audit(
+    conn,
+    *,
+    today_positions: dict[str, Any],
+    prior_positions: Optional[dict[str, Any]],
+    run_date: str,
+    ib_nav: Optional[float] = None,
+    generated_at: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build the reconciliation-audit payload (pure — no I/O).
+
+    ``reconciliation_match_rate`` (the report-card metric) is the fraction of
+    positions where the ledger-reconstructed net shares equal IB's reported
+    shares, over the UNION of tickers that either side holds. A ticker IB
+    holds but the ledger can't explain (or vice-versa) is a mismatch — that
+    is the integrity signal.
+    """
+    ledger = reconstruct_ledger_positions(conn, as_of_date=run_date)
+    ib = _ib_shares(today_positions)
+
+    # ── A. Position parity (headline) ──
+    universe = sorted(set(ledger) | set(ib))
+    mismatches: list[dict[str, Any]] = []
+    n_matched = 0
+    for t in universe:
+        lg, ibq = ledger.get(t, 0), ib.get(t, 0)
+        if abs(lg - ibq) <= _RECON_TOLERANCE_SHARES:
+            n_matched += 1
+        else:
+            mismatches.append({
+                "ticker": t, "ledger_shares": lg, "ib_shares": ibq,
+                "delta": ibq - lg,
+                "kind": (
+                    "ib_only" if lg == 0 else
+                    "ledger_only" if ibq == 0 else "share_mismatch"
+                ),
+            })
+    # Empty universe (no positions either side) is a vacuous match → 1.0.
+    match_rate = 1.0 if not universe else round(n_matched / len(universe), 4)
+
+    # ── B. Daily-delta integrity (supporting) ──
+    daily: dict[str, Any] = {"computed": False}
+    if prior_positions is not None:
+        prior_ib = _ib_shares(prior_positions)
+        ledger_today = reconstruct_ledger_positions(conn, on_date=run_date)
+        d_universe = sorted(set(prior_ib) | set(ib) | set(ledger_today))
+        d_mismatches: list[dict[str, Any]] = []
+        d_matched = 0
+        for t in d_universe:
+            ib_delta = ib.get(t, 0) - prior_ib.get(t, 0)
+            led_delta = ledger_today.get(t, 0)
+            if ib_delta == led_delta:
+                d_matched += 1
+            elif ib_delta != 0 or led_delta != 0:
+                d_mismatches.append({
+                    "ticker": t, "ib_delta": ib_delta, "ledger_delta": led_delta,
+                })
+            else:
+                d_matched += 1
+        daily = {
+            "computed": True,
+            "match_rate": (
+                1.0 if not d_universe else round(d_matched / len(d_universe), 4)
+            ),
+            "n_tickers": len(d_universe),
+            "n_matched": d_matched,
+            "mismatches": d_mismatches,
+        }
+
+    status = "OK" if match_rate >= 1.0 else "DRIFT"
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "date": run_date,
+        "generated_at": generated_at or datetime.now(timezone.utc).isoformat(),
+        # Headline metric consumed by the evaluator reconciliation_integrity grader.
+        "reconciliation_match_rate": match_rate,
+        "status": status,
+        "n_positions": len(universe),
+        "n_matched": n_matched,
+        "n_mismatched": len(mismatches),
+        "position_parity": {
+            "ledger_positions": ledger,
+            "ib_positions": ib,
+            "mismatches": mismatches,
+        },
+        "daily_delta": daily,
+        # Informational only — NAV parity is NOT the metric (an IB-derived
+        # daemon NAV would be a tautology). Recorded for operator context.
+        "ib_nav": ib_nav,
+        "caveats": [
+            "Ledger reconstruction nets signed filled_shares from the trades "
+            "table; positions predating the ledger reconstruct short.",
+            "Corporate actions (splits/spinoffs) change IB shares with no "
+            "ledger trade and surface as expected mismatches until the ledger "
+            "is split-adjusted — cross-check the daily_delta signal, which "
+            "needs no historical baseline.",
+        ],
+    }
+    return payload
+
+
+def write_reconciliation_audit(
+    payload: dict[str, Any], *, bucket: str, run_date: str,
+    region: str = "us-east-1", s3_client: Any | None = None,
+) -> str:
+    """Write the audit payload to ``trades/{run_date}/reconciliation_audit.json``.
+
+    Returns the S3 key written. Sibling of ``trades/execution_quality`` /
+    ``trades/{date}/`` artifacts.
+    """
+    import boto3
+
+    key = f"trades/{run_date}/reconciliation_audit.json"
+    client = s3_client if s3_client is not None else boto3.client("s3", region_name=region)
+    client.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=json.dumps(payload, indent=2, default=str).encode(),
+        ContentType="application/json",
+    )
+    return key

--- a/tests/test_reconciliation_audit.py
+++ b/tests/test_reconciliation_audit.py
@@ -1,0 +1,180 @@
+"""Tests for executor/reconciliation_audit.py (config#859).
+
+Locks the ledger-vs-IB integrity contract: position-parity match_rate from
+ledger-reconstructed net shares vs IB snapshot, the daily-delta check, and
+the explicit avoidance of the IB-vs-IB NAV tautology.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import MagicMock
+
+import pytest
+
+from executor.reconciliation_audit import (
+    build_reconciliation_audit,
+    reconstruct_ledger_positions,
+    write_reconciliation_audit,
+)
+
+
+def _conn(rows: list[dict]) -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.execute(
+        "CREATE TABLE trades (trade_id TEXT, date TEXT, ticker TEXT, action TEXT, "
+        "shares INTEGER, filled_shares INTEGER, status TEXT)"
+    )
+    for i, r in enumerate(rows):
+        c.execute(
+            "INSERT INTO trades VALUES (?,?,?,?,?,?,?)",
+            (str(i), r.get("date", "2026-06-10"), r["ticker"], r["action"],
+             r.get("shares"), r.get("filled_shares"), r.get("status")),
+        )
+    c.commit()
+    return c
+
+
+def _pos(**kw) -> dict:
+    return {t: {"shares": s} for t, s in kw.items()}
+
+
+class TestReconstruct:
+    def test_enter_adds_exit_reduce_subtract(self):
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled"},
+            {"ticker": "AAPL", "action": "REDUCE", "filled_shares": 30, "status": "Filled"},
+            {"ticker": "MSFT", "action": "ENTER", "filled_shares": 50, "status": "Filled"},
+            {"ticker": "MSFT", "action": "EXIT", "filled_shares": 50, "status": "Filled"},
+        ])
+        assert reconstruct_ledger_positions(conn, as_of_date="2026-06-30") == {"AAPL": 70}
+
+    def test_rejected_and_unknown_excluded(self):
+        conn = _conn([
+            {"ticker": "NVDA", "action": "ENTER", "filled_shares": 10, "status": "Rejected"},
+            {"ticker": "NVDA", "action": "ENTER", "filled_shares": 5, "status": "Filled"},
+            {"ticker": "TSLA", "action": "FROBNICATE", "filled_shares": 9, "status": "Filled"},
+        ])
+        # Rejected ENTER ignored; unknown action contributes 0 -> TSLA drops.
+        assert reconstruct_ledger_positions(conn, as_of_date="2026-06-30") == {"NVDA": 5}
+
+    def test_filled_shares_preferred_over_intended(self):
+        conn = _conn([
+            {"ticker": "AMD", "action": "ENTER", "shares": 100, "filled_shares": 80, "status": "Filled"},
+        ])
+        assert reconstruct_ledger_positions(conn, as_of_date="2026-06-30") == {"AMD": 80}
+
+    def test_legacy_null_filled_falls_back_to_shares(self):
+        conn = _conn([
+            {"ticker": "INTC", "action": "ENTER", "shares": 40, "filled_shares": None, "status": None},
+        ])
+        assert reconstruct_ledger_positions(conn, as_of_date="2026-06-30") == {"INTC": 40}
+
+    def test_on_date_restricts_to_single_day(self):
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled", "date": "2026-06-09"},
+            {"ticker": "AAPL", "action": "REDUCE", "filled_shares": 25, "status": "Filled", "date": "2026-06-10"},
+        ])
+        assert reconstruct_ledger_positions(conn, on_date="2026-06-10") == {"AAPL": -25}
+
+    def test_mutually_exclusive_date_args(self):
+        conn = _conn([])
+        with pytest.raises(ValueError):
+            reconstruct_ledger_positions(conn, as_of_date="x", on_date="y")
+
+
+class TestBuildAudit:
+    def test_perfect_match_is_green(self):
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled"},
+            {"ticker": "MSFT", "action": "ENTER", "filled_shares": 50, "status": "Filled"},
+        ])
+        audit = build_reconciliation_audit(
+            conn, today_positions=_pos(AAPL=100, MSFT=50),
+            prior_positions={}, run_date="2026-06-18", ib_nav=1_000_000.0,
+        )
+        assert audit["reconciliation_match_rate"] == 1.0
+        assert audit["status"] == "OK"
+        assert audit["n_mismatched"] == 0
+
+    def test_ib_only_position_is_mismatch(self):
+        # IB holds GOOG the ledger never recorded buying — a real integrity hit.
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled"},
+        ])
+        audit = build_reconciliation_audit(
+            conn, today_positions=_pos(AAPL=100, GOOG=20),
+            prior_positions={}, run_date="2026-06-18",
+        )
+        assert audit["reconciliation_match_rate"] == 0.5
+        assert audit["status"] == "DRIFT"
+        kinds = {m["ticker"]: m["kind"] for m in audit["position_parity"]["mismatches"]}
+        assert kinds == {"GOOG": "ib_only"}
+
+    def test_share_mismatch_detected(self):
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled"},
+        ])
+        audit = build_reconciliation_audit(
+            conn, today_positions=_pos(AAPL=90),
+            prior_positions={}, run_date="2026-06-18",
+        )
+        m = audit["position_parity"]["mismatches"][0]
+        assert m == {"ticker": "AAPL", "ledger_shares": 100, "ib_shares": 90, "delta": -10, "kind": "share_mismatch"}
+
+    def test_empty_universe_is_vacuous_green(self):
+        audit = build_reconciliation_audit(
+            _conn([]), today_positions={}, prior_positions={}, run_date="2026-06-18",
+        )
+        assert audit["reconciliation_match_rate"] == 1.0
+
+    def test_daily_delta_matches_recorded_fills(self):
+        # Prior held AAPL 100; today IB shows 130; ledger recorded a +30 ENTER today.
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled", "date": "2026-06-17"},
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 30, "status": "Filled", "date": "2026-06-18"},
+        ])
+        audit = build_reconciliation_audit(
+            conn, today_positions=_pos(AAPL=130), prior_positions=_pos(AAPL=100),
+            run_date="2026-06-18",
+        )
+        assert audit["daily_delta"]["computed"] is True
+        assert audit["daily_delta"]["match_rate"] == 1.0
+        assert audit["daily_delta"]["mismatches"] == []
+
+    def test_daily_delta_flags_unrecorded_ib_change(self):
+        # IB jumped +30 today but the ledger has no trade for it.
+        conn = _conn([
+            {"ticker": "AAPL", "action": "ENTER", "filled_shares": 100, "status": "Filled", "date": "2026-06-17"},
+        ])
+        audit = build_reconciliation_audit(
+            conn, today_positions=_pos(AAPL=130), prior_positions=_pos(AAPL=100),
+            run_date="2026-06-18",
+        )
+        dd = audit["daily_delta"]
+        assert dd["match_rate"] == 0.0
+        assert dd["mismatches"] == [{"ticker": "AAPL", "ib_delta": 30, "ledger_delta": 0}]
+
+    def test_nav_is_informational_not_the_metric(self):
+        audit = build_reconciliation_audit(
+            _conn([]), today_positions={}, prior_positions=None,
+            run_date="2026-06-18", ib_nav=500_000.0,
+        )
+        assert audit["ib_nav"] == 500_000.0
+        # match_rate is built from the ledger, not NAV.
+        assert "reconciliation_match_rate" in audit
+        assert audit["daily_delta"]["computed"] is False
+
+
+class TestWrite:
+    def test_write_key_and_payload(self):
+        stub = MagicMock()
+        key = write_reconciliation_audit(
+            {"reconciliation_match_rate": 1.0}, bucket="alpha-engine-research",
+            run_date="2026-06-18", s3_client=stub,
+        )
+        assert key == "trades/2026-06-18/reconciliation_audit.json"
+        _, kwargs = stub.put_object.call_args
+        assert kwargs["Key"] == key
+        assert json.loads(kwargs["Body"].decode())["reconciliation_match_rate"] == 1.0


### PR DESCRIPTION
## What (config#859, producer half)

New producer `trades/{date}/reconciliation_audit.json` for the report card's **reconciliation_integrity** component (Executor tile, critical) — was N/A because nothing emitted the artifact.

## Why this design (avoids the trap)

A "daemon NAV" computed from IB's own position market-values reconciles **IB against itself** → structurally always ~0 → GREEN forever (false confidence). Instead the audit uses two **independent** sources:
- **A. Position parity (headline `reconciliation_match_rate`):** ledger-reconstructed net shares (Σ signed `filled_shares`; ENTER/COVER/BUY +, EXIT/REDUCE/SELL/*_SELL −) vs IB's actual positions, over the union of tickers. Catches unrecorded fills / position drift / daemon-believes-X-but-IB-holds-Y.
- **B. Daily-delta integrity:** today's IB position changes (vs prior snapshot) vs today's recorded fills — needs no historical baseline.

Reconstruction caveats (pre-ledger baseline gap, corporate-action splits) are **surfaced in the artifact**, not hidden — and B exists precisely to cross-check A without the baseline problem.

## Wiring

Called from `eod_reconcile.run()` as secondary observability off the primary EOD path: **fail-soft + loud WARN** (report card shows N/A if absent), per the `feedback_no_silent_fails` secondary-observability carve-out with the required inline (a)/(c) comment.

## Tests
14 new (reconstruction sign/status/fallback/unknown-action, parity match_rate, 3 mismatch kinds, daily-delta, NAV-is-informational, write key). **Full executor suite 1173 passed.**

**Pairs with the evaluator consumer grader** (crucible-evaluator PR) — the component un-N/As once both ship.

config#859

🤖 Generated with [Claude Code](https://claude.com/claude-code)