### PR TITLE
fix(deps): hyphenate flow-doctor extra so it resolves on old pip (config#1178)

### DIFF
--- a/infrastructure/boot-pull.sh
+++ b/infrastructure/boot-pull.sh
@@ -115,7 +115,7 @@ for repo in "${REPOS[@]}"; do
 
     # Update pip deps if venv + requirements.txt exist.
     # flow-doctor is now pulled in transitively via
-    # alpha-engine-lib[flow_doctor]; the previous bundled editable
+    # nousergon-lib[flow-doctor]; the previous bundled editable
     # install (pip install -e /home/ec2-user/flow-doctor) has been
     # removed so boot doesn't silently overwrite the lib-provided copy
     # with a local dev branch.

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,12 @@ requests~=2.32
 # v0.60.2 (2026-06-18): SSM-authoritative seed + alpha_engine_lib alias resource-loading shim fix; earlier v0.60.1 flow-doctor secret seed when deployed
 # — overwrites a stale sourced FLOW_DOCTOR_GITHUB_TOKEN with the live SSM value
 # so the github_issue notifier stops 403ing on the EOD/executor path (config#1148).
-nousergon-lib[flow_doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.2
+# NOTE: the flow-doctor extra MUST be hyphenated — setuptools normalizes
+# pyproject's `flow_doctor` to `Provides-Extra: flow-doctor`, and older pip
+# does NOT normalize underscore->hyphen, so `[flow_doctor]` silently drops the
+# extra (leaving flow-doctor stale/absent). `[flow-doctor]` is the PEP 685
+# canonical form and resolves on every pip version (config#1178).
+nousergon-lib[flow-doctor,contracts] @ git+https://github.com/nousergon/nousergon-lib@v0.60.2
 # portfolio_optimizer (PR 1 of portfolio-optimizer-260511 arc): cvxpy solves the
 # constrained mean-variance program (MVO + L1 turnover + SOC vol-target);
 # scikit-learn provides Ledoit-Wolf covariance shrinkage. Both are optional at


### PR DESCRIPTION
Part of the config#1178 fleet sweep (follow-up to crucible-dashboard#236).

## Why
setuptools normalizes pyproject's `flow_doctor` extra to `Provides-Extra: flow-doctor` (hyphen). Older pip does **not** normalize underscore↔hyphen, so `nousergon-lib[flow_doctor]` resolves the package but **silently drops the extra** — leaving `flow-doctor` stale or absent (no error, just a WARN). Switched to the PEP 685-canonical `[flow-doctor]`, which resolves on every pip version.

This is the same defect class that took down the dashboard console (crucible-dashboard#236).

## Severity here: preventive, not an active incident
The executor box is currently **healthy** — verified via S3: today's `executor/hold_book_flags/2026-06-22.json` (morning planner), `daemon_state/2026-06-22/intraday_decisions.jsonl`, and live `intraday/heartbeat.json` + `nav_series/2026-06-22.json` are all fresh, and the daemon runs the crossed code that imports `nousergon_lib`. So the box's venv installed the renamed lib cleanly (its `boot-pull.sh` has no stale upgrade block and its pip is evidently new enough). This PR removes the latent failure mode for any future reinstall on an old-pip box.

## Changes
- `requirements.txt`: `[flow_doctor,contracts]` → `[flow-doctor,contracts]` + explanatory note.
- `infrastructure/boot-pull.sh`: refresh stale `alpha-engine-lib[flow_doctor]` comment → `nousergon-lib[flow-doctor]`.

## Test
`bash -n infrastructure/boot-pull.sh` passes; one-line requirements change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)