### PR TITLE
feat(eod): publish illustrative Reference Rate showcase artifact for Metron

### DIFF
--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -20,6 +20,7 @@ import pandas as pd
 import yaml
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+from executor import reference_rate
 from executor.eod_emailer import send_eod_email
 from executor.trade_logger import (
     init_db, log_eod, backup_to_s3, get_entry_trade, get_todays_trades,
@@ -835,6 +836,22 @@ def run(run_date: str | None = None) -> None:
             logger.info(f"Exported {key} ({len(df)} rows) to s3://{trades_bucket}/{key}")
         except Exception as e:
             logger.warning(f"S3 CSV export failed for {key}: {e}")
+
+    # ── Reference-rate showcase artifact (metron/reference_rate.json) ─────────
+    # Publish the illustrative-only Reference Rate contract artifact Metron renders
+    # as a demo portfolio. Best-effort: it is secondary observability hung off the
+    # already-committed eod_pnl + S3 CSV exports (recording surface = this WARN), so
+    # a publish failure must never override the EOD run's primary deliverables.
+    try:
+        ref_payload = reference_rate.build_payload(
+            positions=positions,
+            nav=nav,
+            nav_history=reference_rate.nav_history_from_eod_df(eod_df),
+            run_date=run_date,
+        )
+        reference_rate.publish(s3, trades_bucket, ref_payload)
+    except Exception as e:  # noqa: BLE001 — best-effort secondary path; never fatal
+        logger.warning("Reference-rate artifact publish failed (non-fatal): %s", e)
 
     backup_to_s3(db_path, run_date, trades_bucket)
 

--- a/executor/reference_rate.py
+++ b/executor/reference_rate.py
@@ -1,0 +1,150 @@
+"""Reference-rate showcase artifact — the public, illustrative-only cross-repo
+contract Metron consumes to render the "Reference Rate" demo portfolio.
+
+This is a PRODUCT CONTRACT (per the M0 slot discipline in ~/Development/CLAUDE.md):
+a versioned, purpose-built artifact at a stable key. Metron MUST consume THIS, never
+reach around it into the executor's producer-private `trades/snapshots/` path.
+
+Disclosure scope (deliberately minimal — illustrative only, no claims):
+  * current positions (ticker / shares / avg_cost / market_value / sector)
+  * portfolio NAV (net_liquidation only)
+  * a NAV-vs-SPY history series (the illustrative performance curve)
+
+What it MUST NOT carry (kept private — strategy edge / assumptions / internals):
+  * scoring weights, model params, predictions, signal logic
+  * buying power, settled cash, realized/unrealized P&L attribution, accrued interest
+
+No performance claims and no stated objective live in this artifact or its consumer
+copy — it is a "reference rate", illustrative and demo-only.
+
+S3 path: s3://alpha-engine-research/metron/reference_rate.json
+
+Schema (additive-only per CLAUDE.md S3 contract):
+    {
+      "schema_version": 1,
+      "as_of": "YYYY-MM-DD",            # run_date (trading_day)
+      "generated_at": ISO8601 UTC,
+      "label": "Reference Rate",
+      "disclaimer": str,                # illustrative-only, no-claims notice
+      "base_currency": "USD",
+      "account": {"net_liquidation": float},
+      "positions": [
+        {"ticker": str, "shares": float, "avg_cost": float,
+         "market_value": float, "sector": str}
+      ],
+      "nav_history": [
+        {"date": "YYYY-MM-DD", "nav": float, "spy_close": float | null}
+      ],
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+REFERENCE_RATE_KEY = "metron/reference_rate.json"
+LABEL = "Reference Rate"
+DISCLAIMER = (
+    "Illustrative reference portfolio. Not investment advice; "
+    "no representation is made as to performance."
+)
+
+# History depth published in the artifact (trading days). ~2y is enough for the
+# illustrative NAV-vs-SPY curve without bloating the object; the executor's full
+# eod_pnl history stays internal.
+_NAV_HISTORY_MAX_ROWS = 504
+
+
+def build_payload(
+    positions: dict[str, dict[str, Any]],
+    nav: float | None,
+    nav_history: list[dict[str, Any]],
+    run_date: str,
+) -> dict[str, Any]:
+    """Build the reference-rate artifact from the EOD reconcile's in-memory state.
+
+    Pure (no I/O) so it is unit-testable. ``positions`` is the enriched EOD positions
+    dict (ticker -> {shares, market_value, avg_cost, sector, ...}); only the disclosed
+    subset of fields is copied through. ``nav_history`` is a list of
+    {date, nav, spy_close} rows (oldest-first); it is truncated to the most recent
+    ``_NAV_HISTORY_MAX_ROWS``. Internal attribution fields (daily_return_*,
+    alpha_contribution_*, unrealized_pnl) are intentionally NOT copied.
+    """
+    out_positions: list[dict[str, Any]] = []
+    for ticker, pos in sorted(positions.items()):
+        shares = pos.get("shares")
+        if not shares:  # closed / zero-share rows are not holdings
+            continue
+        out_positions.append(
+            {
+                "ticker": ticker,
+                "shares": shares,
+                "avg_cost": pos.get("avg_cost"),
+                "market_value": pos.get("market_value"),
+                "sector": pos.get("sector") or "Unknown",
+            }
+        )
+
+    history = [
+        {"date": row["date"], "nav": row.get("nav"), "spy_close": row.get("spy_close")}
+        for row in nav_history
+        if row.get("date") is not None and row.get("nav") is not None
+    ]
+    history = history[-_NAV_HISTORY_MAX_ROWS:]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "as_of": run_date,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "label": LABEL,
+        "disclaimer": DISCLAIMER,
+        "base_currency": "USD",
+        "account": {"net_liquidation": nav},
+        "positions": out_positions,
+        "nav_history": history,
+    }
+
+
+def nav_history_from_eod_df(eod_df) -> list[dict[str, Any]]:
+    """Extract the {date, nav, spy_close} history rows from the eod_pnl DataFrame.
+
+    Tolerant of missing columns / NaNs — a row with no NAV is dropped (the artifact
+    never fabricates a value). Oldest-first; ``build_payload`` truncates the tail.
+    """
+    rows: list[dict[str, Any]] = []
+    if eod_df is None or len(eod_df) == 0:
+        return rows
+    for _, r in eod_df.iterrows():
+        nav = r.get("portfolio_nav")
+        date_val = r.get("date")
+        if date_val is None or nav is None or (isinstance(nav, float) and nav != nav):
+            continue
+        spy = r.get("spy_close")
+        spy = None if (spy is None or (isinstance(spy, float) and spy != spy)) else float(spy)
+        rows.append({"date": str(date_val), "nav": float(nav), "spy_close": spy})
+    return rows
+
+
+def publish(s3, bucket: str, payload: dict[str, Any]) -> None:
+    """Write the artifact to S3. Raises on failure — the caller wraps this best-effort
+    (it is secondary observability hung off the already-committed EOD path)."""
+    s3.put_object(
+        Bucket=bucket,
+        Key=REFERENCE_RATE_KEY,
+        Body=json.dumps(payload, default=str).encode("utf-8"),
+        ContentType="application/json",
+    )
+    logger.info(
+        "Reference-rate artifact written | s3://%s/%s as_of=%s positions=%d nav_history=%d",
+        bucket,
+        REFERENCE_RATE_KEY,
+        payload.get("as_of"),
+        len(payload.get("positions", [])),
+        len(payload.get("nav_history", [])),
+    )

--- a/tests/test_reference_rate_artifact.py
+++ b/tests/test_reference_rate_artifact.py
@@ -1,0 +1,172 @@
+"""Producer contract test for the reference-rate showcase artifact.
+
+Guards the cross-repo contract Metron consumes (metron/reference_rate.json):
+required keys + shape are stable, AND — the privacy invariant — no strategy-edge /
+internal field ever leaks into the published object. Mirrors the
+producer-side-contract pattern (test_executor_params_consumer_contract.py).
+"""
+
+import json
+
+import pandas as pd
+import pytest
+
+from executor import reference_rate
+
+# Fields that MUST NEVER appear anywhere in the published artifact — strategy edge,
+# assumptions, or account internals. The artifact is illustrative-only.
+_FORBIDDEN_KEYS = {
+    "weights",
+    "scoring",
+    "scores",
+    "score",
+    "model",
+    "params",
+    "predictions",
+    "signal",
+    "conviction",
+    "buying_power",
+    "settled_cash",
+    "realized_pnl",
+    "unrealized_pnl",
+    "accrued_interest",
+    "accrued_dividends",
+    "daily_return_usd",
+    "daily_return_pct",
+    "alpha_contribution_usd",
+    "alpha_contribution_pct",
+}
+
+
+def _sample_positions():
+    # Enriched EOD positions dict shape (mirrors eod_reconcile in-memory state),
+    # deliberately carrying internal attribution fields that MUST be stripped.
+    return {
+        "AMD": {
+            "shares": 192,
+            "market_value": 103175.04,
+            "avg_cost": 130.5,
+            "sector": "Information Technology",
+            "unrealized_pnl": 18000.0,
+            "daily_return_usd": 1234.5,
+            "alpha_contribution_pct": 0.12,
+        },
+        "SPY": {
+            "shares": 658,
+            "market_value": 491354.92,
+            "avg_cost": 600.0,
+            "sector": "Broad Market",
+        },
+        "CLOSED": {  # zero-share row — not a holding, must be dropped
+            "shares": 0,
+            "market_value": 0.0,
+            "avg_cost": 50.0,
+            "sector": "Industrials",
+        },
+    }
+
+
+def _walk_keys(obj):
+    """Yield every dict key appearing anywhere in a nested structure."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield k
+            yield from _walk_keys(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk_keys(item)
+
+
+def test_build_payload_required_keys_and_shape():
+    nav_history = [
+        {"date": "2026-06-17", "nav": 1_000_000.0, "spy_close": 745.0},
+        {"date": "2026-06-18", "nav": 1_001_593.11, "spy_close": 746.74},
+    ]
+    payload = reference_rate.build_payload(
+        positions=_sample_positions(),
+        nav=1_001_593.11,
+        nav_history=nav_history,
+        run_date="2026-06-18",
+    )
+
+    assert payload["schema_version"] == reference_rate.SCHEMA_VERSION
+    assert payload["as_of"] == "2026-06-18"
+    assert payload["base_currency"] == "USD"
+    assert payload["label"] == reference_rate.LABEL
+    assert payload["disclaimer"]  # non-empty illustrative-only notice
+    assert payload["account"] == {"net_liquidation": 1_001_593.11}
+
+    # Positions: zero-share row dropped, only the disclosed fields present.
+    tickers = {p["ticker"] for p in payload["positions"]}
+    assert tickers == {"AMD", "SPY"}
+    for p in payload["positions"]:
+        assert set(p) == {"ticker", "shares", "avg_cost", "market_value", "sector"}
+
+    assert payload["nav_history"] == nav_history
+
+
+def test_privacy_no_forbidden_keys_leak():
+    payload = reference_rate.build_payload(
+        positions=_sample_positions(),
+        nav=1_001_593.11,
+        nav_history=[{"date": "2026-06-18", "nav": 1_001_593.11, "spy_close": 746.74}],
+        run_date="2026-06-18",
+    )
+    leaked = set(_walk_keys(payload)) & _FORBIDDEN_KEYS
+    assert not leaked, f"strategy-internal fields leaked into the artifact: {leaked}"
+
+
+def test_payload_json_serializable():
+    payload = reference_rate.build_payload(
+        positions=_sample_positions(),
+        nav=1_001_593.11,
+        nav_history=[{"date": "2026-06-18", "nav": 1_001_593.11, "spy_close": 746.74}],
+        run_date="2026-06-18",
+    )
+    # Round-trips with the same default=str publish() uses.
+    assert json.loads(json.dumps(payload, default=str))["positions"]
+
+
+def test_nav_history_from_eod_df_tolerates_gaps_and_truncates():
+    df = pd.DataFrame(
+        [
+            {"date": "2026-06-16", "portfolio_nav": 999_000.0, "spy_close": 744.0},
+            {"date": "2026-06-17", "portfolio_nav": None, "spy_close": 745.0},  # dropped
+            {"date": "2026-06-18", "portfolio_nav": 1_001_593.11, "spy_close": None},  # spy null OK
+        ]
+    )
+    rows = reference_rate.nav_history_from_eod_df(df)
+    assert [r["date"] for r in rows] == ["2026-06-16", "2026-06-18"]
+    assert rows[-1]["spy_close"] is None
+    assert rows[0]["spy_close"] == 744.0
+
+
+def test_nav_history_truncates_to_max_rows():
+    df = pd.DataFrame(
+        [{"date": f"2024-{(i % 12) + 1:02d}-01", "portfolio_nav": float(i), "spy_close": 1.0}
+         for i in range(reference_rate._NAV_HISTORY_MAX_ROWS + 50)]
+    )
+    history = reference_rate.nav_history_from_eod_df(df)
+    payload = reference_rate.build_payload({}, 0.0, history, "2024-01-01")
+    assert len(payload["nav_history"]) == reference_rate._NAV_HISTORY_MAX_ROWS
+
+
+def test_nav_history_empty_df():
+    assert reference_rate.nav_history_from_eod_df(None) == []
+    assert reference_rate.nav_history_from_eod_df(pd.DataFrame()) == []
+
+
+def test_publish_writes_expected_key():
+    captured = {}
+
+    class _FakeS3:
+        def put_object(self, **kw):
+            captured.update(kw)
+
+    payload = reference_rate.build_payload(
+        {}, 0.0, [{"date": "2026-06-18", "nav": 1.0, "spy_close": None}], "2026-06-18"
+    )
+    reference_rate.publish(_FakeS3(), "alpha-engine-research", payload)
+    assert captured["Key"] == reference_rate.REFERENCE_RATE_KEY
+    assert captured["Bucket"] == "alpha-engine-research"
+    assert json.loads(captured["Body"])["label"] == reference_rate.LABEL


### PR DESCRIPTION
Publishes a versioned, illustrative-only contract artifact (`metron/reference_rate.json`) from the EOD reconcile so Metron can render the paper portfolio as a read-only **"Reference Rate"** showcase. Framed as a reference rate: no performance claims, no stated objective.

## What
- New `executor/reference_rate.py`: pure `build_payload` + `publish`, called **best-effort / fail-soft** from `eod_reconcile.run()` right after the CSV export — hung off the already-committed `eod_pnl` + S3 exports, so a publish failure WARNs and never costs the primary EOD deliverables (per the no-silent-fails rule, the WARN is the recording surface).
- Artifact carries **only** the disclosed surface: current positions (ticker/shares/avg_cost/market_value/sector), NAV (`net_liquidation`), and a NAV-vs-SPY history series.

## Privacy (deliberately minimal)
No scoring weights, model params, predictions, signal logic, buying power, settled cash, or P&L attribution ever enter the artifact. `tests/test_reference_rate_artifact.py` asserts the privacy invariant (forbidden keys absent at any nesting level) alongside the schema. This is **better** than letting a consumer read the producer-private `trades/snapshots/` path, and follows the M0 slot-contract discipline (consume a stable published artifact, not internals).

## Tests
`tests/test_reference_rate_artifact.py` (7) + existing `test_eod_reconcile*` (56) green locally.

Consumer side: nousergon/metron `feat/reference-rate-portfolio` (consumes this artifact's schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)