### PR TITLE
feat(eod): structured EOD report artifact + correct alpha attribution; slim link email

### DIFF
--- a/executor/eod_emailer.py
+++ b/executor/eod_emailer.py
@@ -1,29 +1,38 @@
 """
 EOD performance email — sent after market close on trading days.
 
-Builds a summary of daily NAV, alpha vs SPY, open positions, trades placed,
-and a trailing 10-day history, then sends via Gmail SMTP (primary) or AWS SES
-(fallback).
+As of 2026-06-22 this is a **slim link email** (config#856 pipeline-reporting
+revamp, "pull-for-state console page + push-on-transition emails"): the body
+carries the at-a-glance Daily Summary (NAV, daily return vs SPY, alpha, cash/
+P&L) plus any DATA WARNINGS, then links to the full computed report on the
+private console. The full positions / attribution / rationale / sector /
+roundtrip / trailing tables now live ONLY on the console EOD Report page
+(alpha-engine-dashboard ``views/19_EOD_Report.py``), which renders the
+structured ``consolidated/{date}/eod_report.json`` artifact.
 
-Gmail SMTP is used when GMAIL_APP_PASSWORD is set in the environment. This
-avoids the SPF/DKIM failure that occurs when SES sends on behalf of a
-@gmail.com sender address (SES is not authorized by Gmail's SPF policy, so
-emails are silently dropped).
+Why the change: the old inline email recomputed a per-position "α % of Total"
+column that divided each position's alpha by the *signed* grand-total alpha
+(sign-flipping every row on negative-alpha days) and carried a positions-table
+alpha total that never reconciled with the NAV-based headline. The console page
+renders a single, correct, prior-NAV-basis attribution that ties to the
+headline exactly. Keeping the report in one place (the artifact) removes the
+two-implementations-that-disagree failure mode.
 
-Setup: set GMAIL_APP_PASSWORD in the EC2 environment:
-    echo 'export GMAIL_APP_PASSWORD=xxxxxxxxxxxxxxxxx' >> ~/.bashrc && source ~/.bashrc
+Gmail SMTP is used when GMAIL_APP_PASSWORD is set in the environment (avoids the
+SPF/DKIM drop that occurs when SES sends on behalf of a @gmail.com sender).
 """
 
 from __future__ import annotations
 
 import logging
-import os
-import sqlite3
-
-import boto3
-
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_CONSOLE_BASE_URL = "https://console.nousergon.ai"
+# Pinned slug — must match the EOD Report page's ``url_path`` in
+# alpha-engine-dashboard app.py. A drift here breaks the email deep-link
+# (config#856 Phase 2.5). Guarded by the dashboard's slug-drift test.
+EOD_REPORT_SLUG = "eod-report"
 
 _HTML = """\
 <!DOCTYPE html>
@@ -39,6 +48,9 @@ _HTML = """\
   .pos  {{ color: #006600; font-weight: bold; }}
   .neg  {{ color: #990000; font-weight: bold; }}
   .neu  {{ color: #555; }}
+  .cta  {{ display: inline-block; margin: 14px 0; padding: 10px 18px;
+           background: #0b5; color: #fff !important; text-decoration: none;
+           border-radius: 4px; font-weight: bold; }}
   .foot {{ margin-top: 28px; font-size: 11px; color: #888;
            border-top: 1px solid #ccc; padding-top: 8px; }}
 </style>
@@ -74,46 +86,47 @@ def _plain_pct(v: float | None) -> str:
     return f"{sign}{v:.2f}%"
 
 
+def eod_report_url(run_date: str, console_base_url: str | None = None) -> str:
+    """Deep-link to the console EOD Report page for ``run_date``."""
+    base = (console_base_url or DEFAULT_CONSOLE_BASE_URL).rstrip("/")
+    return f"{base}/{EOD_REPORT_SLUG}?date={run_date}"
+
+
 def build_eod_email(
     run_date: str,
     nav: float,
     daily_return: float | None,
     spy_return: float | None,
     alpha: float | None,
-    positions: dict,
-    conn: sqlite3.Connection,
-    position_narratives: dict[str, str] | None = None,
-    sector_attribution: dict | None = None,
-    data_warnings: list[str] | None = None,
-    roundtrip_stats: dict | None = None,
     account_snapshot: dict | None = None,
-    nav_reconciliation: dict | None = None,
+    data_warnings: list[str] | None = None,
+    console_base_url: str | None = None,
 ) -> tuple[str, str, str]:
-    """
-    Build the EOD email subject + (html_body, plain_body).
+    """Build the slim EOD email: subject + (html_body, plain_body).
 
-    Returns: (subject, html_body, plain_body)
+    The subject is unchanged (NAV + alpha at a glance). The body is the Daily
+    Summary, any DATA WARNINGS, and a deep-link to the full console report.
     """
     alpha_str = _plain_pct(alpha)
     nav_fmt = f"${nav:,.0f}"
     subject = f"Alpha Engine | {run_date} | NAV {nav_fmt} | α {alpha_str}"
+    url = eod_report_url(run_date, console_base_url)
 
-    # ── Daily summary ────────────────────────────────────────────────────────
-    # Extract IB ground truth values
     acct = account_snapshot or {}
     ib_cash = acct.get("total_cash")
-    ib_accrued = acct.get("accrued_interest")
     ib_gross_pos = acct.get("gross_position_value")
     ib_unrealized = acct.get("unrealized_pnl")
     ib_realized = acct.get("realized_pnl")
+    ib_accrued = acct.get("accrued_interest")
 
-    html_parts = ["<h2>Daily Summary</h2>", "<table>",
-                  "<tr><th>Metric</th><th>Value</th></tr>",
-                  f"<tr><td>NAV</td><td>{nav_fmt}</td></tr>",
-                  f"<tr><td>Daily Return</td><td>{_pct(daily_return)}</td></tr>",
-                  f"<tr><td>SPY Return</td><td>{_pct(spy_return)}</td></tr>",
-                  f"<tr><td>Daily Alpha</td><td>{_pct(alpha)}</td></tr>"]
-
+    html_parts = [
+        "<h2>Daily Summary</h2>", "<table>",
+        "<tr><th>Metric</th><th>Value</th></tr>",
+        f"<tr><td>NAV</td><td>{nav_fmt}</td></tr>",
+        f"<tr><td>Daily Return</td><td>{_pct(daily_return)}</td></tr>",
+        f"<tr><td>SPY Return</td><td>{_pct(spy_return)}</td></tr>",
+        f"<tr><td>Daily Alpha</td><td>{_pct(alpha)}</td></tr>",
+    ]
     if ib_cash is not None:
         html_parts.append(f"<tr><td>Cash</td><td>${ib_cash:,.0f}</td></tr>")
     if ib_gross_pos is not None:
@@ -124,7 +137,6 @@ def build_eod_email(
         html_parts.append(f"<tr><td>Realized P&L</td><td>{_dollar(ib_realized)}</td></tr>")
     if ib_accrued is not None and ib_accrued != 0:
         html_parts.append(f"<tr><td>Accrued Interest</td><td>{_dollar(ib_accrued)}</td></tr>")
-
     html_parts.append("</table>")
 
     plain_parts = [
@@ -141,9 +153,12 @@ def build_eod_email(
         plain_parts.append(f"Positions:    ${ib_gross_pos:,.0f}")
     if ib_unrealized is not None:
         plain_parts.append(f"Unrealized:   ${ib_unrealized:+,.0f}")
+    if ib_realized is not None and ib_realized != 0:
+        plain_parts.append(f"Realized:     ${ib_realized:+,.0f}")
     plain_parts.append("")
 
-    # ── Data warnings banner ──────────────────────────────────────────────
+    # DATA WARNINGS still push in the email — a red flag must reach the inbox,
+    # not hide behind a click (per [[feedback_no_silent_fails]]).
     if data_warnings:
         html_parts.append('<div style="background:#fff3cd;border:1px solid #ffc107;padding:10px;margin:10px 0;">')
         html_parts.append('<strong>DATA WARNINGS:</strong><ul>')
@@ -155,243 +170,19 @@ def build_eod_email(
             plain_parts.append(f"  - {w}")
         plain_parts.append("")
 
-    # ── Positions ────────────────────────────────────────────────────────────
-    html_parts.append("<h2>Open Positions</h2>")
-    plain_parts.append("OPEN POSITIONS")
-    plain_parts.append("-" * 40)
-
-    if positions:
-        total_mv = sum(pos.get("market_value", 0) for pos in positions.values())
-        total_day_usd = sum(pos.get("daily_return_usd", 0) for pos in positions.values())
-        total_alpha_usd = sum(pos.get("alpha_contribution_usd", 0) for pos in positions.values())
-
-        # NAV change components (computed by eod_reconcile). Cash earns interest
-        # only — we do NOT stuff the NAV-vs-position residual into cash, since
-        # that absorbs bookkeeping noise and inflates apparent alpha.
-        recon = nav_reconciliation or {}
-        cash = ib_cash if ib_cash is not None else (nav - total_mv if nav else 0)
-        total_nav_change = nav * (daily_return / 100) if daily_return is not None else 0
-        interest_usd = recon.get("interest_usd", 0.0) or 0.0
-        dividend_usd = recon.get("dividend_usd", 0.0) or 0.0
-        # Unattributed = NAV change - position P&L - interest - dividends.
-        # Nonzero values usually indicate pricing/snapshot mismatches, corporate
-        # actions, fees, or FX — surfaced separately so they stay visible.
-        unattributed_usd = recon.get(
-            "unattributed_usd",
-            total_nav_change - total_day_usd - interest_usd - dividend_usd,
-        )
-
-        # Cash α = interest earned, minus the opportunity cost of not holding
-        # SPY on that cash sleeve. Dividends are attributed to source positions,
-        # so they flow through position α. Unattributed noise is excluded.
-        cash_alpha_usd = interest_usd - (cash * (spy_return or 0) / 100) if cash else 0
-
-        grand_day_usd = total_day_usd + interest_usd + dividend_usd + unattributed_usd
-        grand_alpha_usd = total_alpha_usd + cash_alpha_usd
-        grand_alpha_pct = grand_alpha_usd / nav * 100 if nav else 0
-
-        html_parts += ["<table>",
-                       "<tr><th>Ticker</th><th>Shares</th><th>Mkt Value</th>"
-                       "<th>% NAV</th><th>Day Ret %</th><th>Day Ret $</th>"
-                       "<th>α $</th><th>α % of Total</th></tr>"]
-        for ticker, pos in sorted(positions.items()):
-            mv = pos.get("market_value", 0)
-            pct_nav = mv / nav * 100 if nav else 0
-            daily_ret = pos.get("daily_return_pct")
-            daily_usd = pos.get("daily_return_usd", 0)
-            alpha_usd = pos.get("alpha_contribution_usd", 0)
-            alpha_pct_of_total = (alpha_usd / grand_alpha_usd * 100) if grand_alpha_usd else 0
-            html_parts.append(
-                f"<tr><td>{ticker}</td><td>{pos['shares']:,}</td>"
-                f"<td>${mv:,.0f}</td><td>{pct_nav:.1f}%</td>"
-                f"<td>{_pct(daily_ret)}</td><td>{_dollar(daily_usd)}</td>"
-                f"<td>{_dollar(alpha_usd)}</td><td>{_pct(alpha_pct_of_total)}</td></tr>"
-            )
-            dr_str = _plain_pct(daily_ret) if daily_ret is not None else "—"
-            plain_parts.append(
-                f"  {ticker:<6} {pos['shares']:>5}  ${mv:>9,.0f}  {pct_nav:>5.1f}%"
-                f"  {dr_str:>7}  ${daily_usd:>+8,.0f}  ${alpha_usd:>+8,.0f}  {alpha_pct_of_total:>+6.1f}%"
-            )
-
-        # Cash row — balance + α from interest vs SPY, no fabricated daily return
-        if abs(cash) > 1:
-            cash_pct = cash / nav * 100 if nav else 0
-            cash_alpha_pct_of_total = (cash_alpha_usd / grand_alpha_usd * 100) if grand_alpha_usd else 0
-            html_parts.append(
-                f'<tr style="color:#888"><td><i>Cash</i></td><td></td>'
-                f'<td>${cash:,.0f}</td><td>{cash_pct:.1f}%</td>'
-                f'<td>—</td><td>—</td>'
-                f'<td>{_dollar(cash_alpha_usd)}</td><td>{_pct(cash_alpha_pct_of_total)}</td></tr>'
-            )
-            plain_parts.append(
-                f"  {'Cash':<6} {'':>5}  ${cash:>9,.0f}  {cash_pct:>5.1f}%"
-                f"  {'—':>7}  {'—':>9}  ${cash_alpha_usd:>+8,.0f}  {cash_alpha_pct_of_total:>+6.1f}%"
-            )
-
-        # Interest / Dividends / Unattributed rows — only show if non-trivial
-        def _extra_row(label: str, usd: float, style: str = "color:#888;font-style:italic"):
-            if abs(usd) < 1:
-                return
-            html_parts.append(
-                f'<tr style="{style}"><td>{label}</td><td></td><td></td><td></td>'
-                f'<td>—</td><td>{_dollar(usd)}</td><td>—</td><td>—</td></tr>'
-            )
-            plain_parts.append(f"  {label:<14} ${usd:>+8,.0f}")
-
-        _extra_row("Interest", interest_usd)
-        _extra_row("Dividends", dividend_usd)
-        _extra_row(
-            "Unattributed",
-            unattributed_usd,
-            style="color:#c00;font-style:italic",  # red — this should be small
-        )
-
-        # Totals row — ties to Daily Summary (NAV-based)
-        html_parts.append(
-            f'<tr style="font-weight:bold;border-top:2px solid #333">'
-            f'<td>Total</td><td></td>'
-            f'<td>${nav:,.0f}</td><td>100%</td>'
-            f'<td></td><td>{_dollar(grand_day_usd)}</td>'
-            f'<td>{_dollar(grand_alpha_usd)}</td>'
-            f'<td><b>{_pct(grand_alpha_pct)}</b></td></tr>'
-        )
-        html_parts.append("</table>")
-        plain_parts.append(f"  {'':->80}")
-        plain_parts.append(
-            f"  {'Total':<6} {'':>5}  ${nav:>9,.0f}  100.0%"
-            f"  {'':>7}  ${grand_day_usd:>+8,.0f}  ${grand_alpha_usd:>+8,.0f}  {grand_alpha_pct:>+6.2f}%"
-        )
-    else:
-        html_parts.append("<p>No open positions.</p>")
-        plain_parts.append("  No open positions.")
+    html_parts.append(
+        f'<a class="cta" href="{url}">View full EOD report on the console →</a>'
+    )
+    html_parts.append(
+        '<p style="font-size:11px;color:#888;">Positions, daily-alpha attribution, '
+        'rationale, sector contribution, trades, roundtrips, and trailing history '
+        'are on the console report.</p>'
+    )
+    plain_parts.append(f"Full EOD report: {url}")
     plain_parts.append("")
-
-    # ── Position rationale ─────────────────────────────────────────────────
-    if position_narratives and positions:
-        html_parts.append("<h2>Position Rationale</h2>")
-        html_parts.append("<table>")
-        html_parts.append("<tr><th>Ticker</th><th>Rationale</th></tr>")
-        plain_parts.append("POSITION RATIONALE")
-        plain_parts.append("-" * 40)
-        for ticker in sorted(positions.keys()):
-            narrative = position_narratives.get(ticker, "No rationale available.")
-            html_parts.append(
-                f"<tr><td><b>{ticker}</b></td><td>{narrative}</td></tr>"
-            )
-            plain_parts.append(f"  {ticker}: {narrative}")
-        html_parts.append("</table>")
-        html_parts.append(
-            '<p style="font-size:11px; color:#888; margin-top:4px;">'
-            'ⓘ α in <b>GBM:</b> rows is log-domain decimal at the 21d horizon '
-            '(post 2026-05-09 canonical-alpha cutover). Top-of-email Daily Alpha '
-            'is unchanged: arithmetic portfolio return − SPY return.'
-            '</p>'
-        )
-        plain_parts.append(
-            "  Note: α in GBM: rows is log-domain decimal at 21d horizon "
-            "(post 2026-05-09 cutover). Top-of-email Daily Alpha is "
-            "unchanged arithmetic portfolio − SPY."
-        )
-        plain_parts.append("")
-
-    # ── Sector Attribution ─────────────────────────────────────────────────
-    if sector_attribution:
-        html_parts.append("<h2>Sector Attribution</h2>")
-        html_parts.append("<table>")
-        html_parts.append("<tr><th>Sector</th><th>Weight</th><th>Contribution</th><th>Positions</th></tr>")
-        plain_parts.append("SECTOR ATTRIBUTION")
-        plain_parts.append("-" * 40)
-        for sector, data in sorted(sector_attribution.items(), key=lambda x: abs(x[1]["contribution"]), reverse=True):
-            weight_pct = data["weight"] * 100
-            contrib = data["contribution"]
-            n_pos = data["positions"]
-            html_parts.append(
-                f"<tr><td>{sector}</td><td>{weight_pct:.1f}%</td>"
-                f"<td>{_pct(contrib)}</td><td>{n_pos}</td></tr>"
-            )
-            plain_parts.append(f"  {sector:<25} {weight_pct:>5.1f}%  {_plain_pct(contrib):>8}  {n_pos} pos")
-        html_parts.append("</table>")
-        plain_parts.append("")
-
-    # ── Trades today ─────────────────────────────────────────────────────────
-    trades_today = conn.execute(
-        "SELECT action, ticker, shares, price_at_order FROM trades WHERE date=? ORDER BY created_at",
-        (run_date,),
-    ).fetchall()
-
-    html_parts.append("<h2>Trades Today</h2>")
-    plain_parts.append("TRADES TODAY")
-    plain_parts.append("-" * 40)
-
-    if trades_today:
-        html_parts += ["<table>",
-                       "<tr><th>Action</th><th>Ticker</th><th>Shares</th><th>Price</th></tr>"]
-        for action, ticker, shares, price in trades_today:
-            price_str = f"${price:.2f}" if price else "—"
-            html_parts.append(
-                f"<tr><td>{action}</td><td>{ticker}</td>"
-                f"<td>{shares:,}</td><td>{price_str}</td></tr>"
-            )
-            plain_parts.append(f"  {action:<6} {ticker:<6} {shares:>6} shares @ {price_str}")
-        html_parts.append("</table>")
-    else:
-        html_parts.append("<p>No trades today.</p>")
-        plain_parts.append("  No trades today.")
-    plain_parts.append("")
-
-    # ── Roundtrip performance ────────────────────────────────────────────────
-    if roundtrip_stats and roundtrip_stats.get("n_roundtrips", 0) > 0:
-        rs = roundtrip_stats
-        html_parts.append("<h2>Roundtrip Performance (All Time)</h2>")
-        html_parts += [
-            "<table>",
-            "<tr><th>Metric</th><th>Value</th></tr>",
-            f"<tr><td>Closed Roundtrips</td><td>{rs['n_roundtrips']}</td></tr>",
-            f"<tr><td>Avg Return</td><td>{_pct(rs.get('avg_return_pct'))}</td></tr>",
-            f"<tr><td>Avg Alpha vs SPY</td><td>{_pct(rs.get('avg_alpha_pct'))}</td></tr>",
-            f"<tr><td>Win Rate vs SPY</td><td>{rs.get('win_rate_vs_spy', 0):.0f}%</td></tr>",
-            f"<tr><td>Avg Hold (days)</td><td>{rs.get('avg_hold_days', '—')}</td></tr>",
-            "</table>",
-        ]
-        plain_parts.append("ROUNDTRIP PERFORMANCE (ALL TIME)")
-        plain_parts.append("-" * 40)
-        plain_parts.append(f"  Closed roundtrips: {rs['n_roundtrips']}")
-        plain_parts.append(f"  Avg return:        {_plain_pct(rs.get('avg_return_pct'))}")
-        plain_parts.append(f"  Avg alpha vs SPY:  {_plain_pct(rs.get('avg_alpha_pct'))}")
-        plain_parts.append(f"  Win rate vs SPY:   {rs.get('win_rate_vs_spy', 0):.0f}%")
-        plain_parts.append(f"  Avg hold (days):   {rs.get('avg_hold_days', '—')}")
-        plain_parts.append("")
-
-    # ── Trailing 10-day history ──────────────────────────────────────────────
-    history = conn.execute(
-        """SELECT date, portfolio_nav, daily_return_pct, spy_return_pct, daily_alpha_pct
-           FROM eod_pnl ORDER BY date DESC LIMIT 10""",
-    ).fetchall()
-
-    html_parts.append("<h2>Trailing History</h2>")
-    plain_parts.append("TRAILING HISTORY")
-    plain_parts.append("-" * 40)
-
-    if history:
-        html_parts += ["<table>",
-                       "<tr><th>Date</th><th>NAV</th><th>Return</th><th>SPY</th><th>Alpha</th></tr>"]
-        for date_, hnav, ret, spy, alp in history:
-            html_parts.append(
-                f"<tr><td>{date_}</td><td>${hnav:,.0f}</td>"
-                f"<td>{_pct(ret)}</td><td>{_pct(spy)}</td><td>{_pct(alp)}</td></tr>"
-            )
-            plain_parts.append(
-                f"  {date_}  ${hnav:>10,.0f}  "
-                f"ret {_plain_pct(ret):>8}  SPY {_plain_pct(spy):>8}  α {_plain_pct(alp):>8}"
-            )
-        html_parts.append("</table>")
-    else:
-        html_parts.append("<p>No history yet.</p>")
-        plain_parts.append("  No history yet.")
 
     html_body = _HTML.format(body="\n".join(html_parts), date=run_date)
     plain_body = "\n".join(plain_parts)
-
     return subject, html_body, plain_body
 
 
@@ -401,46 +192,24 @@ def send_eod_email(
     daily_return: float | None,
     spy_return: float | None,
     alpha: float | None,
-    positions: dict,
-    conn: sqlite3.Connection,
     sender: str,
     recipients: list[str],
     region: str = "us-east-1",
-    position_narratives: dict[str, str] | None = None,
-    sector_attribution: dict | None = None,
-    data_warnings: list[str] | None = None,
-    roundtrip_stats: dict | None = None,
-    trades_bucket: str = "",
     account_snapshot: dict | None = None,
-    nav_reconciliation: dict | None = None,
+    data_warnings: list[str] | None = None,
+    console_base_url: str | None = None,
 ) -> None:
     subject, html_body, plain_body = build_eod_email(
-        run_date, nav, daily_return, spy_return, alpha, positions, conn,
-        position_narratives=position_narratives,
-        sector_attribution=sector_attribution,
-        data_warnings=data_warnings,
-        roundtrip_stats=roundtrip_stats,
+        run_date, nav, daily_return, spy_return, alpha,
         account_snapshot=account_snapshot,
-        nav_reconciliation=nav_reconciliation,
+        data_warnings=data_warnings,
+        console_base_url=console_base_url,
     )
 
-    # Archive email HTML to S3
-    if trades_bucket:
-        try:
-            _s3 = boto3.client("s3")
-            _s3.put_object(
-                Bucket=trades_bucket,
-                Key=f"consolidated/{run_date}/eod.html",
-                Body=html_body.encode("utf-8"),
-                ContentType="text/html",
-            )
-            logger.info("EOD email archived to S3: consolidated/%s/eod.html", run_date)
-        except Exception as e:
-            logger.warning("EOD email archival failed (non-fatal): %s", e)
-
-    # SMTP/SES dispatch via the nousergon_lib.email_sender chokepoint
-    # (L4356 — Gmail SMTP primary, SES fallback). Identical semantics to
-    # the pre-consolidation inline path.
+    # SMTP/SES dispatch via the alpha_engine_lib.email_sender chokepoint
+    # (Gmail SMTP primary, SES fallback). The full report is archived as the
+    # structured eod_report.json artifact (executor/eod_report.py), not as a
+    # rendered email HTML — the console page is the canonical render.
     from nousergon_lib.email_sender import send_email as _send_email
     _send_email(
         subject, plain_body,

--- a/executor/eod_reconcile.py
+++ b/executor/eod_reconcile.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from executor import reference_rate
 from executor.eod_emailer import send_eod_email
+from executor.eod_report import build_eod_report, write_eod_report
 from executor.trade_logger import (
     init_db, log_eod, backup_to_s3, get_entry_trade, get_todays_trades,
 )
@@ -956,6 +957,46 @@ def run(run_date: str | None = None) -> None:
     except Exception as e:
         logger.warning("Execution quality query failed: %s", e)
 
+    # ── Build + write the structured EOD report artifact ──────────────────
+    # consolidated/{date}/eod_report.json is the single source of truth for
+    # the console EOD Report page. The alpha attribution here is the
+    # prior-NAV-basis decomposition that ties to the headline alpha exactly
+    # (executor/eod_report.py) — it replaces the old emailer's sign-flipping
+    # "α % of Total" column and the positions-table total that never
+    # reconciled with the NAV-based headline.
+    try:
+        report = build_eod_report(
+            run_date=run_date,
+            nav=nav,
+            prior_nav=prior_nav,
+            daily_return=daily_return,
+            spy_return=spy_return,
+            alpha=alpha,
+            positions=positions,
+            prior_positions=prior_positions,
+            conn=conn,
+            account_snapshot=account,
+            nav_reconciliation=nav_reconciliation,
+            position_narratives=position_narratives,
+            sector_attribution=sector_attribution,
+            roundtrip_stats=roundtrip_stats,
+            data_warnings=data_warnings,
+            generated_at=snapshot.get("captured_at"),
+        )
+        attribution = report.get("alpha_attribution")
+        if attribution is not None and not attribution.get("ties_to_headline"):
+            logger.warning(
+                "EOD alpha attribution did not tie to headline (residual=$%.2f) "
+                "on %s — investigate before trusting per-position contributions.",
+                attribution.get("residual_usd", 0.0), run_date,
+            )
+        write_eod_report(report, trades_bucket=trades_bucket, run_date=run_date)
+    except Exception as e:
+        logger.error("EOD report artifact build/write failed: %s", e)
+        if fd:
+            fd.report(e, severity="error", context={
+                "site": "eod_report_artifact", "run_date": run_date})
+
     try:
         send_eod_email(
             run_date=run_date,
@@ -963,17 +1004,11 @@ def run(run_date: str | None = None) -> None:
             daily_return=daily_return,
             spy_return=spy_return,
             alpha=alpha,
-            positions=positions,
-            conn=conn,
             sender=config["email_sender"],
             recipients=config["email_recipients"],
-            position_narratives=position_narratives,
-            sector_attribution=sector_attribution,
-            data_warnings=data_warnings,
-            roundtrip_stats=roundtrip_stats,
-            trades_bucket=trades_bucket,
             account_snapshot=account,
-            nav_reconciliation=nav_reconciliation,
+            data_warnings=data_warnings,
+            console_base_url=config.get("console_base_url"),
         )
     except Exception as e:
         logger.error(f"EOD email failed: {e}")

--- a/executor/eod_report.py
+++ b/executor/eod_report.py
@@ -1,0 +1,296 @@
+"""
+EOD report artifact builder — Alpha Engine executor.
+
+Produces the structured ``consolidated/{date}/eod_report.json`` artifact that
+is the single source of truth for the end-of-day report rendered on the
+private console (alpha-engine-dashboard ``views/19_EOD_Report.py``). This
+*replaces* the prior ``consolidated/{date}/eod.html`` email-render archive:
+the console page renders this payload, and the EOD email links to it instead
+of inlining the whole report.
+
+Alpha attribution methodology
+-----------------------------
+Daily dollar-alpha is decomposed on a **prior-NAV basis** so the per-sleeve
+contributions sum EXACTLY to the headline alpha (``port_return - spy_return``).
+The headline dollar-alpha is, by construction::
+
+    dollar_alpha = nav_change_usd - (spy_return/100) * prior_nav
+                 = prior_nav * (daily_return - spy_return) / 100
+                 = prior_nav * alpha / 100
+
+Each sleeve's additive contribution::
+
+    position_i        : daily_return_usd_i - (spy_return/100) * prior_mv_i
+    cash & rotation   : interest_usd       - (spy_return/100) * prior_cash_residual
+    unattributed      : unattributed_usd
+
+where ``prior_cash_residual := prior_nav - Σ prior_mv_i`` (over *today's* held
+tickers) is defined as the residual sleeve so the prior weights sum to
+``prior_nav`` exactly. Because ``nav_change_usd = position_pnl_usd +
+interest_usd + unattributed_usd`` (the EOD-reconcile identity), the sleeve
+contributions sum to ``dollar_alpha`` regardless of intraday rotation — capital
+that was in positions exited today lands in the cash-&-rotation sleeve, so the
+identity still closes. See ``tests/test_eod_report.py::
+test_attribution_ties_to_headline``.
+
+This is the fix for the old emailer's "α % of Total" column, which divided each
+position's alpha by the *signed* grand-total alpha — so a position with genuinely
+positive alpha rendered negative whenever the day's total alpha was negative, and
+the table total (Σ $-alpha / NAV) never reconciled with the NAV-based headline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+
+import boto3
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "1.0"
+
+# Artifact written per trading day; the console EOD Report page reads it.
+REPORT_KEY_TEMPLATE = "consolidated/{run_date}/eod_report.json"
+
+
+def compute_alpha_attribution(
+    *,
+    prior_nav: float | None,
+    spy_return: float | None,
+    positions: dict,
+    prior_positions: dict | None,
+    interest_usd: float,
+    unattributed_usd: float,
+    nav_change_usd: float | None,
+) -> dict | None:
+    """Additive daily-alpha decomposition that ties to the headline alpha.
+
+    Returns ``None`` when attribution is undefined (first trading day with no
+    prior NAV, or no SPY reference). Otherwise returns a dict with a
+    ``components`` list whose ``contrib_usd`` values sum to ``dollar_alpha``
+    (within floating-point tolerance), plus a ``residual_usd`` tie-out check.
+    """
+    if prior_nav is None or prior_nav <= 0 or spy_return is None:
+        return None
+
+    spy_frac = spy_return / 100.0
+    dollar_alpha = prior_nav * ((nav_change_usd or 0.0) / prior_nav - spy_frac)
+
+    def _prior_mv(tkr: str) -> float:
+        pp = (prior_positions or {}).get(tkr) or {}
+        try:
+            return float(pp.get("market_value", 0) or 0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    sum_prior_mv = sum(_prior_mv(t) for t in positions)
+    # Residual sleeve: prior cash + the prior market value of any position
+    # exited/rotated out today. Defined so Σ prior weights == prior_nav exactly.
+    prior_cash_residual = prior_nav - sum_prior_mv
+
+    components: list[dict] = []
+    for ticker, pos in sorted(positions.items()):
+        daily_usd = float(pos.get("daily_return_usd", 0.0) or 0.0)
+        contrib = daily_usd - spy_frac * _prior_mv(ticker)
+        components.append({
+            "label": ticker,
+            "kind": "position",
+            "contrib_usd": contrib,
+            "contrib_bps": contrib / prior_nav * 1e4,
+        })
+
+    cash_contrib = float(interest_usd or 0.0) - spy_frac * prior_cash_residual
+    components.append({
+        "label": "Cash & rotation",
+        "kind": "cash",
+        "contrib_usd": cash_contrib,
+        "contrib_bps": cash_contrib / prior_nav * 1e4,
+    })
+
+    unattr = float(unattributed_usd or 0.0)
+    components.append({
+        "label": "Unattributed",
+        "kind": "unattributed",
+        "contrib_usd": unattr,
+        "contrib_bps": unattr / prior_nav * 1e4,
+    })
+
+    summed = sum(c["contrib_usd"] for c in components)
+    residual = dollar_alpha - summed
+
+    return {
+        "basis": "prior_nav",
+        "prior_nav": prior_nav,
+        "spy_return_pct": spy_return,
+        "dollar_alpha": dollar_alpha,
+        "alpha_pct": dollar_alpha / prior_nav * 100.0,
+        "components": components,
+        "residual_usd": residual,
+        "ties_to_headline": abs(residual) < 1.0,
+    }
+
+
+def _trades_today(conn: sqlite3.Connection, run_date: str) -> list[dict]:
+    rows = conn.execute(
+        "SELECT action, ticker, shares, price_at_order FROM trades "
+        "WHERE date=? ORDER BY created_at",
+        (run_date,),
+    ).fetchall()
+    return [
+        {"action": a, "ticker": t, "shares": s, "price": p}
+        for (a, t, s, p) in rows
+    ]
+
+
+def _trailing_history(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
+    rows = conn.execute(
+        "SELECT date, portfolio_nav, daily_return_pct, spy_return_pct, "
+        "daily_alpha_pct FROM eod_pnl ORDER BY date DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+    return [
+        {
+            "date": d,
+            "nav": nav,
+            "daily_return_pct": ret,
+            "spy_return_pct": spy,
+            "daily_alpha_pct": alp,
+        }
+        for (d, nav, ret, spy, alp) in rows
+    ]
+
+
+def build_eod_report(
+    *,
+    run_date: str,
+    nav: float,
+    prior_nav: float | None,
+    daily_return: float | None,
+    spy_return: float | None,
+    alpha: float | None,
+    positions: dict,
+    prior_positions: dict | None,
+    conn: sqlite3.Connection,
+    account_snapshot: dict | None = None,
+    nav_reconciliation: dict | None = None,
+    position_narratives: dict[str, str] | None = None,
+    sector_attribution: dict | None = None,
+    roundtrip_stats: dict | None = None,
+    data_warnings: list[str] | None = None,
+    generated_at: str | None = None,
+) -> dict:
+    """Assemble the structured EOD report payload (the ``eod_report.json`` artifact)."""
+    acct = account_snapshot or {}
+    recon = nav_reconciliation or {}
+    narratives = position_narratives or {}
+
+    attribution = compute_alpha_attribution(
+        prior_nav=prior_nav,
+        spy_return=spy_return,
+        positions=positions,
+        prior_positions=prior_positions,
+        interest_usd=recon.get("interest_usd", 0.0) or 0.0,
+        unattributed_usd=recon.get("unattributed_usd", 0.0) or 0.0,
+        nav_change_usd=recon.get("nav_change_usd"),
+    )
+    contrib_by_ticker = {
+        c["label"]: c
+        for c in (attribution["components"] if attribution else [])
+        if c["kind"] == "position"
+    }
+
+    positions_out: list[dict] = []
+    for ticker, pos in sorted(positions.items()):
+        mv = float(pos.get("market_value", 0) or 0)
+        contrib = contrib_by_ticker.get(ticker)
+        positions_out.append({
+            "ticker": ticker,
+            "shares": pos.get("shares"),
+            "market_value": mv,
+            "pct_nav": (mv / nav * 100.0) if nav else None,
+            "daily_return_pct": pos.get("daily_return_pct"),
+            "daily_return_usd": pos.get("daily_return_usd"),
+            "alpha_contrib_usd": contrib["contrib_usd"] if contrib else None,
+            "alpha_contrib_bps": contrib["contrib_bps"] if contrib else None,
+            "sector": pos.get("sector", "Unknown"),
+            "rationale": narratives.get(ticker),
+        })
+
+    sector_out = [
+        {
+            "sector": sector,
+            "weight_pct": data.get("weight", 0.0) * 100.0,
+            "contribution_pct": data.get("contribution", 0.0),
+            "positions": data.get("positions", 0),
+        }
+        for sector, data in sorted(
+            (sector_attribution or {}).items(),
+            key=lambda kv: abs(kv[1].get("contribution", 0.0)),
+            reverse=True,
+        )
+    ]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_date": run_date,
+        "generated_at": generated_at,
+        "summary": {
+            "nav": nav,
+            "prior_nav": prior_nav,
+            "daily_return_pct": daily_return,
+            "spy_return_pct": spy_return,
+            "daily_alpha_pct": alpha,
+            "dollar_alpha": attribution["dollar_alpha"] if attribution else None,
+            "cash": acct.get("total_cash"),
+            "positions_mv": acct.get("gross_position_value"),
+            "unrealized_pnl": acct.get("unrealized_pnl"),
+            "realized_pnl": acct.get("realized_pnl"),
+            "accrued_interest": acct.get("accrued_interest"),
+        },
+        "nav_reconciliation": {
+            "nav_change_usd": recon.get("nav_change_usd"),
+            "position_pnl_usd": recon.get("position_pnl_usd"),
+            "interest_usd": recon.get("interest_usd"),
+            "dividend_usd": recon.get("dividend_usd"),
+            "unattributed_usd": recon.get("unattributed_usd"),
+        },
+        "data_warnings": list(data_warnings or []),
+        "alpha_attribution": attribution,
+        "positions": positions_out,
+        "sector_attribution": sector_out,
+        "trades_today": _trades_today(conn, run_date),
+        "roundtrip_stats": roundtrip_stats,
+        "trailing_history": _trailing_history(conn),
+    }
+
+
+def write_eod_report(
+    report: dict,
+    *,
+    trades_bucket: str,
+    run_date: str,
+) -> str | None:
+    """Persist the report artifact to S3. Returns the key on success, else None.
+
+    Non-fatal: a failed report write must not break EOD reconciliation. The
+    failure is logged at WARNING (the console page surfaces the absence via
+    its own freshness check), consistent with the artifact-archival posture
+    of the old ``eod.html`` write.
+    """
+    if not trades_bucket:
+        return None
+    key = REPORT_KEY_TEMPLATE.format(run_date=run_date)
+    try:
+        boto3.client("s3").put_object(
+            Bucket=trades_bucket,
+            Key=key,
+            Body=json.dumps(report, indent=2, default=str).encode("utf-8"),
+            ContentType="application/json",
+        )
+        logger.info("EOD report artifact written to s3://%s/%s", trades_bucket, key)
+        return key
+    except Exception as e:  # noqa: BLE001 — best-effort archival, page surfaces absence
+        logger.warning("EOD report artifact write failed (non-fatal): %s", e)
+        return None

--- a/tests/test_eod_emailer.py
+++ b/tests/test_eod_emailer.py
@@ -1,10 +1,20 @@
-"""Tests for executor/eod_emailer.py — pure HTML/text building functions."""
+"""Tests for executor/eod_emailer.py — the slim EOD link email.
 
-import sqlite3
+The EOD email is a headline + DATA WARNINGS + console deep-link (config#856).
+The full positions / attribution / rationale / sector / roundtrip / trailing
+report lives on the console EOD Report page (rendered from the
+consolidated/{date}/eod_report.json artifact). These tests cover the slim
+email surface only; attribution correctness is in test_eod_report.py.
+"""
 
-import pytest
-
-from executor.eod_emailer import _dollar, _pct, _plain_pct, build_eod_email
+from executor.eod_emailer import (
+    EOD_REPORT_SLUG,
+    _dollar,
+    _pct,
+    _plain_pct,
+    build_eod_email,
+    eod_report_url,
+)
 
 
 class TestFormatters:
@@ -18,215 +28,102 @@ class TestFormatters:
         assert "-2.30%" in result
         assert "neg" in result
 
-    def test_pct_zero(self):
-        result = _pct(0.0)
-        assert "0.00%" in result
-
     def test_pct_none(self):
         assert _pct(None) == "—"
-
-    def test_dollar_positive(self):
-        result = _dollar(1500.0)
-        assert "+$1,500" in result
 
     def test_dollar_negative(self):
         result = _dollar(-800.0)
         assert "800" in result
         assert "neg" in result
 
-    def test_dollar_none(self):
-        assert _dollar(None) == "—"
-
-    def test_plain_pct_positive(self):
-        assert _plain_pct(1.5) == "+1.50%"
-
-    def test_plain_pct_negative(self):
-        assert _plain_pct(-2.3) == "-2.30%"
-
     def test_plain_pct_none(self):
         assert _plain_pct(None) == "—"
 
 
-class TestBuildEodEmail:
-    @pytest.fixture
-    def mock_db(self):
-        conn = sqlite3.connect(":memory:")
-        conn.execute("""
-            CREATE TABLE eod_pnl (
-                date TEXT, portfolio_nav REAL, daily_return_pct REAL,
-                spy_return_pct REAL, daily_alpha_pct REAL
-            )
-        """)
-        conn.execute("""
-            CREATE TABLE trades (
-                trade_id INTEGER PRIMARY KEY, date TEXT, ticker TEXT, action TEXT,
-                shares INTEGER, fill_price REAL, price_at_order REAL,
-                research_score REAL, market_regime TEXT, trigger_type TEXT,
-                rationale_json TEXT, created_at TEXT,
-                portfolio_nav_at_order REAL, position_pct REAL,
-                research_conviction TEXT, research_rating TEXT, sector_rating TEXT,
-                thesis_summary TEXT, predicted_direction TEXT, prediction_confidence REAL,
-                fill_time TEXT, ib_order_id TEXT, execution_latency_ms REAL,
-                signal_price REAL, trigger_price REAL, slippage_vs_signal REAL,
-                entry_trade_id INTEGER, realized_pnl REAL, realized_return_pct REAL,
-                realized_alpha_pct REAL, days_held INTEGER, spy_price_at_order REAL
-            )
-        """)
-        conn.executemany(
-            "INSERT INTO eod_pnl VALUES (?,?,?,?,?)",
-            [
-                ("2026-04-07", 100000, 0.5, 0.3, 0.2),
-                ("2026-04-08", 100500, 0.5, 0.2, 0.3),
-            ],
-        )
-        conn.commit()
-        return conn
+class TestEodReportUrl:
+    def test_default_base(self):
+        url = eod_report_url("2026-06-22")
+        assert url == f"https://console.nousergon.ai/{EOD_REPORT_SLUG}?date=2026-06-22"
 
-    def test_basic_email(self, mock_db):
+    def test_custom_base_strips_trailing_slash(self):
+        url = eod_report_url("2026-06-22", "https://console.example.com/")
+        assert url == f"https://console.example.com/{EOD_REPORT_SLUG}?date=2026-06-22"
+
+
+class TestBuildEodEmail:
+    def test_subject_carries_nav_and_alpha(self):
         subject, html, plain = build_eod_email(
             run_date="2026-04-08",
             nav=100500.0,
             daily_return=0.5,
             spy_return=0.2,
             alpha=0.3,
-            positions={"AAPL": {"shares": 10, "market_value": 1500}},
-            conn=mock_db,
         )
         assert "2026-04-08" in subject
         assert "100,500" in subject
         assert "+0.30%" in subject
-        assert "AAPL" in html
-        assert "AAPL" in plain
 
-    def test_no_positions(self, mock_db):
-        subject, html, plain = build_eod_email(
-            run_date="2026-04-08",
-            nav=100000.0,
-            daily_return=0.0,
-            spy_return=0.0,
-            alpha=0.0,
-            positions={},
-            conn=mock_db,
-        )
-        assert "2026-04-08" in subject
-        assert "html" in html.lower() or "body" in html.lower()
-
-    def test_with_sector_attribution(self, mock_db):
-        subject, html, plain = build_eod_email(
+    def test_body_links_to_console_report(self):
+        _, html, plain = build_eod_email(
             run_date="2026-04-08",
             nav=100500.0,
             daily_return=0.5,
             spy_return=0.2,
             alpha=0.3,
-            positions={"AAPL": {"shares": 10, "market_value": 1500}},
-            conn=mock_db,
-            sector_attribution={"Technology": {"weight": 0.15, "contribution": 0.08, "positions": 2}},
         )
-        assert "Technology" in html or "Sector" in html
+        expected = eod_report_url("2026-04-08")
+        assert expected in html
+        assert expected in plain
 
-    def test_with_roundtrip_stats(self, mock_db):
-        subject, html, plain = build_eod_email(
+    def test_summary_numbers_present(self):
+        _, html, plain = build_eod_email(
             run_date="2026-04-08",
             nav=100500.0,
             daily_return=0.5,
             spy_return=0.2,
             alpha=0.3,
-            positions={},
-            conn=mock_db,
-            roundtrip_stats={"n_roundtrips": 5, "avg_return_pct": 2.1, "win_rate_vs_spy": 60.0},
+            account_snapshot={
+                "total_cash": 35587.0,
+                "gross_position_value": 64913.0,
+                "unrealized_pnl": 289.0,
+                "realized_pnl": -18799.0,
+            },
         )
-        # Should include roundtrip stats somewhere in email
-        assert "html" in html.lower() or "body" in html.lower()
+        assert "35,587" in html
+        assert "Daily Alpha" in html
 
-    def test_with_data_warnings(self, mock_db):
-        subject, html, plain = build_eod_email(
+    def test_data_warnings_still_push_in_email(self):
+        """A red flag must reach the inbox, not hide behind the click."""
+        _, html, plain = build_eod_email(
             run_date="2026-04-08",
             nav=100500.0,
             daily_return=0.5,
             spy_return=0.2,
             alpha=0.3,
-            positions={},
-            conn=mock_db,
-            data_warnings=["Stale prices for 3 tickers"],
+            data_warnings=["NAV reconciliation gap: $-2,404 unattributed"],
         )
-        assert "Stale" in html or "warning" in html.lower()
+        assert "reconciliation gap" in html
+        assert "reconciliation gap" in plain
 
-    def test_none_returns(self, mock_db):
-        subject, html, plain = build_eod_email(
+    def test_no_inline_positions_table(self):
+        """The slim email must NOT inline the per-position table or the
+        sign-flipping 'α % of Total' column — that's the bug we removed."""
+        _, html, _ = build_eod_email(
+            run_date="2026-04-08",
+            nav=100500.0,
+            daily_return=0.5,
+            spy_return=0.2,
+            alpha=0.3,
+        )
+        assert "% of Total" not in html
+        assert "Open Positions" not in html
+
+    def test_none_returns(self):
+        subject, _, _ = build_eod_email(
             run_date="2026-04-08",
             nav=100000.0,
             daily_return=None,
             spy_return=None,
             alpha=None,
-            positions={},
-            conn=mock_db,
         )
-        assert "—" in subject or "None" not in subject
-
-    def test_cash_row_does_not_absorb_nav_residual(self, mock_db):
-        """Regression: cash should NOT show a fabricated daily return.
-
-        Prior bug: cash_daily_usd = total_nav_change - total_day_usd absorbed
-        pricing/snapshot noise. On 2026-04-17, this produced a +2.27% daily
-        return on the cash sleeve and +$7,148 of bogus cash alpha (133% of
-        total alpha). Cash row must show '—' for daily return and only earn
-        α from actual interest.
-        """
-        positions = {
-            "AAPL": {
-                "shares": 10, "market_value": 1500,
-                "daily_return_pct": 0.01, "daily_return_usd": 0.15,
-                "alpha_contribution_usd": 0.05,
-            },
-        }
-        # NAV moved by $8000 but positions only contributed $0.15
-        # and reconciliation says only $50 is interest.
-        recon = {
-            "nav_change_usd": 8000.0,
-            "position_pnl_usd": 0.15,
-            "interest_usd": 50.0,
-            "dividend_usd": 0.0,
-            "unattributed_usd": 7949.85,
-        }
-        account = {"total_cash": 350000.0, "accrued_interest": 550.0}
-        _, html, plain = build_eod_email(
-            run_date="2026-04-08",
-            nav=1_031_666.0,
-            daily_return=0.76,
-            spy_return=0.25,
-            alpha=0.51,
-            positions=positions,
-            conn=mock_db,
-            account_snapshot=account,
-            nav_reconciliation=recon,
-        )
-        # Cash row must not claim a 2.27% daily return
-        assert "2.27%" not in html
-        # Unattributed gap must be surfaced (not hidden)
-        assert "Unattributed" in html
-        assert "7,950" in html or "7,949" in html
-        # Interest row should appear
-        assert "Interest" in html
-
-    def test_reconciliation_absent_falls_back_cleanly(self, mock_db):
-        """If nav_reconciliation isn't passed, cash alpha is ~0 (interest=0)."""
-        positions = {
-            "AAPL": {
-                "shares": 10, "market_value": 1500,
-                "daily_return_pct": 0.1, "daily_return_usd": 1.5,
-                "alpha_contribution_usd": 0.5,
-            },
-        }
-        _, html, _ = build_eod_email(
-            run_date="2026-04-08",
-            nav=100_000.0,
-            daily_return=0.1,
-            spy_return=0.05,
-            alpha=0.05,
-            positions=positions,
-            conn=mock_db,
-            account_snapshot={"total_cash": 98_500.0},
-        )
-        # No explicit reconciliation → no Interest/Dividends rows
-        assert "Interest</td>" not in html
-        assert "Dividends</td>" not in html
+        assert "None" not in subject

--- a/tests/test_eod_report.py
+++ b/tests/test_eod_report.py
@@ -1,0 +1,195 @@
+"""Tests for executor/eod_report.py — the structured EOD report artifact.
+
+The load-bearing invariant is **attribution tie-out**: the per-sleeve daily
+dollar-alpha contributions (positions + cash & rotation + unattributed) must
+sum to the headline dollar-alpha (prior_nav × (daily_return − spy_return)/100)
+to within floating-point tolerance, for arbitrary intraday rotation. This is
+the property the old emailer violated — its positions-table alpha total never
+reconciled with the NAV-based headline, and its "α % of Total" column
+sign-flipped on negative-alpha days.
+"""
+
+import sqlite3
+
+import pytest
+
+from executor.eod_report import build_eod_report, compute_alpha_attribution
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE eod_pnl (date TEXT, portfolio_nav REAL, "
+        "daily_return_pct REAL, spy_return_pct REAL, daily_alpha_pct REAL)"
+    )
+    conn.execute(
+        "CREATE TABLE trades (date TEXT, ticker TEXT, action TEXT, shares INTEGER, "
+        "price_at_order REAL, created_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO eod_pnl VALUES (?,?,?,?,?)",
+        [
+            ("2026-06-18", 1001593, 0.10, 0.78, -0.68),
+            ("2026-06-22", 991322, -1.03, -0.33, -0.70),
+        ],
+    )
+    conn.commit()
+    return conn
+
+
+def _attr_residual(**kwargs) -> float:
+    attr = compute_alpha_attribution(**kwargs)
+    return attr["residual_usd"]
+
+
+class TestAttributionTieOut:
+    def test_ties_to_headline_simple(self):
+        attr = compute_alpha_attribution(
+            prior_nav=1_000_000.0,
+            spy_return=-0.33,
+            positions={
+                "ADBE": {"daily_return_usd": 1156.0},   # entered today → prior_mv 0
+                "GOOG": {"daily_return_usd": -4278.0},
+            },
+            prior_positions={"GOOG": {"market_value": 84149.0}},  # held yesterday
+            interest_usd=2.0,
+            # EOD identity: unattributed = nav_change − position_pnl − interest
+            # = -10271 − (1156 − 4278) − 2 = -7151
+            unattributed_usd=-7151.0,
+            nav_change_usd=-10271.0,
+        )
+        # Sum of components == dollar_alpha
+        assert attr["ties_to_headline"] is True
+        assert abs(attr["residual_usd"]) < 1.0
+        summed = sum(c["contrib_usd"] for c in attr["components"])
+        assert summed == pytest.approx(attr["dollar_alpha"], abs=1e-6)
+
+    def test_dollar_alpha_matches_headline_formula(self):
+        prior_nav, nav_change, spy = 1_001_593.0, -10271.0, -0.33
+        attr = compute_alpha_attribution(
+            prior_nav=prior_nav, spy_return=spy,
+            positions={"X": {"daily_return_usd": -10271.0}},
+            prior_positions={"X": {"market_value": 950000.0}},
+            interest_usd=0.0, unattributed_usd=0.0, nav_change_usd=nav_change,
+        )
+        daily_return = nav_change / prior_nav * 100.0
+        expected_alpha_pct = daily_return - spy
+        assert attr["alpha_pct"] == pytest.approx(expected_alpha_pct, abs=1e-9)
+
+    def test_ties_with_heavy_rotation(self):
+        """Capital from positions exited today lands in cash & rotation; the
+        identity must still close (unattributed absorbs the rest)."""
+        residual = _attr_residual(
+            prior_nav=1_000_000.0,
+            spy_return=0.5,
+            positions={"NEW": {"daily_return_usd": 300.0}},  # entered today
+            prior_positions={
+                "GEHC": {"market_value": 78000.0},  # exited today
+                "WDAY": {"market_value": 66000.0},  # exited today
+            },
+            interest_usd=10.0,
+            # EOD identity: unattributed = 2000 − 300 − 10 = 1690. The exited
+            # GEHC/WDAY prior MV is NOT in today's positions, so it stays in
+            # the cash & rotation residual (prior_cash_residual = prior_nav).
+            unattributed_usd=1690.0,
+            nav_change_usd=2000.0,
+        )
+        assert abs(residual) < 1.0
+
+    def test_positive_alpha_position_stays_positive_on_negative_total(self):
+        """Regression for the 'α % of Total' sign-flip: a position that beat
+        SPY must show a POSITIVE contribution even when the day's total alpha
+        is negative."""
+        attr = compute_alpha_attribution(
+            prior_nav=1_000_000.0,
+            spy_return=-0.33,  # SPY down
+            positions={"ADBE": {"daily_return_usd": 1156.0}},  # up, entered today
+            prior_positions={},
+            interest_usd=0.0,
+            unattributed_usd=-5000.0,  # drives the TOTAL negative
+            nav_change_usd=-3844.0,
+        )
+        adbe = next(c for c in attr["components"] if c["label"] == "ADBE")
+        assert adbe["contrib_usd"] > 0  # NOT sign-flipped by a negative total
+        assert attr["dollar_alpha"] < 0  # total is still negative
+
+    def test_none_when_first_trading_day(self):
+        assert compute_alpha_attribution(
+            prior_nav=None, spy_return=-0.33, positions={},
+            prior_positions=None, interest_usd=0.0,
+            unattributed_usd=0.0, nav_change_usd=None,
+        ) is None
+
+    def test_none_when_no_spy_reference(self):
+        assert compute_alpha_attribution(
+            prior_nav=1_000_000.0, spy_return=None, positions={},
+            prior_positions=None, interest_usd=0.0,
+            unattributed_usd=0.0, nav_change_usd=0.0,
+        ) is None
+
+
+class TestBuildEodReport:
+    def test_payload_shape(self):
+        conn = _conn()
+        conn.execute(
+            "INSERT INTO trades VALUES "
+            "('2026-06-22','ADBE','ENTER',360,191.99,'2026-06-22T13:00:00')"
+        )
+        conn.commit()
+        report = build_eod_report(
+            run_date="2026-06-22",
+            nav=991322.0,
+            prior_nav=1001593.0,
+            daily_return=-1.03,
+            spy_return=-0.33,
+            alpha=-0.70,
+            positions={
+                "ADBE": {
+                    "shares": 360, "market_value": 70164.0,
+                    "daily_return_pct": 1.68, "daily_return_usd": 1156.0,
+                    "sector": "Information Technology",
+                },
+            },
+            prior_positions={},
+            conn=conn,
+            account_snapshot={
+                "total_cash": 35587.0, "gross_position_value": 955656.0,
+                "unrealized_pnl": 289.0, "realized_pnl": -18799.0,
+                "accrued_interest": 80.0,
+            },
+            nav_reconciliation={
+                "nav_change_usd": -10271.0, "position_pnl_usd": -1156.0,
+                "interest_usd": 2.0, "dividend_usd": 0.0,
+                "unattributed_usd": -2404.0,
+            },
+            position_narratives={"ADBE": "Entered 2026-06-22 at $191.99."},
+            sector_attribution={
+                "Information Technology": {
+                    "weight": 0.071, "contribution": 0.12, "positions": 1,
+                },
+            },
+            roundtrip_stats={"n_roundtrips": 211, "avg_return_pct": 3.82},
+            data_warnings=["NAV reconciliation gap: $-2,404 unattributed"],
+            generated_at="2026-06-22T20:10:00Z",
+        )
+        assert report["schema_version"]
+        assert report["run_date"] == "2026-06-22"
+        assert report["summary"]["nav"] == 991322.0
+        # Per-position alpha contribution is wired from the attribution
+        adbe = report["positions"][0]
+        assert adbe["ticker"] == "ADBE"
+        assert adbe["alpha_contrib_bps"] is not None
+        assert adbe["rationale"]
+        # Trades + trailing history pulled from conn
+        assert report["trades_today"][0]["ticker"] == "ADBE"
+        assert len(report["trailing_history"]) == 2
+        assert report["data_warnings"]
+
+    def test_first_day_no_attribution(self):
+        conn = _conn()
+        report = build_eod_report(
+            run_date="2026-06-22", nav=991322.0, prior_nav=None,
+            daily_return=None, spy_return=None, alpha=None,
+            positions={}, prior_positions=None, conn=conn,
+        )
+        assert report["alpha_attribution"] is None


### PR DESCRIPTION
## What

The daily EOD email was full of errors. Root cause + fix:

- **"α % of Total" column** divided each position's alpha by the *signed* grand-total alpha → every row sign-flipped on negative-alpha days (ADBE's genuinely **+$1,407** alpha rendered as **−34.57%**).
- **Two alpha figures that never tied**: headline **−0.70%** (NAV-based) vs positions-table total **−0.41%** (Σ $-alpha / NAV) — different basis, omitted the unattributed residual.

## Fix (config#856 — pull-for-state console page + push-on-transition emails)

- `executor/eod_report.py` (new): writes versioned `consolidated/{date}/eod_report.json`, the single source of truth for the console EOD Report page. `compute_alpha_attribution()` decomposes daily dollar-alpha on a **prior-NAV basis** (position + cash & rotation + unattributed) so contributions sum **exactly** to the headline alpha. A position that beat SPY is always a positive contribution regardless of the portfolio total's sign.
- `eod_reconcile.py`: build + write the artifact; WARN if attribution does not tie; call the slimmed email.
- `eod_emailer.py`: **slim link email** — Daily Summary + DATA WARNINGS (a red flag still pushes to the inbox) + deep-link to `…/eod-report?date=YYYY-MM-DD`. Drops the inline tables and the `eod.html` render.

## Tests
`tests/test_eod_report.py` (attribution tie-out incl. heavy rotation + the sign-flip regression) + rewritten `tests/test_eod_emailer.py`. **Full executor suite green (1199 passed).**

## Coupling
Consumer = dashboard PR (crucible-dashboard `feat/eod-report-console`). Email deep-link slug `eod-report` is pinned on both sides.

## Note on the config#856 soak gate
#856 said hold the content-email drop until ≥1wk console-only soak. Brian explicitly directed the email→link change now; the producer still writes the full structured artifact (consumer-ready), so only the email *content* changes — the report data is not dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)