### PR TITLE
feat(daemon): publish intraday/nav.json live NAV snapshot each poll tick

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -54,6 +54,7 @@ from executor.intraday_resolve import (
     solve_redeploy,
 )
 from executor.intraday_snapshot import (
+    IntradayNavWriter,
     IntradaySnapshotWriter,
     compute_surveillance_universe,
 )
@@ -597,6 +598,12 @@ def run_daemon(dry_run: bool = False) -> None:
         daemon_pid=os.getpid(),
     )
 
+    # Live-NAV snapshot writer — publishes intraday/nav.json each tick so
+    # live.nousergon.ai can render a live intraday header (current NAV,
+    # today's return + alpha vs SPY) instead of only the last EOD close.
+    # Same fire-and-forget contract as the writers above.
+    nav_writer = IntradayNavWriter(bucket=config["signals_bucket"])
+
     n_urgent = len(order_book.pending_urgent_exits())
     send_daemon_status(
         f"\u2705 *Daemon started*\n"
@@ -906,6 +913,22 @@ def run_daemon(dry_run: bool = False) -> None:
                 # swallow S3 errors. This catch ensures no unexpected
                 # exception from the writer leaks into the trade loop.
                 logger.warning("intraday snapshot writer raised: %s", _snap_err)
+
+            # ── Live-NAV snapshot ────────────────────────────────────
+            # Publish intraday/nav.json (IB NetLiquidation + SPY mark) so
+            # live.nousergon.ai renders a live intraday header. Only when
+            # connected — a NAV read off a dead session is meaningless.
+            # Fire-and-forget; same defensive belt as the writers above.
+            try:
+                if ibkr.ib.isConnected():
+                    spy_state = monitor.prices.get("SPY") or {}
+                    nav_writer.write(
+                        ibkr.get_account_snapshot(),
+                        spy_last=spy_state.get("last"),
+                        ib_connected=True,
+                    )
+            except Exception as _nav_err:  # noqa: BLE001
+                logger.warning("nav snapshot writer raised: %s", _nav_err)
 
             # ── Open-IB-orders snapshot ──────────────────────────────
             # Refresh trades/open_orders/latest.json each tick so the

--- a/executor/intraday_snapshot.py
+++ b/executor/intraday_snapshot.py
@@ -43,6 +43,33 @@ logger = logging.getLogger(__name__)
 
 LATEST_PRICES_KEY = "intraday/latest_prices.json"
 HEARTBEAT_KEY = "intraday/heartbeat.json"
+NAV_KEY = "intraday/nav.json"
+
+
+def _put_json_to_s3(s3: Any, bucket: str, key: str, payload: dict) -> bool:
+    """Write a JSON dict to S3 as a single object. Fire-and-forget.
+
+    Shared by all intraday writers: S3 errors are logged at WARNING and
+    swallowed (return ``False``) so a failed observability write never
+    interrupts the daemon's order-execution loop. The recording surface
+    for a sustained failure is heartbeat-timestamp staleness, which the
+    surveillance Lambda treats as a first-class daemon-down alert.
+    """
+    try:
+        s3.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=json.dumps(payload, default=str).encode("utf-8"),
+            ContentType="application/json",
+        )
+        return True
+    except (ClientError, BotoCoreError) as e:
+        logger.warning(
+            "intraday write to s3://%s/%s failed (%s) — surveillance Lambda "
+            "will see heartbeat staleness",
+            bucket, key, type(e).__name__,
+        )
+        return False
 
 
 def compute_surveillance_universe(
@@ -163,18 +190,73 @@ class IntradaySnapshotWriter:
 
     def _put_json(self, key: str, payload: dict) -> bool:
         """Write a JSON dict to S3 as a single object. Fire-and-forget."""
-        try:
-            self._s3.put_object(
-                Bucket=self._bucket,
-                Key=key,
-                Body=json.dumps(payload, default=str).encode("utf-8"),
-                ContentType="application/json",
-            )
-            return True
-        except (ClientError, BotoCoreError) as e:
-            logger.warning(
-                "intraday snapshot write to s3://%s/%s failed (%s) — "
-                "surveillance Lambda will see heartbeat staleness",
-                self._bucket, key, type(e).__name__,
-            )
-            return False
+        return _put_json_to_s3(self._s3, self._bucket, key, payload)
+
+
+class IntradayNavWriter:
+    """Publishes a live portfolio NAV snapshot to ``intraday/nav.json``.
+
+    Powers the live.nousergon.ai intraday header (current NAV, today's
+    return, today's alpha vs SPY). The daemon already holds an IB
+    account-summary subscription, so ``NetLiquidation`` is IB's own
+    real-time, fill-inclusive ground truth — more accurate than marking
+    a stale position list dashboard-side.
+
+    Producer publishes RAW marks only (NAV, cash, SPY last); the consumer
+    derives today's return/alpha against the prior EOD baseline it already
+    loads from ``eod_pnl.csv``. Keeping the math consumer-side means the
+    display convention can change without redeploying the trading box.
+
+    Fire-and-forget — S3 failures are logged at WARNING and never raise.
+    A failed NAV write must never interrupt the order-execution loop;
+    sustained failure surfaces via heartbeat staleness like the price
+    writer.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        s3_client: Any | None = None,
+    ) -> None:
+        """:param bucket: S3 bucket to write under (the daemon's
+            ``signals_bucket``).
+        :param s3_client: Inject a pre-built boto3 client (tests). Defaults
+            to a freshly-constructed ``boto3.client("s3")``.
+        """
+        self._bucket = bucket
+        self._s3 = s3_client if s3_client is not None else boto3.client("s3")
+
+    def write(
+        self,
+        account_snapshot: dict,
+        *,
+        spy_last: float | None,
+        ib_connected: bool,
+    ) -> bool:
+        """Publish the NAV snapshot artifact to S3.
+
+        :param account_snapshot: The dict returned by
+            ``ibkr.get_account_snapshot()`` (``net_liquidation``,
+            ``total_cash``, ``gross_position_value``, ``unrealized_pnl``,
+            etc.). Missing fields are tolerated — published as ``None``.
+        :param spy_last: Current SPY last price from the daemon's price
+            monitor (``monitor.prices["SPY"]["last"]``), or ``None`` if SPY
+            has no live tick yet. The consumer needs it to compute today's
+            alpha vs SPY.
+        :param ib_connected: ``ibkr.ib.isConnected()`` — stamped so the
+            consumer can distinguish a fresh-but-disconnected snapshot from
+            a stale one.
+        :returns: ``True`` on successful write, ``False`` otherwise
+            (logged).
+        """
+        payload = {
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "ib_connected": ib_connected,
+            "net_liquidation": account_snapshot.get("net_liquidation"),
+            "total_cash": account_snapshot.get("total_cash"),
+            "gross_position_value": account_snapshot.get("gross_position_value"),
+            "unrealized_pnl": account_snapshot.get("unrealized_pnl"),
+            "spy_last": spy_last,
+        }
+        return _put_json_to_s3(self._s3, self._bucket, NAV_KEY, payload)

--- a/tests/test_intraday_snapshot.py
+++ b/tests/test_intraday_snapshot.py
@@ -15,6 +15,8 @@ from botocore.exceptions import ClientError
 from executor.intraday_snapshot import (
     HEARTBEAT_KEY,
     LATEST_PRICES_KEY,
+    NAV_KEY,
+    IntradayNavWriter,
     IntradaySnapshotWriter,
     compute_surveillance_universe,
 )
@@ -216,3 +218,69 @@ class TestDaemonPidDefault:
         # Just confirm it's an int — actual value is the test runner's pid.
         assert isinstance(body["daemon_pid"], int)
         assert body["daemon_pid"] > 0
+
+
+# ── IntradayNavWriter ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def nav_writer(mock_s3):
+    return IntradayNavWriter(bucket="test-bucket", s3_client=mock_s3)
+
+
+_ACCT = {
+    "net_liquidation": 1_000_564.85,
+    "total_cash": 28_634.48,
+    "gross_position_value": 971_930.37,
+    "unrealized_pnl": -10_465.16,
+    "settled_cash": 28_634.48,  # extra field the writer should ignore
+}
+
+
+class TestIntradayNavWriterHappyPath:
+    def test_returns_true_and_writes_one_object(self, nav_writer, mock_s3):
+        ok = nav_writer.write(_ACCT, spy_last=740.96, ib_connected=True)
+        assert ok is True
+        assert mock_s3.put_object.call_count == 1
+
+    def test_correct_key_and_bucket(self, nav_writer, mock_s3):
+        nav_writer.write(_ACCT, spy_last=740.96, ib_connected=True)
+        call = mock_s3.put_object.call_args
+        assert call.kwargs["Key"] == NAV_KEY
+        assert call.kwargs["Bucket"] == "test-bucket"
+        assert call.kwargs["ContentType"] == "application/json"
+
+    def test_payload_shape(self, nav_writer, mock_s3):
+        nav_writer.write(_ACCT, spy_last=740.96, ib_connected=True)
+        body = json.loads(mock_s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert body["net_liquidation"] == 1_000_564.85
+        assert body["total_cash"] == 28_634.48
+        assert body["gross_position_value"] == 971_930.37
+        assert body["unrealized_pnl"] == -10_465.16
+        assert body["spy_last"] == 740.96
+        assert body["ib_connected"] is True
+        assert "timestamp" in body
+        # Raw marks only — no derived return/alpha leaks into the producer.
+        assert "settled_cash" not in body
+        assert "daily_return" not in body and "alpha" not in body
+
+    def test_missing_account_fields_become_null(self, nav_writer, mock_s3):
+        nav_writer.write({}, spy_last=None, ib_connected=True)
+        body = json.loads(mock_s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert body["net_liquidation"] is None
+        assert body["spy_last"] is None
+
+    def test_disconnected_flag_stamped(self, nav_writer, mock_s3):
+        nav_writer.write(_ACCT, spy_last=740.96, ib_connected=False)
+        body = json.loads(mock_s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+        assert body["ib_connected"] is False
+
+
+class TestIntradayNavWriterFailureSwallowing:
+    def test_s3_error_returns_false_no_raise(self, mock_s3):
+        mock_s3.put_object.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied", "Message": "nope"}},
+            operation_name="PutObject",
+        )
+        writer = IntradayNavWriter(bucket="test-bucket", s3_client=mock_s3)
+        assert writer.write(_ACCT, spy_last=740.96, ib_connected=True) is False


### PR DESCRIPTION
## Summary
Publishes a live portfolio NAV snapshot from the daemon so `live.nousergon.ai` can show an **intraday** header (current NAV, today's return, today's alpha vs SPY) instead of only the last EOD close.

The daemon already holds an IB account-summary subscription and already publishes `intraday/latest_prices.json` + `heartbeat.json` + `trades/open_orders/latest.json` each poll tick — this adds one more fire-and-forget artifact alongside them.

## What it writes
`intraday/nav.json` (overwritten each tick, when IB-connected):
- `net_liquidation` (IB NetLiquidation — real-time, fill-inclusive ground truth)
- `total_cash`, `gross_position_value`, `unrealized_pnl`
- `spy_last` (SPY mark from the daemon price monitor — consumer needs it for today's alpha)
- `ib_connected`, `timestamp`

**Producer publishes RAW marks only.** The consumer (dashboard) derives today's return/alpha against the prior EOD baseline it already loads from `eod_pnl.csv`, so the display convention can change without redeploying the trading box.

## Safety
- Fire-and-forget — S3 failures log WARNING and never raise (acceptable swallow per the no-silent-fails rule: secondary observability whose sustained failure surfaces via heartbeat staleness, the same recording surface the price writer relies on).
- Only writes when `ib.isConnected()` — a NAV read off a dead session is meaningless.
- Shared S3 put factored into a module-level `_put_json_to_s3` helper used by both writers (no behavior change to the existing price/heartbeat writer).

## Tests
`tests/test_intraday_snapshot.py::TestIntradayNavWriter*` — happy path, raw-marks-only payload (asserts no derived return/alpha leaks), null-tolerance, disconnected flag, failure swallowing. **94 passed** across the intraday test group locally.

## Consumer
Paired dashboard PR (nousergon/crucible-dashboard) adds the live header strip on the Live Portfolio page. Goes to the **public** live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
