### PR TITLE
chore(deps): repin nousergon-lib v0.60.1 (flow-doctor SSM seed fix, config#1148)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,13 +42,15 @@ requests~=2.32
 # setup_logging()/_attach_flow_doctor() before flow_doctor.init() reads
 # os.environ — closes the PR 9g systemd-entrypoint env gap upstream for
 # all repos (replaces the executor-local secrets_bootstrap.py approach).
-# Pinned at v0.33.0 — executor uses setup_logging/secrets/dates/eval_
-# artifacts/alerts/universe/telegram/decision_capture/preflight/trading_
-# calendar surfaces. The cost-telemetry primitives shipped at v0.30+
-# are NOT consumed here (executor has no LLM exposure per
-# [[preference_llm_calls_confined_to_research_module]]) but the
-# transitive lib pin stays current.
-alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.59.1
+# Executor uses setup_logging/secrets/dates/eval_artifacts/alerts/universe/
+# telegram/decision_capture/preflight/trading_calendar surfaces. The
+# cost-telemetry primitives are NOT consumed here (executor has no LLM
+# exposure per [[preference_llm_calls_confined_to_research_module]]) but the
+# lib pin stays current.
+# v0.60.1 (2026-06-18): SSM-authoritative flow-doctor secret seed when deployed
+# — overwrites a stale sourced FLOW_DOCTOR_GITHUB_TOKEN with the live SSM value
+# so the github_issue notifier stops 403ing on the EOD/executor path (config#1148).
+alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.1
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ requests~=2.32
 # v0.60.1 (2026-06-18): SSM-authoritative flow-doctor secret seed when deployed
 # — overwrites a stale sourced FLOW_DOCTOR_GITHUB_TOKEN with the live SSM value
 # so the github_issue notifier stops 403ing on the EOD/executor path (config#1148).
-alpha-engine-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.1
+nousergon-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.1
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,10 +47,10 @@ requests~=2.32
 # cost-telemetry primitives are NOT consumed here (executor has no LLM
 # exposure per [[preference_llm_calls_confined_to_research_module]]) but the
 # lib pin stays current.
-# v0.60.1 (2026-06-18): SSM-authoritative flow-doctor secret seed when deployed
+# v0.60.2 (2026-06-18): SSM-authoritative seed + alpha_engine_lib alias resource-loading shim fix; earlier v0.60.1 flow-doctor secret seed when deployed
 # — overwrites a stale sourced FLOW_DOCTOR_GITHUB_TOKEN with the live SSM value
 # so the github_issue notifier stops 403ing on the EOD/executor path (config#1148).
-nousergon-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.1
+nousergon-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.2
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
Repins nousergon-lib v0.59.1 → v0.60.1 to pick up #125 (SSM-authoritative flow-doctor secret seed when deployed). Combined with nousergon-data's EOD `ALPHA_ENGINE_DEPLOYED=1`, the EOD/executor flow-doctor github_issue notifier now resolves the live SSM `FLOW_DOCTOR_GITHUB_TOKEN` instead of the stale `.env` value → stops the 403 storm (config#1148). Box picks this up on next boot. requirements.txt only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)