### PR TITLE
feat(config): experiment-package-first risk.yaml resolution (config#1042)

### DIFF
--- a/executor/config_loader.py
+++ b/executor/config_loader.py
@@ -10,9 +10,21 @@ against the placeholder bucket → 404 surfaced as a cryptic
 the executor-sim call chain.
 
 Search order (example template NOT a fallback — copyable only):
-  1. ~/alpha-engine-config/executor/risk.yaml  (EC2 — config repo cloned at home)
-  2. {repo_root}/../alpha-engine-config/executor/risk.yaml  (local dev — sibling directory)
-  3. {repo_root}/config/risk.yaml  (legacy fallback)
+  1. ~/alpha-engine-config/experiments/$ALPHA_ENGINE_EXPERIMENT_ID/executor/risk.yaml
+  2. {repo_root}/../alpha-engine-config/experiments/$EXP/executor/risk.yaml
+  3. ~/alpha-engine-config/executor/risk.yaml          (legacy top-level)
+  4. {repo_root}/../alpha-engine-config/executor/risk.yaml  (legacy, sibling)
+  5. {repo_root}/config/risk.yaml                      (legacy repo-local)
+
+Experiment-package resolution (config#1042, HARNESS_EXPERIMENT_CLASSIFICATION
+§3): the executor's risk beliefs load from
+``experiments/$ALPHA_ENGINE_EXPERIMENT_ID/executor/risk.yaml`` (default
+experiment ``reference``) ahead of the legacy top-level ``executor/risk.yaml``,
+which is retained as a fallback through the transition. Mirrors the loader in
+alpha-engine-research/config.py::_find_config and
+alpha-engine-data/weekly_collector.py::load_config. The experiment id is read
+from the environment at import time (consistent with the sibling loaders) — set
+``ALPHA_ENGINE_EXPERIMENT_ID`` before the process starts to select a slot.
 
 Path resolution is deliberately LAZY — consumers call ``get_config_path()``
 or ``load_config()`` at runtime, not at import time. An import-time
@@ -30,11 +42,28 @@ import yaml
 
 _REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 
-_SEARCH_PATHS = [
-    os.path.expanduser("~/alpha-engine-config/executor/risk.yaml"),
-    os.path.join(_REPO_ROOT, "..", "alpha-engine-config", "executor", "risk.yaml"),
-    os.path.join(_REPO_ROOT, "config", "risk.yaml"),
-]
+
+def _build_search_paths() -> list:
+    """Build the risk.yaml search order, experiment-package first (config#1042).
+
+    Returns the ordered candidate paths: the experiment-package copy under
+    ``experiments/$ALPHA_ENGINE_EXPERIMENT_ID/executor/`` in the config repo
+    first, then the legacy top-level ``executor/`` config-repo path, then the
+    legacy repo-local ``config/risk.yaml``. The ``.example`` template is never
+    a candidate (see module docstring).
+    """
+    exp = os.environ.get("ALPHA_ENGINE_EXPERIMENT_ID", "reference")
+    config_roots = [
+        os.path.expanduser("~/alpha-engine-config"),
+        os.path.join(_REPO_ROOT, "..", "alpha-engine-config"),
+    ]
+    paths = [os.path.join(r, "experiments", exp, "executor", "risk.yaml") for r in config_roots]
+    paths += [os.path.join(r, "executor", "risk.yaml") for r in config_roots]
+    paths.append(os.path.join(_REPO_ROOT, "config", "risk.yaml"))
+    return paths
+
+
+_SEARCH_PATHS = _build_search_paths()
 
 
 def get_config_path() -> str:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,11 +1,33 @@
 """Tests for executor.config_loader — risk.yaml resolution with no silent fallback."""
 
+import importlib
 import os
 
 import pytest
 import yaml
 
 from executor import config_loader
+
+
+def test_search_paths_experiment_package_first(monkeypatch):
+    """Experiment-package risk.yaml resolves ahead of the legacy top-level path (config#1042)."""
+    monkeypatch.setenv("ALPHA_ENGINE_EXPERIMENT_ID", "myexp")
+    paths = config_loader._build_search_paths()
+    # First candidate must be the experiment-package copy for the selected slot.
+    assert paths[0].endswith(os.path.join("experiments", "myexp", "executor", "risk.yaml"))
+    # The legacy top-level config-repo path must still be present, AFTER all package paths.
+    legacy_idx = next(i for i, p in enumerate(paths) if p.endswith(os.path.join("alpha-engine-config", "executor", "risk.yaml")))
+    pkg_idx = next(i for i, p in enumerate(paths) if "myexp" in p)
+    assert pkg_idx < legacy_idx
+    # The repo-local legacy fallback remains last.
+    assert paths[-1].endswith(os.path.join("config", "risk.yaml"))
+
+
+def test_search_paths_default_experiment_is_reference(monkeypatch):
+    """With no ALPHA_ENGINE_EXPERIMENT_ID set, the default experiment is `reference`."""
+    monkeypatch.delenv("ALPHA_ENGINE_EXPERIMENT_ID", raising=False)
+    paths = config_loader._build_search_paths()
+    assert paths[0].endswith(os.path.join("experiments", "reference", "executor", "risk.yaml"))
 
 
 def test_get_config_path_returns_first_match(tmp_path, monkeypatch):


### PR DESCRIPTION
Step 1 of **config#1042** (experiment-package adoption).

## What
`executor/config_loader.py` now resolves `risk.yaml` from `experiments/$ALPHA_ENGINE_EXPERIMENT_ID/executor/risk.yaml` (default experiment `reference`) **ahead of** the legacy top-level `executor/risk.yaml`, which is retained as a fallback through the transition.

Mirrors the loaders already shipped in `alpha-engine-research/config.py::_find_config` (research#285) and `alpha-engine-data/features/feature_engineer.py`.

## Notes
- **flow-doctor.yaml is out of scope here** — it is repo-local (`{repo_root}/flow-doctor.yaml`, resolved in `main.py`/`daemon.py`/`eod_reconcile.py`/`snapshot_capturer.py`), NOT sourced from `alpha-engine-config`. The issue's "same for flow-doctor.yaml if applicable" therefore does not apply to the executor.
- `_SEARCH_PATHS` kept as a monkeypatchable module attribute so existing tests are unaffected. Experiment id read at import time, consistent with the sibling loaders.
- `.example` template remains intentionally un-searched (silent-fallthrough guard preserved).

## Tests
`tests/test_config_loader.py` — added package-first ordering + default-`reference` assertions. **7 passed** locally (`.venv`). Verified live resolution picks `experiments/reference/executor/risk.yaml`.

## Follow-ups (not in this PR)
- Sibling loader PRs for **data** (`weekly_collector.py::load_config`) and **backtester** (`config.yaml`) — same arc.
- **Lib consolidation**: this is now the 3rd–5th repo to mirror this resolver; will file a P2 to lift it into `nousergon-lib` per the SOTA cross-repo-consolidation sub-rule (kept inline here to match the research/predictor precedent and avoid lib-pin churn mid-arc).
- Legacy-dir removal (config#1042 step 4) is gated on all loader PRs merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)