### PR TITLE
chore: migrate alpha_engine_lib -> nousergon_lib imports (complete the 0.60.x crossing)

### DIFF
--- a/executor/daemon.py
+++ b/executor/daemon.py
@@ -68,7 +68,7 @@ from executor.price_monitor import PriceMonitor
 from executor.strategies.config import load_strategy_config
 from executor.trade_logger import init_db, log_trade, get_unmatched_entry
 
-from alpha_engine_lib.logging import setup_logging, guard_entrypoint
+from nousergon_lib.logging import setup_logging, guard_entrypoint
 # See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
@@ -393,7 +393,7 @@ def run_daemon(dry_run: bool = False) -> None:
     preflight.run()
 
     # Flow Doctor: retrieve the shared instance set up at module import
-    from alpha_engine_lib.logging import get_flow_doctor
+    from nousergon_lib.logging import get_flow_doctor
     fd = get_flow_doctor()
 
     global _allow_shorts

--- a/executor/decision_capture.py
+++ b/executor/decision_capture.py
@@ -7,7 +7,7 @@ the Saturday evaluator email. Per-component artifacts at
 
 Schema is the lib's ``DecisionArtifact`` with ``model_metadata=None`` and
 ``full_prompt_context=None`` (deterministic decision — see
-``alpha_engine_lib.decision_capture`` schema_version=2 lib v0.10.0+).
+``nousergon_lib.decision_capture`` schema_version=2 lib v0.10.0+).
 Producer provenance lives in ``input_data_snapshot._producer`` +
 ``_producer_version`` rather than the LLM ``model_metadata.model_name``
 field — the plan doc question 2 anchor.
@@ -40,7 +40,7 @@ import os
 import uuid
 from typing import Any
 
-from alpha_engine_lib.decision_capture import (
+from nousergon_lib.decision_capture import (
     DecisionCaptureWriteError,
     capture_decision,
 )

--- a/executor/eod_emailer.py
+++ b/executor/eod_emailer.py
@@ -438,10 +438,10 @@ def send_eod_email(
         except Exception as e:
             logger.warning("EOD email archival failed (non-fatal): %s", e)
 
-    # SMTP/SES dispatch via the alpha_engine_lib.email_sender chokepoint
+    # SMTP/SES dispatch via the nousergon_lib.email_sender chokepoint
     # (L4356 — Gmail SMTP primary, SES fallback). Identical semantics to
     # the pre-consolidation inline path.
-    from alpha_engine_lib.email_sender import send_email as _send_email
+    from nousergon_lib.email_sender import send_email as _send_email
     _send_email(
         subject, plain_body,
         recipients=recipients, html=html_body,

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -26,8 +26,8 @@ from executor.trade_logger import (
     init_db, log_eod, backup_to_s3, get_entry_trade, get_todays_trades,
 )
 
-from alpha_engine_lib.dates import now_dual
-from alpha_engine_lib.logging import setup_logging, guard_entrypoint
+from nousergon_lib.dates import now_dual
+from nousergon_lib.logging import setup_logging, guard_entrypoint
 # See executor/main.py for the rationale on IB Error 10197 / 10349 suppression.
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "flow-doctor.yaml")
@@ -397,7 +397,7 @@ def run(run_date: str | None = None) -> None:
     ExecutorPreflight(bucket=trades_bucket, mode="eod").run()
 
     # Flow Doctor: retrieve the shared instance set up at module import
-    from alpha_engine_lib.logging import get_flow_doctor
+    from nousergon_lib.logging import get_flow_doctor
     fd = get_flow_doctor()
 
     if not config.get("email_sender") or not config.get("email_recipients"):
@@ -1050,7 +1050,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=(
             "EOD reconciliation. Defaults to today's trading_day "
-            "(via alpha_engine_lib.dates.now_dual). Hard-fails on any "
+            "(via nousergon_lib.dates.now_dual). Hard-fails on any "
             "explicit --date that isn't today: live IB state would corrupt "
             "the historical row's NAV/positions."
         )

--- a/executor/intraday_snapshot.py
+++ b/executor/intraday_snapshot.py
@@ -24,7 +24,7 @@ the daemon's order-execution loop. Stale snapshots are visible to the
 surveillance Lambda via heartbeat-timestamp staleness, which is itself the
 designed alert signal.
 
-ROADMAP L1067 PR 2b. Composes with ``alpha_engine_lib.telegram`` (lib v0.14.0,
+ROADMAP L1067 PR 2b. Composes with ``nousergon_lib.telegram`` (lib v0.14.0,
 PR 1) and ``executor/notifier.py`` migration (PR 2a, merged).
 """
 

--- a/executor/main.py
+++ b/executor/main.py
@@ -60,7 +60,7 @@ from executor.trade_logger import (
     log_trade,
 )
 
-from alpha_engine_lib.logging import setup_logging, guard_entrypoint
+from nousergon_lib.logging import setup_logging, guard_entrypoint
 # Suppress benign IB Error codes that don't represent real failures:
 #   10197 — "No market data during competing live session". The daemon
 #     keeps receiving delayed ticks via the delayedLast fallback in
@@ -898,7 +898,7 @@ def run(
         ExecutorPreflight(bucket=signals_bucket, mode="main").run()
 
     # ── Flow Doctor: retrieve the shared instance set up at module import ───
-    from alpha_engine_lib.logging import get_flow_doctor
+    from nousergon_lib.logging import get_flow_doctor
     fd = get_flow_doctor() if not simulate else None
 
     # ── 0. Check upstream health — hard-fail if anything upstream is broken ──
@@ -983,7 +983,7 @@ def run(
         try:
             import pandas as _pd
             from executor.price_cache import _open_macro_library
-            from alpha_engine_lib.trading_calendar import last_closed_trading_day
+            from nousergon_lib.trading_calendar import last_closed_trading_day
             _macro = _open_macro_library(signals_bucket)
             _spy_df = _macro.read("SPY").data
             _expected_min = _pd.Timestamp(last_closed_trading_day()).normalize()
@@ -1764,8 +1764,8 @@ def run(
             try:
                 import boto3
 
-                from alpha_engine_lib.dates import now_dual
-                from alpha_engine_lib.eval_artifacts import new_eval_run_id
+                from nousergon_lib.dates import now_dual
+                from nousergon_lib.eval_artifacts import new_eval_run_id
                 from executor.order_book_rationale import (
                     build_order_book_rationale,
                     write_order_book_rationale,
@@ -1819,7 +1819,7 @@ def run(
                     _rat_err,
                 )
                 try:
-                    from alpha_engine_lib import alerts as _alerts
+                    from nousergon_lib import alerts as _alerts
                     _alerts.publish(
                         message=(
                             f"[executor/main.py] Order-book rationale write "

--- a/executor/notifier.py
+++ b/executor/notifier.py
@@ -1,7 +1,7 @@
 """
 Telegram trade notification sender — daemon-side structured-message formatters.
 
-Sits on top of ``alpha_engine_lib.telegram.send_message`` (lib v0.14.0+), which
+Sits on top of ``nousergon_lib.telegram.send_message`` (lib v0.14.0+), which
 handles token/chat_id resolution, markdown escape, retry/timeout, and
 fire-and-forget bool-return semantics. This module contributes daemon-specific
 *message formatting* — emoji + structured trade/status templates — and
@@ -15,7 +15,7 @@ Setup (one-time):
 
 Migration arc: ROADMAP L1067 PR 2a (2026-05-13). Previously this module owned
 the primitive send path inline; the surveillance Lambda arc required a second
-producer, so the primitive was consolidated into ``alpha_engine_lib.telegram``
+producer, so the primitive was consolidated into ``nousergon_lib.telegram``
 to prevent the "two writers diverged silently" antipattern.
 """
 
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 
-from alpha_engine_lib.telegram import send_message
+from nousergon_lib.telegram import send_message
 
 logger = logging.getLogger(__name__)
 

--- a/executor/optimizer_shadow.py
+++ b/executor/optimizer_shadow.py
@@ -264,7 +264,7 @@ def _build_and_solve(
             _req * 100, (_flag or 0) * 100, (_cap or 0) * 100, run_date,
         )
         try:
-            from alpha_engine_lib import alerts as _alerts
+            from nousergon_lib import alerts as _alerts
             _alerts.publish(
                 message=(
                     f"[executor] Optimizer requested a large rebalance: "

--- a/executor/order_book_rationale.py
+++ b/executor/order_book_rationale.py
@@ -20,7 +20,7 @@ new instrumentation**. It reuses the ``risk_events`` rule slugs
 (alpha-engine #138), and the ``entries_with_meta`` sizing breakdown
 the order book already carries.
 
-The artifact is written in the canonical ``alpha_engine_lib.eval_artifacts``
+The artifact is written in the canonical ``nousergon_lib.eval_artifacts``
 shape (``{prefix}/{run_id}.json`` dated forensic artifact + a
 ``{prefix}/latest.json`` operator-UX sidecar) so the dashboard reads it
 with the same ``load_latest_eval_artifact`` / ``list_eval_artifacts``
@@ -686,7 +686,7 @@ def write_order_book_rationale(
 
     Returns dict with ``artifact_key`` and (when written) ``latest_key``.
     """
-    from alpha_engine_lib.eval_artifacts import (
+    from nousergon_lib.eval_artifacts import (
         eval_artifact_key,
         eval_latest_key,
     )

--- a/executor/preflight.py
+++ b/executor/preflight.py
@@ -2,7 +2,7 @@
 Executor preflight: connectivity + safety checks run at the top of each
 entrypoint before any real work starts.
 
-Primitives live in ``alpha_engine_lib.preflight.BasePreflight``; this
+Primitives live in ``nousergon_lib.preflight.BasePreflight``; this
 module composes them into a mode-specific sequence. See the
 alpha-engine-lib README for the rationale.
 
@@ -23,7 +23,7 @@ Modes:
 
 from __future__ import annotations
 
-from alpha_engine_lib.preflight import BasePreflight
+from nousergon_lib.preflight import BasePreflight
 
 
 class ExecutorPreflight(BasePreflight):

--- a/executor/price_cache.py
+++ b/executor/price_cache.py
@@ -62,14 +62,14 @@ def _open_universe_library(signals_bucket: str):
     those live in the `macro` library; use ``_open_macro_library`` for
     those.
 
-    Thin wrapper over ``alpha_engine_lib.arcticdb.open_universe_lib`` —
+    Thin wrapper over ``nousergon_lib.arcticdb.open_universe_lib`` —
     the lib chokepoint (L2771) centralizes the S3 URI construction and
     `get_library` error-wrapping across all alpha-engine consumers.
     Kept as a local wrapper so the existing callers' import surface
     stays unchanged and so the macOS allocator-prime invariant
     (``import arcticdb`` at module top, BEFORE pandas) is preserved.
     """
-    from alpha_engine_lib.arcticdb import open_universe_lib
+    from nousergon_lib.arcticdb import open_universe_lib
     return open_universe_lib(signals_bucket)
 
 
@@ -81,10 +81,10 @@ def _open_macro_library(signals_bucket: str):
     and builders.backfill. SPY in particular is what the morning
     freshness gate and EOD reconcile check.
 
-    Thin wrapper over ``alpha_engine_lib.arcticdb.open_macro_lib`` —
+    Thin wrapper over ``nousergon_lib.arcticdb.open_macro_lib`` —
     see ``_open_universe_library`` above for the rationale.
     """
-    from alpha_engine_lib.arcticdb import open_macro_lib
+    from nousergon_lib.arcticdb import open_macro_lib
     return open_macro_lib(signals_bucket)
 
 

--- a/executor/signal_reader.py
+++ b/executor/signal_reader.py
@@ -11,8 +11,8 @@ from datetime import date, timedelta
 import boto3
 from botocore.exceptions import ClientError
 
-from alpha_engine_lib.eval_artifacts import load_latest_eval_artifact
-from alpha_engine_lib.universe import filter_to_universe
+from nousergon_lib.eval_artifacts import load_latest_eval_artifact
+from nousergon_lib.universe import filter_to_universe
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ REGIME_SUBSTRATE_PREFIX = "regime"
 def read_regime_substrate(s3_bucket: str) -> dict | None:
     """Read the latest regime substrate artifact via canonical sidecar.
 
-    Wraps ``alpha_engine_lib.eval_artifacts.load_latest_eval_artifact``
+    Wraps ``nousergon_lib.eval_artifacts.load_latest_eval_artifact``
     pointed at ``s3://{bucket}/regime/latest.json``. Returns the parsed
     payload dict (composite.intensity_z, hmm.posterior, bocpd.run_length_z,
     guardrails, run_id) or ``None`` if the artifact is unavailable.
@@ -388,7 +388,7 @@ def filter_buy_candidates_to_universe(
         )
         return signals
 
-    # Membership predicate is delegated to ``alpha_engine_lib.universe`` so
+    # Membership predicate is delegated to ``nousergon_lib.universe`` so
     # this Layer 2 filter and research's Layer 1 ``population_selector`` filter
     # share one canonical code path (no silent divergence on universe drift —
     # see lib v0.13.0 docstring).

--- a/executor/snapshot_capturer.py
+++ b/executor/snapshot_capturer.py
@@ -51,8 +51,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from executor.config_loader import load_config
 from executor.ibkr import IBKRClient
 
-from alpha_engine_lib.dates import now_dual
-from alpha_engine_lib.logging import setup_logging
+from nousergon_lib.dates import now_dual
+from nousergon_lib.logging import setup_logging
 
 _FLOW_DOCTOR_EXCLUDE_PATTERNS = [r"Error 10197", r"Error 10349"]
 _FLOW_DOCTOR_YAML = os.path.join(

--- a/executor/strategies/conformance/kit.py
+++ b/executor/strategies/conformance/kit.py
@@ -2,7 +2,7 @@
 
 ``conformance_errors(rule)`` returns a flat list of human-readable
 violations (empty = conformant), mirroring
-``alpha_engine_lib.contracts.conformance_errors`` for slots R/M so the
+``nousergon_lib.contracts.conformance_errors`` for slots R/M so the
 future ``ne validate`` CLI can front both with one vocabulary.
 
 What conformance asserts (the Slot S contract, executor/strategies/contract.py):

--- a/executor/strategies/contract.py
+++ b/executor/strategies/contract.py
@@ -2,7 +2,7 @@
 
 The harness's three experiment slots exchange PRODUCT CONTRACTS (M0
 discipline, ratified 2026-06-11 — config#638). Slots R and M are JSON
-artifacts with versioned schemas in ``alpha_engine_lib.contracts``; Slot S
+artifacts with versioned schemas in ``nousergon_lib.contracts``; Slot S
 is different in kind: a **Python plugin interface** for backtestable exit
 strategy rules. This module is that contract's single source of truth:
 

--- a/executor/trade_logger.py
+++ b/executor/trade_logger.py
@@ -93,7 +93,7 @@ _TRADES_MIGRATIONS = [
     "ALTER TABLE trades ADD COLUMN prediction_date TEXT",
     # ── Phase 2 transparency-inventory: entry-trigger lineage (2026-05-07) ──
     # entry_trigger is the canonical name in the substrate inventory
-    # (alpha_engine_lib/transparency_inventory.yaml row trade_execution_lineage).
+    # (nousergon_lib/transparency_inventory.yaml row trade_execution_lineage).
     # The existing trigger_type column overlaps but is also populated on exits
     # (with the exit reason); separating entry_trigger keeps the
     # entry-trigger-only contract clean. Populated only on ENTER rows; NULL
@@ -274,7 +274,7 @@ def log_trade(conn: sqlite3.Connection, trade: dict) -> str:
     trading_day = trade.get("trading_day")
     if trading_day is None:
         try:
-            from alpha_engine_lib.dates import now_dual
+            from nousergon_lib.dates import now_dual
             trading_day = now_dual().trading_day
         except Exception:
             # Lib not yet bumped on this deploy — leave NULL. Backfill script
@@ -412,7 +412,7 @@ def log_risk_event(conn: sqlite3.Connection, event: dict) -> str:
     trading_day = event.get("trading_day")
     if trading_day is None:
         try:
-            from alpha_engine_lib.dates import now_dual
+            from nousergon_lib.dates import now_dual
             trading_day = now_dual().trading_day
         except Exception:
             trading_day = None

--- a/executor/turnover_tripwire.py
+++ b/executor/turnover_tripwire.py
@@ -210,7 +210,7 @@ def _publish(out: dict, *, severity: str, dedup_key: str, message: str) -> None:
     publish failure must never block the planner; it is recorded in the
     artifact's ``publish_error`` field."""
     try:
-        from alpha_engine_lib import alerts as _alerts
+        from nousergon_lib import alerts as _alerts
         _alerts.publish(
             message=message,
             severity=severity,

--- a/executor/uptime_tracker.py
+++ b/executor/uptime_tracker.py
@@ -65,7 +65,7 @@ def _parse_ts(line: str) -> datetime | None:
 def _parse_tick_line(line: str) -> tuple[datetime, bool] | None:
     """Extract (ts_utc, ib_connected) from a DAEMON_TICK line in either the
     legacy text format or the current JSON format emitted by
-    alpha_engine_lib.logging. Returns None for anything else.
+    nousergon_lib.logging. Returns None for anything else.
     """
     if "DAEMON_TICK" not in line:
         return None

--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -272,7 +272,7 @@ import os
 import sys
 sys.path.insert(0, "/home/ec2-user/alpha-engine")
 try:
-    from alpha_engine_lib.secrets import get_secret
+    from nousergon_lib.secrets import get_secret
     for _name in ("EMAIL_SENDER", "EMAIL_RECIPIENTS", "GMAIL_APP_PASSWORD", "FLOW_DOCTOR_GITHUB_TOKEN"):
         _val = get_secret(_name, required=False)
         if _val is not None and _name not in os.environ:

--- a/polygon_client.py
+++ b/polygon_client.py
@@ -30,7 +30,7 @@ from datetime import date, datetime, timedelta
 import pandas as pd
 import requests
 
-from alpha_engine_lib.secrets import get_secret
+from nousergon_lib.secrets import get_secret
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/backfill_trading_day.py
+++ b/scripts/backfill_trading_day.py
@@ -51,13 +51,13 @@ logger = logging.getLogger(__name__)
 
 
 def _import_lib_dates():
-    """Import alpha_engine_lib.dates with a clear error if the pin is stale."""
+    """Import nousergon_lib.dates with a clear error if the pin is stale."""
     try:
-        from alpha_engine_lib.dates import session_for_timestamp
+        from nousergon_lib.dates import session_for_timestamp
         return session_for_timestamp
     except ImportError as exc:
         sys.stderr.write(
-            "ERROR: alpha_engine_lib.dates not importable. "
+            "ERROR: nousergon_lib.dates not importable. "
             "This script requires alpha-engine-lib v0.2.0+. "
             "Update requirements.txt and reinstall before running.\n"
             f"Underlying ImportError: {exc}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Test fixtures + sys.path setup.
 
 Pins ``ALPHA_ENGINE_SECRETS_SOURCE=env`` for the test process so
-``alpha_engine_lib.secrets.get_secret()`` (post 2026-05-12 .env→SSM
+``nousergon_lib.secrets.get_secret()`` (post 2026-05-12 .env→SSM
 migration, PR 6 of the arc) reads from monkeypatched env vars only —
 never the real SSM Parameter Store.
 """
@@ -24,7 +24,7 @@ def _isolate_secrets_from_ssm(monkeypatch):
     """
     monkeypatch.setenv("ALPHA_ENGINE_SECRETS_SOURCE", "env")
     try:
-        from alpha_engine_lib.secrets import clear_cache
+        from nousergon_lib.secrets import clear_cache
     except ImportError:
         yield
         return
@@ -35,7 +35,7 @@ def _isolate_secrets_from_ssm(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _block_real_alert_publish(monkeypatch):
-    """Stub ``alpha_engine_lib.alerts.publish`` so NO test fans out a real
+    """Stub ``nousergon_lib.alerts.publish`` so NO test fans out a real
     SNS / Telegram operator alert.
 
     Without this, any test exercising a code path that calls
@@ -45,13 +45,13 @@ def _block_real_alert_publish(monkeypatch):
     #237, which fired a live WARN to Telegram + SNS on every suite run
     (``run_date=2026-05-11``, observed 2026-06-07). Tests assert on the call
     inputs, not on real delivery. ``optimizer_shadow`` imports the symbol
-    lazily as ``from alpha_engine_lib import alerts as _alerts`` and calls
+    lazily as ``from nousergon_lib import alerts as _alerts`` and calls
     ``_alerts.publish`` at runtime, so patching the module attribute here
     intercepts it. See ROADMAP L4566; mirrored by a cross-repo guard in
-    ``alpha_engine_lib.alerts.publish`` (PYTEST_CURRENT_TEST).
+    ``nousergon_lib.alerts.publish`` (PYTEST_CURRENT_TEST).
     """
     try:
-        from alpha_engine_lib import alerts
+        from nousergon_lib import alerts
     except ImportError:
         yield
         return

--- a/tests/test_intraday.py
+++ b/tests/test_intraday.py
@@ -404,7 +404,7 @@ class TestMarketHours:
 
 class TestNotifier:
     """Daemon-side formatter tests. Primitive send/escape behavior is locked
-    upstream in alpha_engine_lib.telegram's own test suite (29 tests). These
+    upstream in nousergon_lib.telegram's own test suite (29 tests). These
     tests cover only the daemon-specific message-shape contracts and that
     the formatters correctly route through the lib substrate.
     """

--- a/tests/test_no_secret_environ_reads.py
+++ b/tests/test_no_secret_environ_reads.py
@@ -2,7 +2,7 @@
 or ``os.getenv``.
 
 After the 2026-05-12 ``.env`` → SSM migration (PR 6 of the arc), every
-secret-bearing call site routes through ``alpha_engine_lib.secrets.get_secret()``.
+secret-bearing call site routes through ``nousergon_lib.secrets.get_secret()``.
 This test re-greps the codebase on every CI run so a future commit can't
 silently re-introduce a secret read via ``os.environ``.
 
@@ -60,6 +60,6 @@ def test_no_secret_environ_reads():
                     violations.append((path.relative_to(_REPO_ROOT), lineno, name))
     assert not violations, (
         "Found os.environ.get / os.getenv reads of pinned secrets — use "
-        "`from alpha_engine_lib.secrets import get_secret` instead:\n"
+        "`from nousergon_lib.secrets import get_secret` instead:\n"
         + "\n".join(f"  {p}:{ln}  {name}" for p, ln, name in violations)
     )

--- a/tests/test_order_book_rationale.py
+++ b/tests/test_order_book_rationale.py
@@ -318,7 +318,7 @@ def test_write_latest_false_skips_sidecar(scenario):
 def test_round_trip_via_lib_loader(scenario):
     """The artifact resolves through the lib's canonical reader —
     proves the dashboard's load_latest_eval_artifact path works."""
-    from alpha_engine_lib.eval_artifacts import load_latest_eval_artifact
+    from nousergon_lib.eval_artifacts import load_latest_eval_artifact
 
     payload = build_order_book_rationale(**scenario)
     s3 = _StubS3()
@@ -733,7 +733,7 @@ class TestHeldFromPortfolioTruth:
 def test_obr_write_failure_publishes_alert_not_silent_swallow():
     """Pin the L171 fix (2026-05-22): an OBR write failure in
     `executor/main.py` must reach the operator via
-    `alpha_engine_lib.alerts.publish` — silent warning-log only is
+    `nousergon_lib.alerts.publish` — silent warning-log only is
     exactly the [[feedback_no_silent_fails]] failure mode (page 16
     falls back to yesterday's snapshot with zero signal that today's
     write never landed).
@@ -748,7 +748,7 @@ def test_obr_write_failure_publishes_alert_not_silent_swallow():
 
     src = inspect.getsource(main_mod)
     # Locate the OBR-rationale write block — the WARN log + the
-    # alpha_engine_lib.alerts.publish must BOTH live in the except
+    # nousergon_lib.alerts.publish must BOTH live in the except
     # handler that wraps write_order_book_rationale.
     assert "Order-book rationale write failed" in src, (
         "OBR write-failure WARN log appears to have been refactored — "
@@ -756,13 +756,13 @@ def test_obr_write_failure_publishes_alert_not_silent_swallow():
         "before merging."
     )
     assert "obr_write_failed_" in src, (
-        "OBR write-failure handler must call `alpha_engine_lib.alerts.publish` "
+        "OBR write-failure handler must call `nousergon_lib.alerts.publish` "
         "with a `dedup_key` starting `obr_write_failed_` so the failure "
         "reaches Telegram/SNS rather than silently swallowing "
         "([[feedback_no_silent_fails]])."
     )
-    assert "from alpha_engine_lib import alerts" in src, (
-        "OBR write-failure handler must import alpha_engine_lib.alerts "
+    assert "from nousergon_lib import alerts" in src, (
+        "OBR write-failure handler must import nousergon_lib.alerts "
         "lazily (inside the except) so a missing lib at boot doesn't "
         "break the planner cold-start."
     )

--- a/tests/test_slot_contract_fixture_conformance.py
+++ b/tests/test_slot_contract_fixture_conformance.py
@@ -5,7 +5,7 @@ The executor is the canonical consumer of both slot contracts. Its consumer
 contract tests (``test_signal_reader_consumer_contract.py``) exercise
 ``signal_reader`` against fixtures — if those fixtures drift from the real
 producer shape, the consumer tests prove nothing about the actual boundary.
-This pins fixture <-> contract agreement via ``alpha_engine_lib.contracts``
+This pins fixture <-> contract agreement via ``nousergon_lib.contracts``
 (lib >= 0.59.1), the same versioned schemas the producers validate against
 (research / predictor CI).
 
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 
 contracts = pytest.importorskip(
-    "alpha_engine_lib.contracts",
+    "nousergon_lib.contracts",
     reason="needs alpha-engine-lib[contracts] >= 0.59.1",
 )
 

--- a/tests/test_trade_logger.py
+++ b/tests/test_trade_logger.py
@@ -97,12 +97,12 @@ def test_init_db_risk_events_migration_idempotent(tmp_path, monkeypatch):
 
 
 def test_log_risk_event_falls_through_when_lib_unavailable(tmp_path):
-    """The optional alpha_engine_lib.dates import must NOT hard-fail."""
+    """The optional nousergon_lib.dates import must NOT hard-fail."""
     conn = init_db(str(tmp_path / "trades.db"))
     fake_lib = MagicMock()
     fake_lib.now_dual.side_effect = RuntimeError("simulated import failure")
-    sys.modules.pop("alpha_engine_lib.dates", None)
-    sys.modules["alpha_engine_lib.dates"] = fake_lib
+    sys.modules.pop("nousergon_lib.dates", None)
+    sys.modules["nousergon_lib.dates"] = fake_lib
 
     try:
         event_id = log_risk_event(conn, {
@@ -113,7 +113,7 @@ def test_log_risk_event_falls_through_when_lib_unavailable(tmp_path):
         ).fetchone()[0]
         assert td is None
     finally:
-        sys.modules.pop("alpha_engine_lib.dates", None)
+        sys.modules.pop("nousergon_lib.dates", None)
 
 
 # ── log_trade ───────────────────────────────────────────────────────────────
@@ -135,20 +135,20 @@ def test_log_trade_uses_caller_trading_day_when_provided(db):
 
 def test_log_trade_falls_through_when_lib_unavailable(db, monkeypatch):
     """If the optional lib raises on import, trading_day stays NULL — no hard fail."""
-    # Force the inline `from alpha_engine_lib.dates import now_dual` to raise
+    # Force the inline `from nousergon_lib.dates import now_dual` to raise
     fake_lib = MagicMock()
     fake_lib.now_dual.side_effect = RuntimeError("simulated import failure")
     # Inject into sys.modules so the inline import picks it up — we need to
     # invalidate the cached import first
-    sys.modules.pop("alpha_engine_lib.dates", None)
-    sys.modules["alpha_engine_lib.dates"] = fake_lib
+    sys.modules.pop("nousergon_lib.dates", None)
+    sys.modules["nousergon_lib.dates"] = fake_lib
 
     try:
         log_trade(db, _trade())  # no trading_day provided
         td = db.execute("SELECT trading_day FROM trades").fetchone()[0]
         assert td is None
     finally:
-        sys.modules.pop("alpha_engine_lib.dates", None)
+        sys.modules.pop("nousergon_lib.dates", None)
 
 
 # ── log_shadow_book_block ───────────────────────────────────────────────────

--- a/tests/test_trades_db_dual_tracking.py
+++ b/tests/test_trades_db_dual_tracking.py
@@ -3,7 +3,7 @@
 Covers:
   * Schema migration is idempotent — re-running init_db() against a DB that
     already has the new columns is a no-op.
-  * log_trade() populates trading_day via the alpha_engine_lib.dates fallback
+  * log_trade() populates trading_day via the nousergon_lib.dates fallback
     when the caller doesn't pass it explicitly.
   * log_trade() honors an explicit trading_day from the caller (live daemon
     path will populate this from the OrderBook entry context).
@@ -207,7 +207,7 @@ def _set_columns_null(db_path: Path) -> None:
 
 def test_backfill_dry_run_does_not_write(tmp_path):
     """--dry-run computes updates but doesn't mutate the DB."""
-    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    pytest.importorskip("nousergon_lib.dates", reason="lib v0.2.0+ required")
     from scripts import backfill_trading_day
 
     db_path = tmp_path / "trades.db"
@@ -244,7 +244,7 @@ def test_backfill_dry_run_does_not_write(tmp_path):
 def test_backfill_idempotent(tmp_path):
     """Running backfill twice produces the same end state — already-set
     columns are skipped on the second pass."""
-    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    pytest.importorskip("nousergon_lib.dates", reason="lib v0.2.0+ required")
     from scripts import backfill_trading_day
 
     db_path = tmp_path / "trades.db"
@@ -292,7 +292,7 @@ def test_backfill_idempotent(tmp_path):
 def test_backfill_does_not_overwrite_existing_values(tmp_path):
     """If trading_day is already set (e.g., from a forward-write call site),
     the backfill must not overwrite it."""
-    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    pytest.importorskip("nousergon_lib.dates", reason="lib v0.2.0+ required")
     from scripts import backfill_trading_day
 
     db_path = tmp_path / "trades.db"
@@ -330,7 +330,7 @@ def test_backfill_skips_signal_trading_day_for_non_enter(tmp_path):
     """EXIT and REDUCE actions don't have a signal_trading_day backfill —
     they stay NULL by design (they're outcomes of held positions, not new
     signal-driven entries)."""
-    pytest.importorskip("alpha_engine_lib.dates", reason="lib v0.2.0+ required")
+    pytest.importorskip("nousergon_lib.dates", reason="lib v0.2.0+ required")
     from scripts import backfill_trading_day
 
     db_path = tmp_path / "trades.db"

--- a/tests/test_trades_entry_trigger.py
+++ b/tests/test_trades_entry_trigger.py
@@ -2,7 +2,7 @@
 Tests for the `entry_trigger` column on the trades table.
 
 Phase 2 transparency-inventory item — closes the *trade execution lineage*
-row in alpha_engine_lib/transparency_inventory.yaml. The substrate health
+row in nousergon_lib/transparency_inventory.yaml. The substrate health
 check asserts the column is present in trades_full.csv; the daemon's
 ENTER fill site is the only writer that populates it (mirrors the
 trigger_reason returned by EntryTriggerEngine.should_enter).

--- a/tests/test_turnover_tripwire.py
+++ b/tests/test_turnover_tripwire.py
@@ -50,7 +50,7 @@ _CFG = {
 @pytest.fixture
 def published(monkeypatch):
     calls = []
-    from alpha_engine_lib import alerts
+    from nousergon_lib import alerts
 
     monkeypatch.setattr(alerts, "publish", lambda **kw: calls.append(kw))
     return calls
@@ -139,7 +139,7 @@ def test_governor_off_uses_absolute_band(published):
 
 
 def test_publish_failure_recorded_not_raised(monkeypatch):
-    from alpha_engine_lib import alerts
+    from nousergon_lib import alerts
 
     def _boom(**kw):
         raise RuntimeError("sns down")

--- a/tests/test_uptime_tracker.py
+++ b/tests/test_uptime_tracker.py
@@ -38,7 +38,7 @@ def test_parse_tick_lines_roundtrip():
 
 
 def _make_json_tick_line(ts_utc: datetime, connected: bool) -> str:
-    """Render a DAEMON_TICK line in the JSON format emitted by alpha_engine_lib.logging."""
+    """Render a DAEMON_TICK line in the JSON format emitted by nousergon_lib.logging."""
     return json.dumps({
         "ts": ts_utc.isoformat(),
         "level": "INFO",
@@ -49,7 +49,7 @@ def _make_json_tick_line(ts_utc: datetime, connected: bool) -> str:
 
 
 def test_parse_tick_lines_json_format():
-    """Parser handles the JSON format written by the new alpha_engine_lib.logging."""
+    """Parser handles the JSON format written by the new nousergon_lib.logging."""
     day = date(2026, 4, 13)
     t_et = _ET.localize(datetime(2026, 4, 13, 10, 15))
     t_utc = t_et.astimezone(_UTC)


### PR DESCRIPTION
## Why

The executor crossed to **nousergon-lib 0.60.2** (#270), but its code still imported the package under the **deprecated `alpha_engine_lib` alias**, riding the rename shim. The shim is explicitly temporary ("will be removed in a future major release"), and its meta-path loader doesn't support `python -m` (the `_AliasLoader.get_code` gap that broke CheckTradingDay — fixed for the SF string in nousergon-data#458). Completing the migration stops the executor depending on a layer marked for removal — rather than patching the shim to extend its life.

## What

Renamed all **31 files'** references `alpha_engine_lib` → `nousergon_lib`: imports, `sys.modules` fake-injection keys, `pytest.importorskip` targets, `-m` invocations, `boot-pull.sh` heredoc import, and comments. The shim makes both names the *same module object*, so the change is behaviour-preserving.

Source and tests migrated **in lockstep** — e.g. `test_trade_logger` injects its fake under `nousergon_lib.dates` to match the renamed import; otherwise the mock wouldn't be picked up.

## Tests

**1196 passed** in a fresh Python 3.11 venv built on `nousergon-lib 0.60.2` (matches the box/CI). Requirements already pin nousergon-lib 0.60.2 (#270) — no pin change.

Part of completing the `alpha_engine_lib → nousergon_lib` conversion (companion: nousergon-data#458 SF strings, dashboard migration, fleet tracking issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)