### PR TITLE
feat(daemon): append per-day intraday nav_series for the live curve

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -54,6 +54,7 @@ from executor.intraday_resolve import (
     solve_redeploy,
 )
 from executor.intraday_snapshot import (
+    IntradayNavSeriesWriter,
     IntradayNavWriter,
     IntradaySnapshotWriter,
     compute_surveillance_universe,
@@ -604,6 +605,11 @@ def run_daemon(dry_run: bool = False) -> None:
     # Same fire-and-forget contract as the writers above.
     nav_writer = IntradayNavWriter(bucket=config["signals_bucket"])
 
+    # Per-day NAV series writer — appends each tick's (NAV, SPY) point to
+    # intraday/nav_series/{run_date}.json so the live site can draw an
+    # intraday portfolio-vs-SPY curve, not just the latest number.
+    nav_series_writer = IntradayNavSeriesWriter(bucket=config["signals_bucket"])
+
     n_urgent = len(order_book.pending_urgent_exits())
     send_daemon_status(
         f"\u2705 *Daemon started*\n"
@@ -914,18 +920,25 @@ def run_daemon(dry_run: bool = False) -> None:
                 # exception from the writer leaks into the trade loop.
                 logger.warning("intraday snapshot writer raised: %s", _snap_err)
 
-            # ── Live-NAV snapshot ────────────────────────────────────
-            # Publish intraday/nav.json (IB NetLiquidation + SPY mark) so
-            # live.nousergon.ai renders a live intraday header. Only when
-            # connected — a NAV read off a dead session is meaningless.
-            # Fire-and-forget; same defensive belt as the writers above.
+            # ── Live-NAV snapshot + series ───────────────────────────
+            # Publish intraday/nav.json (latest NetLiquidation + SPY mark)
+            # for the live header, and append the same point to the per-day
+            # nav_series for the intraday curve. Only when connected — a NAV
+            # read off a dead session is meaningless. One get_account_snapshot
+            # call feeds both writers. Fire-and-forget; same defensive belt.
             try:
                 if ibkr.ib.isConnected():
-                    spy_state = monitor.prices.get("SPY") or {}
+                    spy_last = (monitor.prices.get("SPY") or {}).get("last")
+                    account_snapshot = ibkr.get_account_snapshot()
                     nav_writer.write(
-                        ibkr.get_account_snapshot(),
-                        spy_last=spy_state.get("last"),
+                        account_snapshot,
+                        spy_last=spy_last,
                         ib_connected=True,
+                    )
+                    nav_series_writer.write(
+                        run_date,
+                        account_snapshot,
+                        spy_last=spy_last,
                     )
             except Exception as _nav_err:  # noqa: BLE001
                 logger.warning("nav snapshot writer raised: %s", _nav_err)

--- a/executor/intraday_snapshot.py
+++ b/executor/intraday_snapshot.py
@@ -44,6 +44,12 @@ logger = logging.getLogger(__name__)
 LATEST_PRICES_KEY = "intraday/latest_prices.json"
 HEARTBEAT_KEY = "intraday/heartbeat.json"
 NAV_KEY = "intraday/nav.json"
+NAV_SERIES_PREFIX = "intraday/nav_series/"
+
+# Defensive cap on per-day series length. At a 60s poll the daemon writes
+# ~390 points across a session; 2000 leaves generous headroom for a faster
+# poll interval while bounding the read-modify-write object size.
+_MAX_SERIES_POINTS = 2000
 
 
 def _put_json_to_s3(s3: Any, bucket: str, key: str, payload: dict) -> bool:
@@ -70,6 +76,32 @@ def _put_json_to_s3(s3: Any, bucket: str, key: str, payload: dict) -> bool:
             bucket, key, type(e).__name__,
         )
         return False
+
+
+def _get_json_from_s3(s3: Any, bucket: str, key: str) -> tuple[dict | None, str]:
+    """GET + parse a JSON object. Returns ``(payload, status)``.
+
+    ``status`` is one of:
+    - ``"ok"`` — parsed dict returned;
+    - ``"missing"`` — object absent (NoSuchKey/404), an expected state
+      (e.g. the first tick of a trading day);
+    - ``"error"`` — a transient failure; callers doing read-modify-write
+      MUST NOT treat this as "empty" and clobber the existing object.
+    """
+    try:
+        resp = s3.get_object(Bucket=bucket, Key=key)
+        return json.loads(resp["Body"].read()), "ok"
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404"):
+            return None, "missing"
+        logger.warning("intraday read s3://%s/%s failed (%s)", bucket, key, code)
+        return None, "error"
+    except (BotoCoreError, ValueError) as e:
+        logger.warning(
+            "intraday read s3://%s/%s failed (%s)", bucket, key, type(e).__name__
+        )
+        return None, "error"
 
 
 def compute_surveillance_universe(
@@ -260,3 +292,83 @@ class IntradayNavWriter:
             "spy_last": spy_last,
         }
         return _put_json_to_s3(self._s3, self._bucket, NAV_KEY, payload)
+
+
+class IntradayNavSeriesWriter:
+    """Appends a per-tick (NAV, SPY) point to a per-day intraday series.
+
+    Powers the intraday portfolio-vs-SPY curve on live.nousergon.ai. Unlike
+    ``IntradayNavWriter`` (a single overwritten snapshot for the live
+    header numbers), this accumulates the day's points into
+    ``intraday/nav_series/{trading_day}.json`` so the consumer can draw a
+    line, not just a number.
+
+    **Single-writer read-modify-write.** The daemon is the only writer of
+    this object and its poll loop is single-threaded, so RMW is race-free.
+    A transient READ error skips the append rather than clobbering the
+    day's history with a fresh list; a missing object (first tick of the
+    day) starts a new series. Fire-and-forget on write like the other
+    intraday writers — a failed point is a dropped chart sample, never an
+    interruption to the order loop.
+    """
+
+    def __init__(
+        self,
+        bucket: str,
+        *,
+        s3_client: Any | None = None,
+        max_points: int = _MAX_SERIES_POINTS,
+    ) -> None:
+        self._bucket = bucket
+        self._s3 = s3_client if s3_client is not None else boto3.client("s3")
+        self._max_points = max_points
+
+    @staticmethod
+    def key_for(trading_day: str) -> str:
+        return f"{NAV_SERIES_PREFIX}{trading_day}.json"
+
+    def write(
+        self,
+        trading_day: str,
+        account_snapshot: dict,
+        *,
+        spy_last: float | None,
+    ) -> bool:
+        """Append today's current (NAV, SPY) point to the per-day series.
+
+        :param trading_day: The series key date (the daemon's run_date).
+        :param account_snapshot: ``ibkr.get_account_snapshot()`` — only
+            ``net_liquidation`` is charted; a point with no NAV is skipped.
+        :param spy_last: SPY mark from the price monitor (may be ``None``
+            before SPY has a live tick; stored as-is for the consumer).
+        :returns: ``True`` on a successful append+write, ``False`` if the
+            point was skipped (no NAV / transient read error) or the write
+            failed.
+        """
+        nav = account_snapshot.get("net_liquidation")
+        if nav is None:
+            return False
+
+        key = self.key_for(trading_day)
+        existing, status = _get_json_from_s3(self._s3, self._bucket, key)
+        if status == "error":
+            # Don't clobber the day's history on a transient read failure.
+            return False
+
+        points: list = []
+        if status == "ok" and isinstance(existing, dict):
+            prior = existing.get("points")
+            if isinstance(prior, list):
+                points = prior
+
+        now_iso = datetime.utcnow().isoformat() + "Z"
+        points.append({"t": now_iso, "nav": nav, "spy": spy_last})
+        if len(points) > self._max_points:
+            points = points[-self._max_points:]
+
+        payload = {
+            "trading_day": trading_day,
+            "updated_at": now_iso,
+            "points": points,
+        }
+        return _put_json_to_s3(self._s3, self._bucket, key, payload)

--- a/tests/test_intraday_snapshot.py
+++ b/tests/test_intraday_snapshot.py
@@ -16,6 +16,8 @@ from executor.intraday_snapshot import (
     HEARTBEAT_KEY,
     LATEST_PRICES_KEY,
     NAV_KEY,
+    NAV_SERIES_PREFIX,
+    IntradayNavSeriesWriter,
     IntradayNavWriter,
     IntradaySnapshotWriter,
     compute_surveillance_universe,
@@ -284,3 +286,112 @@ class TestIntradayNavWriterFailureSwallowing:
         )
         writer = IntradayNavWriter(bucket="test-bucket", s3_client=mock_s3)
         assert writer.write(_ACCT, spy_last=740.96, ib_connected=True) is False
+
+
+# ── IntradayNavSeriesWriter ─────────────────────────────────────────────────
+
+
+def _get_body(payload: dict) -> dict:
+    """Build a mock get_object response wrapping ``payload`` as JSON bytes."""
+    body = MagicMock()
+    body.read.return_value = json.dumps(payload).encode("utf-8")
+    return {"Body": body}
+
+
+def _no_such_key():
+    return ClientError(
+        error_response={"Error": {"Code": "NoSuchKey", "Message": "absent"}},
+        operation_name="GetObject",
+    )
+
+
+def _written_payload(mock_s3) -> dict:
+    return json.loads(mock_s3.put_object.call_args.kwargs["Body"].decode("utf-8"))
+
+
+@pytest.fixture
+def series_writer(mock_s3):
+    return IntradayNavSeriesWriter(bucket="test-bucket", s3_client=mock_s3)
+
+
+class TestIntradayNavSeriesWriter:
+    def test_key_format(self):
+        assert IntradayNavSeriesWriter.key_for("2026-06-18") == (
+            NAV_SERIES_PREFIX + "2026-06-18.json"
+        )
+
+    def test_first_tick_starts_new_series(self, series_writer, mock_s3):
+        mock_s3.get_object.side_effect = _no_such_key()
+        ok = series_writer.write("2026-06-18", _ACCT, spy_last=740.96)
+        assert ok is True
+        call = mock_s3.put_object.call_args
+        assert call.kwargs["Key"] == NAV_SERIES_PREFIX + "2026-06-18.json"
+        body = _written_payload(mock_s3)
+        assert body["trading_day"] == "2026-06-18"
+        assert len(body["points"]) == 1
+        p = body["points"][0]
+        assert p["nav"] == _ACCT["net_liquidation"]
+        assert p["spy"] == 740.96
+        assert "t" in p
+
+    def test_appends_to_existing_series(self, series_writer, mock_s3):
+        prior = {
+            "trading_day": "2026-06-18",
+            "points": [{"t": "2026-06-18T13:45:00Z", "nav": 999_000.0, "spy": 739.0}],
+        }
+        mock_s3.get_object.return_value = _get_body(prior)
+        series_writer.write("2026-06-18", _ACCT, spy_last=740.96)
+        body = _written_payload(mock_s3)
+        assert len(body["points"]) == 2
+        assert body["points"][0]["nav"] == 999_000.0  # prior preserved
+        assert body["points"][1]["nav"] == _ACCT["net_liquidation"]  # new appended
+
+    def test_no_nav_skips_write(self, series_writer, mock_s3):
+        ok = series_writer.write("2026-06-18", {}, spy_last=740.96)
+        assert ok is False
+        mock_s3.get_object.assert_not_called()
+        mock_s3.put_object.assert_not_called()
+
+    def test_transient_read_error_does_not_clobber(self, series_writer, mock_s3):
+        mock_s3.get_object.side_effect = ClientError(
+            error_response={"Error": {"Code": "ServiceUnavailable"}},
+            operation_name="GetObject",
+        )
+        ok = series_writer.write("2026-06-18", _ACCT, spy_last=740.96)
+        assert ok is False
+        # Critically: no PUT — we must not overwrite the day's history with a
+        # fresh single-point list on a transient read failure.
+        mock_s3.put_object.assert_not_called()
+
+    def test_max_points_trims_oldest(self, mock_s3):
+        writer = IntradayNavSeriesWriter(
+            bucket="test-bucket", s3_client=mock_s3, max_points=3
+        )
+        prior = {
+            "trading_day": "2026-06-18",
+            "points": [
+                {"t": "t1", "nav": 1.0, "spy": 1.0},
+                {"t": "t2", "nav": 2.0, "spy": 2.0},
+                {"t": "t3", "nav": 3.0, "spy": 3.0},
+            ],
+        }
+        mock_s3.get_object.return_value = _get_body(prior)
+        writer.write("2026-06-18", _ACCT, spy_last=740.96)
+        body = _written_payload(mock_s3)
+        assert len(body["points"]) == 3
+        assert body["points"][0]["nav"] == 2.0  # oldest (t1) dropped
+        assert body["points"][-1]["nav"] == _ACCT["net_liquidation"]
+
+    def test_spy_none_stored(self, series_writer, mock_s3):
+        mock_s3.get_object.side_effect = _no_such_key()
+        series_writer.write("2026-06-18", _ACCT, spy_last=None)
+        body = _written_payload(mock_s3)
+        assert body["points"][0]["spy"] is None
+
+    def test_put_failure_returns_false(self, series_writer, mock_s3):
+        mock_s3.get_object.side_effect = _no_such_key()
+        mock_s3.put_object.side_effect = ClientError(
+            error_response={"Error": {"Code": "AccessDenied"}},
+            operation_name="PutObject",
+        )
+        assert series_writer.write("2026-06-18", _ACCT, spy_last=740.96) is False


### PR DESCRIPTION
## Summary
Follow-up to #266. Adds the per-day **NAV series** the live intraday *curve* needs — #266 published a single overwritten snapshot (`intraday/nav.json`) good for the live header *number*; this accumulates the day's points so the dashboard can draw a *line*.

Each poll tick (when IB-connected) the daemon appends a `{t, nav, spy}` point to `intraday/nav_series/{trading_day}.json`.

## Design
- **Single-writer read-modify-write.** The daemon is the only writer and its poll loop is single-threaded → RMW is race-free.
- **Robust RMW:** a transient READ error *skips* the append (never clobbers the day's history with a fresh single-point list); a missing object (first tick of the day) starts a new series; points capped at 2000.
- **One IB call feeds both writers** — folded into the existing nav block so `get_account_snapshot()` isn't called twice per tick.
- Fire-and-forget on write, same contract as the existing intraday writers. New `_get_json_from_s3` helper returns `(payload, status)` with status `ok`/`missing`/`error` so RMW can tell "absent" from "transient failure".

## Tests
`tests/test_intraday_snapshot.py::TestIntradayNavSeriesWriter` (8) — new-series, append-preserves-prior, no-NAV skip, **transient-read-no-clobber**, max-points trim, spy-None, put-failure, key format. **37 passed** in the intraday group.

## Consumer
Paired dashboard PR adds the intraday portfolio-vs-SPY curve under the live header. Public site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
